### PR TITLE
Upgrade ekirjasto-circulation-admin to v0.1.0

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -16,7 +16,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "E-kirjasto Collection Manager"
     PACKAGE_NAME = "@natlibfi/ekirjasto-circulation-admin"
-    PACKAGE_VERSION = "0.0.1-post.8"
+    PACKAGE_VERSION = "0.1.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Upgrade ekirjasto-circulation-admin to [v0.1.0](https://github.com/NatLibFi/ekirjasto-circulation-admin/releases/tag/v0.1.0) with latest changes