### PR TITLE
Fix search filter for 'All' languages facet

### DIFF
--- a/core/lane.py
+++ b/core/lane.py
@@ -553,9 +553,7 @@ class Facets(FacetsWithEntryPoint):
         self.collection_name = collection_name or self.default_facet(
             library, self.COLLECTION_NAME_FACETS_GROUP_NAME
         )
-        self.language: str = language or self.default_facet(
-            library, self.LANGUAGE_FACET_GROUP_NAME
-        )
+        self.language: str = language
         if order_ascending == self.ORDER_ASCENDING:
             order_ascending = True
         elif order_ascending == self.ORDER_DESCENDING:
@@ -727,7 +725,9 @@ class Facets(FacetsWithEntryPoint):
         filter.subcollection = self.collection
 
         # Finland
-        if self.language and self.language != self.LANGUAGE_ALL:
+        if self.language == self.LANGUAGE_ALL:
+            filter.languages = []
+        elif self.language:
             filter.languages = [self.language]
 
         # We can only have distributor and collection name facets if we have a library

--- a/tests/api/feed/test_opds_acquisition_feed.py
+++ b/tests/api/feed/test_opds_acquisition_feed.py
@@ -1151,7 +1151,7 @@ class TestEntrypointLinkInsertion:
         # The make_link function that was passed in calls
         # TestAnnotator.feed_url() when passed an EntryPoint. The
         # Facets object's other facet groups are propagated in this URL.
-        first_page_url = "http://wl/?available=all&collection=full&collectionName=All&distributor=All&entrypoint=Book&language=all&order=author"
+        first_page_url = "http://wl/?available=all&collection=full&collectionName=All&distributor=All&entrypoint=Book&order=author"
         assert first_page_url == make_link(EbooksEntryPoint)
 
         # Pagination information is not propagated through entry point links

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -908,7 +908,7 @@ class TestCrawlableFacets:
         assert facets.collection == CrawlableFacets.COLLECTION_FULL
         assert facets.availability == CrawlableFacets.AVAILABLE_ALL
         assert facets.order == CrawlableFacets.ORDER_LAST_UPDATE
-        assert facets.language == CrawlableFacets.LANGUAGE_ALL
+        assert facets.language is None
         assert facets.order_ascending is False
 
         [
@@ -921,7 +921,7 @@ class TestCrawlableFacets:
         ] = facets.enabled_facets
 
         # The default facets are the only ones enabled.
-        for facet in [order, availability, collection, language]:
+        for facet in [order, availability, collection]:
             assert len(facet) == 1
 
         # Except for distributor and collectionName, which have the default

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -360,7 +360,7 @@ class TestFacets:
             ["collectionName", db.default_collection().name, False],
             ["distributor", "All", True],
             ["distributor", DataSource.AMAZON, False],
-            ["language", "all", True],
+            ["language", "all", False],
             ["language", "eng", False],
             ["language", "fin", False],
             ["language", "others", False],


### PR DESCRIPTION
When selecting the 'All' option under language facet, the search was being performed only against languages defined for the library instead of all the languages in the collection.

Now it should will show books in any language that exists in the collection.

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
