### PR TITLE
SIMPLYE-218 Passkey endpoints

### DIFF
--- a/api/ekirjasto_authentication.py
+++ b/api/ekirjasto_authentication.py
@@ -30,11 +30,11 @@ from api.circulation_exceptions import (
 from api.config import Configuration
 from api.problem_details import (
     EKIRJASTO_REMOTE_AUTHENTICATION_FAILED,
+    EKIRJASTO_REMOTE_ENDPOINT_FAILED,
+    EKIRJASTO_REMOTE_METHOD_NOT_SUPPORTED,
     INVALID_EKIRJASTO_DELEGATE_TOKEN,
     INVALID_EKIRJASTO_TOKEN,
     UNSUPPORTED_AUTHENTICATION_MECHANISM,
-    EKIRJASTO_REMOTE_METHOD_NOT_SUPPORTED,
-    EKIRJASTO_REMOTE_ENDPOINT_FAILED,
 )
 from api.util.patron import PatronUtility
 from core.analytics import Analytics
@@ -184,7 +184,10 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
             "type": self.flow_type,
             "description": self.label(),
             "links": [
-                {"rel": "authenticate", "href": self._create_circulation_url("ekirjasto_authenticate", _db)},
+                {
+                    "rel": "authenticate",
+                    "href": self._create_circulation_url("ekirjasto_authenticate", _db)
+                },
                 {"rel": "api", "href": self._ekirjasto_api_url},
                 {
                     "rel": "tunnistus_start",
@@ -204,11 +207,15 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
                 },
                 {
                     "rel": "passkey_register_start",
-                    "href": self._create_circulation_url("ekirjasto_passkey_register_start", _db),
+                    "href": self._create_circulation_url(
+                        "ekirjasto_passkey_register_start", _db
+                    ),
                 },
                 {
                     "rel": "passkey_register_finish",
-                    "href": self._create_circulation_url("ekirjasto_passkey_register_finish", _db),
+                    "href": self._create_circulation_url(
+                        "ekirjasto_passkey_register_finish", _db
+                    ),
                 },
             ],
         }
@@ -578,12 +585,12 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
             return INVALID_EKIRJASTO_TOKEN, None
         elif response.status_code != 200:
             return EKIRJASTO_REMOTE_ENDPOINT_FAILED, None
-            
+
         try:
             response_json = response.json()
         except requests.exceptions.JSONDecodeError as e:
             response_json = None
-        
+
         return response_json, response.status_code
 
     def authenticate_and_update_patron(

--- a/api/ekirjasto_authentication.py
+++ b/api/ekirjasto_authentication.py
@@ -186,7 +186,7 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
             "links": [
                 {
                     "rel": "authenticate",
-                    "href": self._create_circulation_url("ekirjasto_authenticate", _db)
+                    "href": self._create_circulation_url("ekirjasto_authenticate", _db),
                 },
                 {"rel": "api", "href": self._ekirjasto_api_url},
                 {

--- a/api/ekirjasto_authentication.py
+++ b/api/ekirjasto_authentication.py
@@ -33,6 +33,8 @@ from api.problem_details import (
     INVALID_EKIRJASTO_DELEGATE_TOKEN,
     INVALID_EKIRJASTO_TOKEN,
     UNSUPPORTED_AUTHENTICATION_MECHANISM,
+    EKIRJASTO_REMOTE_METHOD_NOT_SUPPORTED,
+    EKIRJASTO_REMOTE_ENDPOINT_FAILED,
 )
 from api.util.patron import PatronUtility
 from core.analytics import Analytics
@@ -182,7 +184,7 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
             "type": self.flow_type,
             "description": self.label(),
             "links": [
-                {"rel": "authenticate", "href": self._create_authenticate_url(_db)},
+                {"rel": "authenticate", "href": self._create_circulation_url("ekirjasto_authenticate", _db)},
                 {"rel": "api", "href": self._ekirjasto_api_url},
                 {
                     "rel": "tunnistus_start",
@@ -202,18 +204,18 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
                 },
                 {
                     "rel": "passkey_register_start",
-                    "href": f"{self._ekirjasto_api_url}/v1/auth/passkey/register/start",
+                    "href": self._create_circulation_url("ekirjasto_passkey_register_start", _db),
                 },
                 {
                     "rel": "passkey_register_finish",
-                    "href": f"{self._ekirjasto_api_url}/v1/auth/passkey/register/finish",
+                    "href": self._create_circulation_url("ekirjasto_passkey_register_finish", _db),
                 },
             ],
         }
 
         return flow_doc
 
-    def _create_authenticate_url(self, db):
+    def _create_circulation_url(self, endpoint, db):
         """Returns an authentication link used by clients to authenticate patrons
 
         :param db: Database session
@@ -226,7 +228,7 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
         library = self.library(db)
 
         return url_for(
-            "ekirjasto_authenticate",
+            endpoint,
             _external=True,
             library_short_name=library.short_name,
             provider=self.label(),
@@ -551,6 +553,39 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
 
         return self.remote_patron_lookup(ekirjasto_token)
 
+    def remote_endpoint(
+        self, remote_path: str, token: str, method: str, json_body: object = None
+    ) -> tuple[ProblemDetail, None] | tuple[object, int]:
+        """Call E-kirjasto API's passkey register endpoints on behalf of the user.
+
+        :return: token and expire timestamp if refresh was succesfull or None | ProblemDetail otherwise.
+        """
+
+        url = self._ekirjasto_api_url + remote_path
+
+        try:
+            if method == "POST":
+                response = self.requests_post(url, token, json_body)
+            elif method == "GET":
+                response = self.requests_get(url, token)
+            else:
+                return EKIRJASTO_REMOTE_METHOD_NOT_SUPPORTED, None
+        except requests.exceptions.ConnectionError as e:
+            raise RemoteInitiatedServerError(str(e), self.__class__.__name__)
+
+        if response.status_code == 401:
+            # Do nothing if authentication fails, e.g. token expired.
+            return INVALID_EKIRJASTO_TOKEN, None
+        elif response.status_code != 200:
+            return EKIRJASTO_REMOTE_ENDPOINT_FAILED, None
+            
+        try:
+            response_json = response.json()
+        except requests.exceptions.JSONDecodeError as e:
+            response_json = None
+        
+        return response_json, response.status_code
+
     def authenticate_and_update_patron(
         self, _db: Session, ekirjasto_token: str | None
     ) -> Patron | PatronData | ProblemDetail | None:
@@ -715,8 +750,8 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
             headers = {"Authorization": f"Bearer {ekirjasto_token}"}
         return requests.get(url, headers=headers)
 
-    def requests_post(self, url, ekirjasto_token=None):
+    def requests_post(self, url, ekirjasto_token=None, json_body=None):
         headers = None
         if ekirjasto_token:
             headers = {"Authorization": f"Bearer {ekirjasto_token}"}
-        return requests.post(url, headers=headers)
+        return requests.post(url, headers=headers, json=json_body)

--- a/api/ekirjasto_controller.py
+++ b/api/ekirjasto_controller.py
@@ -65,8 +65,8 @@ class EkirjastoController:
             return EKIRJASTO_PROVIDER_NOT_CONFIGURED, None, None, None
 
         if (
-            authorization is None 
-            or authorization.token is None 
+            authorization is None
+            or authorization.token is None
             or len(authorization.token) == 0
         ):
             return EKIRJASTO_REMOTE_AUTHENTICATION_FAILED, None, None, None
@@ -218,7 +218,7 @@ class EkirjastoController:
 
         (
             response_json,
-            response_code
+            response_code,
         ) = self._authenticator.ekirjasto_provider.remote_endpoint(
             remote_path, ekirjasto_token, request.method, request.json
         )

--- a/api/ekirjasto_controller.py
+++ b/api/ekirjasto_controller.py
@@ -64,8 +64,11 @@ class EkirjastoController:
         if self.is_configured != True:
             return EKIRJASTO_PROVIDER_NOT_CONFIGURED, None, None, None
 
-        if (authorization is None or authorization.token is None 
-                or len(authorization.token) == 0):
+        if (
+            authorization is None 
+            or authorization.token is None 
+            or len(authorization.token) == 0
+        ):
             return EKIRJASTO_REMOTE_AUTHENTICATION_FAILED, None, None, None
 
         token = authorization.token
@@ -198,11 +201,10 @@ class EkirjastoController:
         return Response(response_json, response_code, mimetype="application/json")
 
     def call_remote_endpoint(self, remote_path, request, _db):
-        """Call E-kirjasto API's passkey register endpoints on behalf of the user.
-        """
+        """Call E-kirjasto API's passkey register endpoints on behalf of the user."""
         if self.is_configured != True:
             return EKIRJASTO_PROVIDER_NOT_CONFIGURED
-        
+
         (
             delegate_token,
             ekirjasto_token,
@@ -213,15 +215,18 @@ class EkirjastoController:
             return delegate_token
         elif delegate_token == None:
             return INVALID_EKIRJASTO_DELEGATE_TOKEN
-            
-        response_json, response_code = self._authenticator.ekirjasto_provider.remote_endpoint(
+
+        (
+            response_json,
+            response_code
+        ) = self._authenticator.ekirjasto_provider.remote_endpoint(
             remote_path, ekirjasto_token, request.method, request.json
         )
         if isinstance(response_json, ProblemDetail):
             return response_json
         elif isinstance(response_json, dict):
             response_json = json.dumps(response_json)
-        else: 
+        else:
             response_json = None
-        
+
         return Response(response_json, response_code, mimetype="application/json")

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -258,6 +258,14 @@ EKIRJASTO_PROVIDER_NOT_CONFIGURED = pd(
     detail=_("Ekirjasto provider was not configured for the library"),
 )
 
+# Finland
+EKIRJASTO_REMOTE_METHOD_NOT_SUPPORTED = pd(
+    "http://librarysimplified.org/terms/problem/requested-provider-not-configured",
+    status_code=415,
+    title=_("Ekirjasto remote method not supported."),
+    detail=_("Method for a remote call not supported."),
+)
+
 INVALID_SAML_BEARER_TOKEN = pd(
     "http://librarysimplified.org/terms/problem/credentials-invalid",
     status_code=401,
@@ -289,6 +297,14 @@ EKIRJASTO_REMOTE_AUTHENTICATION_FAILED = pd(
     status_code=400,
     title=_("Authentication with ekirjasto API failed."),
     detail=_("Authentication with ekirjasto API failed, for unknown reason."),
+)
+
+# Finland
+EKIRJASTO_REMOTE_ENDPOINT_FAILED = pd(
+    "http://librarysimplified.org/terms/problem/credentials-invalid",
+    status_code=400,
+    title=_("Call to ekirjasto API failed."),
+    detail=_("Call to ekirjasto API failed, for unknown reason."),
 )
 
 UNSUPPORTED_AUTHENTICATION_MECHANISM = pd(

--- a/api/routes.py
+++ b/api/routes.py
@@ -583,6 +583,28 @@ def ekirjasto_authenticate():
 
 
 # Finland
+# Authenticate with the ekirjasto token.
+@library_route("/ekirjasto/passkey/register/start", methods=["POST"])
+@has_library
+@returns_problem_detail
+def ekirjasto_passkey_register_start():
+    return app.manager.ekirjasto_controller.call_remote_endpoint(
+        "/v1/auth/passkey/register/start", request, app.manager._db
+    )
+
+
+# Finland
+# Authenticate with the ekirjasto token.
+@library_route("/ekirjasto/passkey/register/finish", methods=["POST"])
+@has_library
+@returns_problem_detail
+def ekirjasto_passkey_register_finish():
+    return app.manager.ekirjasto_controller.call_remote_endpoint(
+        "/v1/auth/passkey/register/finish", request, app.manager._db
+    )
+
+
+# Finland
 # Get descriptions for the library catalogs in the system.
 # This is public route.
 @app.route("/libraries", defaults={"library_uuid": None}, methods=["GET"])

--- a/tests/api/finland/test_ekirjasto.py
+++ b/tests/api/finland/test_ekirjasto.py
@@ -794,7 +794,11 @@ class TestEkirjastoAuthentication:
         user_id = "verified"
         token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
 
-        response_json, response_code = provider.remote_endpoint("/v1/auth/userinfo", token, "GET")
+        response_json, response_code = provider.remote_endpoint(
+            "/v1/auth/userinfo",
+            token,
+            "GET"
+        )
 
         assert isinstance(response_json, dict)
         assert response_code == 200
@@ -807,7 +811,12 @@ class TestEkirjastoAuthentication:
         user_id = "verified"
         token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
 
-        response_json, response_code = provider.remote_endpoint("/v1/auth/refresh", token, "POST", {"empty": "json"})
+        response_json, response_code = provider.remote_endpoint(
+            "/v1/auth/refresh",
+            token,
+            "POST",
+            {"empty": "json"}
+        )
 
         assert isinstance(response_json, dict)
         assert response_code == 200
@@ -823,7 +832,11 @@ class TestEkirjastoAuthentication:
         # Invalidate the token.
         provider.mock_api._refresh_token_for_user_id(user_id)
 
-        response_json, response_code = provider.remote_endpoint("/v1/auth/userinfo", token, "GET")
+        response_json, response_code = provider.remote_endpoint(
+            "/v1/auth/userinfo",
+            token,
+            "GET"
+        )
 
         assert isinstance(response_json, ProblemDetail)
         assert response_json.status_code == 401
@@ -834,7 +847,11 @@ class TestEkirjastoAuthentication:
     ):
         provider = create_provider()
 
-        response_json, response_code = provider.remote_endpoint("/v1/auth/userinfo", "token", "PUT")
+        response_json, response_code = provider.remote_endpoint(
+            "/v1/auth/userinfo",
+            "token",
+            "PUT"
+        )
 
         assert isinstance(response_json, ProblemDetail)
         assert response_json.status_code == 415

--- a/tests/api/finland/test_ekirjasto.py
+++ b/tests/api/finland/test_ekirjasto.py
@@ -155,9 +155,11 @@ class MockEkirjastoAuthenticationAPI(EkirjastoAuthenticationAPI):
 
         self.mock_api = MockEkirjastoRemoteAPI()
 
-    def _create_authenticate_url(self, db):
+    def _create_circulation_url(self, endpoint, db):
+        library = self.library(db)
+
         return url_for(
-            "ekirjasto_authenticate",
+            endpoint,
             _external=True,
             library_short_name="test-library",
             provider=self.label(),
@@ -178,7 +180,7 @@ class MockEkirjastoAuthenticationAPI(EkirjastoAuthenticationAPI):
 
         assert None, f"Mockup for GET {url} not created"
 
-    def requests_post(self, url, ekirjasto_token=None):
+    def requests_post(self, url, ekirjasto_token=None, json_body=None):
         if self.bad_connection:
             raise requests.exceptions.ConnectionError(
                 "Connection error", self.__class__.__name__
@@ -245,6 +247,18 @@ class TestEkirjastoAuthentication:
             assert (
                 doc["links"][0]["href"]
                 == "http://localhost/test-library/ekirjasto_authenticate?provider=E-kirjasto+provider+for+circulation+manager"
+            )
+
+            assert (
+                doc["links"][6]["rel"] == "passkey_register_start"
+                and doc["links"][6]["href"]
+                == "http://localhost/test-library/ekirjasto/passkey/register/start?provider=E-kirjasto+provider+for+circulation+manager"
+            )
+
+            assert (
+                doc["links"][7]["rel"] == "passkey_register_finish"
+                and doc["links"][7]["href"]
+                == "http://localhost/test-library/ekirjasto/passkey/register/finish?provider=E-kirjasto+provider+for+circulation+manager"
             )
 
     def test_from_config(
@@ -771,3 +785,57 @@ class TestEkirjastoAuthentication:
         )
         assert isinstance(patron, Patron)
         assert PatronUtility.needs_external_sync(patron) == False
+
+    def test_remote_endpoint_get_success(
+        self,
+        create_provider: Callable[..., MockEkirjastoAuthenticationAPI],
+    ):
+        provider = create_provider()
+        user_id = "verified"
+        token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
+
+        response_json, response_code = provider.remote_endpoint("/v1/auth/userinfo", token, "GET")
+
+        assert isinstance(response_json, dict)
+        assert response_code == 200
+
+    def test_remote_endpoint_post_success(
+        self,
+        create_provider: Callable[..., MockEkirjastoAuthenticationAPI],
+    ):
+        provider = create_provider()
+        user_id = "verified"
+        token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
+
+        response_json, response_code = provider.remote_endpoint("/v1/auth/refresh", token, "POST", {"empty": "json"})
+
+        assert isinstance(response_json, dict)
+        assert response_code == 200
+
+    def test_remote_endpoint_invalid_token(
+        self,
+        create_provider: Callable[..., MockEkirjastoAuthenticationAPI],
+    ):
+        provider = create_provider()
+        user_id = "verified"
+        token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
+        
+        # Invalidate the token.
+        provider.mock_api._refresh_token_for_user_id(user_id)
+
+        response_json, response_code = provider.remote_endpoint("/v1/auth/userinfo", token, "GET")
+
+        assert response_json == None
+        assert response_code == 401
+
+    def test_remote_endpoint_unsupported_method(
+        self,
+        create_provider: Callable[..., MockEkirjastoAuthenticationAPI],
+    ):
+        provider = create_provider()
+
+        response_json, response_code = provider.remote_endpoint("/v1/auth/userinfo", "token", "PUT")
+
+        assert isinstance(response_json, ProblemDetail)
+        assert response_json.status_code == 415
+        assert response_code == None

--- a/tests/api/finland/test_ekirjasto.py
+++ b/tests/api/finland/test_ekirjasto.py
@@ -795,9 +795,7 @@ class TestEkirjastoAuthentication:
         token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
 
         response_json, response_code = provider.remote_endpoint(
-            "/v1/auth/userinfo",
-            token,
-            "GET"
+            "/v1/auth/userinfo", token, "GET"
         )
 
         assert isinstance(response_json, dict)
@@ -812,10 +810,7 @@ class TestEkirjastoAuthentication:
         token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
 
         response_json, response_code = provider.remote_endpoint(
-            "/v1/auth/refresh",
-            token,
-            "POST",
-            {"empty": "json"}
+            "/v1/auth/refresh", token, "POST", {"empty": "json"}
         )
 
         assert isinstance(response_json, dict)
@@ -828,14 +823,12 @@ class TestEkirjastoAuthentication:
         provider = create_provider()
         user_id = "verified"
         token, expires = provider.mock_api.get_test_access_token_for_user(user_id)
-        
+
         # Invalidate the token.
         provider.mock_api._refresh_token_for_user_id(user_id)
 
         response_json, response_code = provider.remote_endpoint(
-            "/v1/auth/userinfo",
-            token,
-            "GET"
+            "/v1/auth/userinfo", token, "GET"
         )
 
         assert isinstance(response_json, ProblemDetail)
@@ -848,9 +841,7 @@ class TestEkirjastoAuthentication:
         provider = create_provider()
 
         response_json, response_code = provider.remote_endpoint(
-            "/v1/auth/userinfo",
-            "token",
-            "PUT"
+            "/v1/auth/userinfo", "token", "PUT"
         )
 
         assert isinstance(response_json, ProblemDetail)

--- a/tests/api/finland/test_ekirjasto.py
+++ b/tests/api/finland/test_ekirjasto.py
@@ -825,8 +825,8 @@ class TestEkirjastoAuthentication:
 
         response_json, response_code = provider.remote_endpoint("/v1/auth/userinfo", token, "GET")
 
-        assert response_json == None
-        assert response_code == 401
+        assert isinstance(response_json, ProblemDetail)
+        assert response_json.status_code == 401
 
     def test_remote_endpoint_unsupported_method(
         self,


### PR DESCRIPTION
## Description

Added endpoints to call "/passkey/register" endpoints at ekirjasto API on behalf of the enduser. Implementation was done so that it is easy to add more similar endpoints later.

## Motivation and Context

The mobile client doesn't have ekirjasto token in usable form, "/passkey/register" endpoints requires those to authenticate requests.

See more at issue: SIMPLYE-218

## How Has This Been Tested?

- New unit tests for ekirjasto authentication were created. And tested manually with curl command. 

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
