### PR TITLE
Enable authentication with suomi.fi credentials

### DIFF
--- a/alembic/versions/20240222_9966f6f95674_create_admincredentials_table.py
+++ b/alembic/versions/20240222_9966f6f95674_create_admincredentials_table.py
@@ -1,0 +1,38 @@
+"""Create admincredentials table
+
+Revision ID: 9966f6f95674
+Revises: 993729d4bf97
+Create Date: 2024-02-22 02:36:07.130941+00:00
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9966f6f95674"
+down_revision = "993729d4bf97"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admincredentials",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("external_id", sa.Unicode(), nullable=False),
+        sa.Column("admin_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["admin_id"], ["admins.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_admincredentials_admin_id"),
+        "admincredentials",
+        ["admin_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_admincredentials_admin_id"), table_name="admincredentials")
+    op.drop_table("admincredentials")

--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -3,7 +3,10 @@ from enum import Enum
 from urllib.parse import urljoin
 
 from requests import RequestException
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.exc import ArgumentError
 
+from core.config import CannotLoadConfiguration
 from core.util.http import HTTP, RequestNetworkException
 from core.util.log import LoggerMixin
 
@@ -50,8 +53,30 @@ class Configuration(LoggerMixin):
     ENV_ADMIN_UI_PACKAGE_NAME = "TPP_CIRCULATION_ADMIN_PACKAGE_NAME"
     ENV_ADMIN_UI_PACKAGE_VERSION = "TPP_CIRCULATION_ADMIN_PACKAGE_VERSION"
 
+    # Finland
+    # Environment variable that defines admin ekirjasto sign in URL
+    ENV_ADMIN_EKIRJASTO_AUTHENTICATION_URL = "ADMIN_EKIRJASTO_AUTHENTICATION_URL"
+
     # Cache the package version after first lookup.
     _version: str | None = None
+
+    @classmethod
+    def ekirjasto_authentication_url(cls) -> str:
+        url = os.environ.get(cls.ENV_ADMIN_EKIRJASTO_AUTHENTICATION_URL)
+        if not url:
+            raise CannotLoadConfiguration(
+                "Admin Ekirjasto authentication url was not defined in environment variable %s."
+                % cls.ENV_ADMIN_EKIRJASTO_AUTHENTICATION_URL
+            )
+
+        try:
+            make_url(url)
+        except ArgumentError as e:
+            raise ArgumentError(
+                "Bad format for admin ekirjasto authentication URL (%s)." % url
+            )
+
+        return url
 
     @classmethod
     def operational_mode(cls) -> OperationalMode:

--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -19,7 +19,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "E-kirjasto Collection Manager"
     PACKAGE_NAME = "@natlibfi/ekirjasto-circulation-admin"
-    PACKAGE_VERSION = "0.1.0"
+    PACKAGE_VERSION = "0.2.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -97,6 +97,9 @@ class LibrarySettingsController(AdminPermissionsControllerMixin):
         )
 
     def process_post(self) -> Response:
+        # Finland, for ekirjasto users, restrict library update to system admins only
+        self.ekirjasto_require_system_admin()
+
         is_new = False
         form_data = flask.request.form
 

--- a/api/admin/controller/reset_password.py
+++ b/api/admin/controller/reset_password.py
@@ -70,7 +70,8 @@ class ResetPasswordController(AdminController):
 
         admin = self._extract_admin_from_request(flask.request)
 
-        if not admin:
+        # Finland, extra check to disable password reset for ekirjasto authenticated users.
+        if not admin or admin.is_authenticated_externally():
             return self._response_with_message_and_redirect_button(
                 INVALID_ADMIN_CREDENTIALS.detail,
                 url_for("admin_forgot_password"),

--- a/api/admin/controller/view.py
+++ b/api/admin/controller/view.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Literal
 from urllib.parse import quote_plus
 
 import flask
@@ -19,6 +20,7 @@ class ViewController(AdminController):
         setting_up = self.admin_auth_providers == []
         email = None
         roles = []
+        auth_type: Literal["password", "external"] = "password"
         if not setting_up:
             admin = self.authenticated_admin_from_request()
             if isinstance(admin, ProblemDetail):
@@ -60,6 +62,9 @@ class ViewController(AdminController):
                     roles.append({"role": role.role, "library": role.library})
                 else:
                     roles.append({"role": role.role})
+            auth_type = (
+                "external" if admin.is_authenticated_externally() else "password"
+            )
 
         csrf_token = (
             flask.request.cookies.get("csrf_token") or self.generate_csrf_token()
@@ -93,6 +98,7 @@ class ViewController(AdminController):
                 setting_up=setting_up,
                 email=email,
                 roles=roles,
+                auth_type=auth_type,
                 admin_js=admin_js,
                 admin_css=admin_css,
             )

--- a/api/admin/ekirjasto_admin_authentication_provider.py
+++ b/api/admin/ekirjasto_admin_authentication_provider.py
@@ -1,0 +1,116 @@
+import logging
+from urllib.parse import quote
+
+import flask
+import requests
+from flask import url_for
+from pydantic import BaseModel
+
+from api.admin.admin_authentication_provider import AdminAuthenticationProvider
+from api.admin.config import Configuration
+from api.admin.template_styles import button_style, input_style, label_style
+from api.admin.templates import ekirjasto_sign_in_template
+from api.circulation_exceptions import RemoteInitiatedServerError
+from api.problem_details import (
+    EKIRJASTO_REMOTE_AUTHENTICATION_FAILED,
+    INVALID_EKIRJASTO_TOKEN,
+)
+from core.util.problem_detail import ProblemDetail
+
+
+class EkirjastoUserInfo(BaseModel):
+    exp: int
+    family_name: str = ""
+    given_name: str = ""
+    role: str
+    sub: str
+    sid: str
+    municipality: str
+    verified: bool = False
+    passkeys: list[dict] = []
+
+
+# Finland
+class EkirjastoAdminAuthenticationProvider(AdminAuthenticationProvider):
+    NAME = "Ekirjasto Auth"
+
+    SIGN_IN_TEMPLATE = ekirjasto_sign_in_template.format(
+        label=label_style, input=input_style, button=button_style
+    )
+
+    _ekirjasto_api_url = Configuration.ekirjasto_authentication_url()
+
+    def sign_in_template(self, redirect):
+        redirect_uri = quote(
+            url_for("ekirjasto_auth_finish", redirect_uri=redirect, _external=True),
+        )
+
+        # Allow passing authentication test state with query parameter. For
+        # example, http://localhost:6500/admin/sign_in?state=:T0008 will result
+        # in authentication with "orgadmin" role.
+        state = flask.request.args.get("state", "")
+        ekirjasto_auth_url = (
+            f"{self._ekirjasto_api_url}/v1/auth/tunnistus/start"
+            f"?locale=fi"
+            f"&state={state}"
+            f"&redirect_uri={redirect_uri}"
+        )
+        return self.SIGN_IN_TEMPLATE % dict(
+            ekirjasto_auth_url=ekirjasto_auth_url,
+        )
+
+    def active_credentials(self, admin):
+        # This is not called anywhere, not sure what this is for.
+        return True
+
+    def ekirjasto_authenticate(
+        self, ekirjasto_token
+    ) -> EkirjastoUserInfo | ProblemDetail:
+        return self._get_user_info(ekirjasto_token)
+
+    def _get_user_info(self, ekirjasto_token: str) -> EkirjastoUserInfo | ProblemDetail:
+        userinfo_url = self._ekirjasto_api_url + "/v1/auth/userinfo"
+        try:
+            response = requests.get(
+                userinfo_url, headers={"Authorization": f"Bearer {ekirjasto_token}"}
+            )
+        except requests.exceptions.ConnectionError as e:
+            raise RemoteInitiatedServerError(str(e), self.__class__.__name__)
+
+        if response.status_code == 401:
+            return INVALID_EKIRJASTO_TOKEN
+        elif response.status_code != 200:
+            logging.error(
+                "Got unexpected response code %d, content=%s",
+                response.status_code,
+                (response.content or b"No content").decode("utf-8", errors="replace"),
+            )
+            return EKIRJASTO_REMOTE_AUTHENTICATION_FAILED
+        else:
+            try:
+                return EkirjastoUserInfo(**response.json())
+            except requests.exceptions.JSONDecodeError as e:
+                raise RemoteInitiatedServerError(str(e), self.__class__.__name__)
+
+    def try_revoke_ekirjasto_session(self, ekirjasto_token: str) -> None:
+        revoke_url = self._ekirjasto_api_url + "/v1/auth/revoke"
+
+        try:
+            response = requests.post(
+                revoke_url, headers={"Authorization": f"Bearer {ekirjasto_token}"}
+            )
+        except requests.exceptions.ConnectionError as e:
+            logging.exception(
+                "Failed to revoke ekirjasto session due to connection error."
+            )
+            # Ignore connection error, we tried our best
+
+        # Response codes in 4xx range mean that session is already expired, thus ok.
+        # For 5xx range, we want to log the response
+        if 500 <= response.status_code < 600:
+            logging.error(
+                "Failed to revoke ekirjasto session due to server error, status=%s, content=%s",
+                response.status_code,
+                (response.content or b"No content").decode("utf-8", errors="replace"),
+            )
+            # Ignore the error response, we tried our best

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -115,6 +115,14 @@ def admin_sign_in():
     return app.manager.admin_sign_in_controller.sign_in()
 
 
+# Finland
+# Ekirjasto auth client calls this endpoint when it finishes authenticating the user
+@app.route("/admin/ekirjasto_auth_finish", methods=["POST"])
+@returns_problem_detail
+def ekirjasto_auth_finish():
+    return app.manager.admin_sign_in_controller.ekirjasto_auth_finish()
+
+
 @app.route("/admin/sign_out")
 @returns_problem_detail
 @requires_admin

--- a/api/admin/templates.py
+++ b/api/admin/templates.py
@@ -18,6 +18,7 @@ admin = """
         settingUp: {{ "true" if setting_up else "false" }},
         email: "{{ email }}",
         roles: [{% for role in roles %}{"role": "{{role.role}}"{% if role.library %}, "library": "{{role.library.short_name}}"{% endif %} },{% endfor %}],
+        authType: "{{ auth_type }}",
         featureFlags: {
           enableAutoList: true,
         },

--- a/api/admin/templates.py
+++ b/api/admin/templates.py
@@ -58,6 +58,11 @@ sign_in_template = """
 </form>
 """
 
+# Finland
+ekirjasto_sign_in_template = """
+<a href="%(ekirjasto_auth_url)s">Sign in with Suomi.fi e-Identification</a>
+"""
+
 forgot_password_template = """
 <form action="%(forgot_password_url)s" method="post">
 <input type="hidden" name="redirect" value="%(redirect)s"/>

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ setenv =
     {api,core}: COVERAGE_FILE = .coverage.{envname}
     docker: SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:test@localhost:9005/simplified_circulation_test
     docker: PALACE_TEST_SEARCH_URL=http://localhost:9007
+    docker: ADMIN_EKIRJASTO_AUTHENTICATION_URL=http://localhost
     core-docker: PALACE_TEST_MINIO_ENDPOINT_URL=http://localhost:9004
     core-docker: PALACE_TEST_MINIO_USER=palace
     core-docker: PALACE_TEST_MINIO_PASSWORD=12345678901234567890


### PR DESCRIPTION
## Description

Implement admin authentication via external E-kirjasto authentication application.

This implementation assumes that:
  - The users & roles are managed externally, not with circulation.
  - The system will have only one library, so the external users will be mapped as site-wide admins. See table below.
 
### Role mapping

| Circulation admin role | E-kirjasto role | Description (fi) | Description (en)
|---|---|---|---|
| _unauthorized_ | `sysadmin` | - | Internal technical role for auth E-kirjasto auth system management only |
| `system-admin` | `orgadmin` | E-kirjaston pääkäyttäjä | E-library main admin |
| `manager-all` | `admin` | Paikalliskirjaston pääkäyttäjä | Local library admin user |
| _unauthorized_ | `registrant` | Paikalliskirjaston työntekijä / rekisteröijä | Local librarian user / registering agent |
| `librarian-all` | `librarian` | Paikalliskirjaston työntekijä / työryhmä | Local librarian user / work group |
| _unauthorized_ | `customer` | Kirjaston asiakas | Patron |

### Restrictions for externally authenticated users

The following extra authorization rules are put in place for E-kirjasto (i.e. externally authenticated) users.

- It is not possible to create / update / delete E-kirjasto users via admin UI (or API).
- E-kirjasto users are omitted from the `/admin/individual_admins` response. Thus, under the admin UI “System Configuration” panel, E-kirjasto users are not listed.
- E-kirjasto users are not authorized to see or edit password authenticated users.
- E-kirjasto users cannot add or change their password
- Only E-kirjasto main admin role is authorized to edit or delete libraries.

### Other implementation details:

The E-kirjasto user ID is used to populate the `email` field for admin data model. This ID will also be shown in the admin UI in place of the e-mail. We have the user's `given_name` and `family_name` on the backend so with some extra implementation would be possible to show that in the UI instead of the ID.

The original email+password based login is still available. Also, the initial admin UI "setting up" mode is still there for creating an initial system-admin user without relying on E-kirjasto API.

New environment value `ADMIN_EKIRJASTO_AUTHENTICATION_URL` added for configuring the admin authentication URL.

In the test environment, a `state` parameter can be used to test different types of admin users. The available values are:
  - `:T0000`: Failure
  - `:T0001`: Success, Turku 853, Unverified, customer
  - `:T0002`: Success, Turku 853, Verified, customer
  - `:T0003`: Success, Helsinki 091, Verified, customer
  - `:T0004`: Success, Empty municipality, Verified, customer
  - `:T0005`: Success, Helsinki 091, Verified, customer, born 2010
  - `:T0006`: Success, Helsinki 091, Verified, registrant
  - `:T0007`: Success, Helsinki 091, Verified, admin
  - `:T0008`: Success, Helsinki 091, Verified, orgadmin
  - `:T0009`: Success, Turku 853, Verified, sysadmin
  - `:T0010`: Success, Turku 853, Verified, librarian

This state can be passed to circulation admin sign in page with a query param. For example, use <http://localhost:6500/admin/sign_in?state=:T0008> to log in as a system admin.

## Motivation and Context

https://jira.lingsoft.fi/browse/SIMPLYE-216 - Enable the authentication of librarians to the administration console with their suomi.fi credentials

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
