### PR TITLE
Enable Docker image builds in Actions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -149,8 +149,7 @@ jobs:
 
     # Only build docker containers on a push event. Otherwise, we won't have
     # permissions to push the built containers into registry.
-    # if: github.event_name == 'push'
-    if: false # Disable temporarily
+    if: github.event_name == 'push'
 
     outputs:
       baseimage-changed: ${{ steps.changes.outputs.baseimage }}
@@ -262,8 +261,7 @@ jobs:
             BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
 
   docker-image-test:
-    if: false # Disable temporarily
-    name: Docker test circ-${{ matrix.image }} (${{ matrix.platform }})
+    name: Docker test ekirjasto-circ-${{ matrix.image }} (${{ matrix.platform }})
     runs-on: ubuntu-latest
     needs: [docker-image-build]
     permissions:
@@ -308,8 +306,7 @@ jobs:
         run: docker compose down
 
   docker-image-push:
-    if: false # Disable temporarily
-    name: Push circ-${{ matrix.image }}
+    name: Push ekirjasto-circ-${{ matrix.image }}
     runs-on: ubuntu-latest
     needs: [test, test-migrations, docker-test-migrations, docker-image-build, docker-image-test]
     permissions:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 This is the E-kirjasto fork of the [The Palace Project](https://thepalaceproject.org) Palace Manager (which is a fork of
 [Library Simplified](http://www.librarysimplified.org/) Circulation Manager).
 
-<!-- ## Installation
+## Installation
 
 Docker images created from this code will be available at:
 
-- [circ-webapp](https://github.com/NatLibFi/circulation/pkgs/container/ekirjasto-circ-webapp)
-- [circ-scripts](https://github.com/NatLibFi/circulation/pkgs/container/ekirjasto-circ-scripts)
-- [circ-exec](https://github.com/NatLibFi/circulation/pkgs/container/ekirjasto-circ-exec)
+- [ekirjasto-circ-webapp](https://github.com/NatLibFi/circulation/pkgs/container/ekirjasto-circ-webapp)
+- [ekirjasto-circ-scripts](https://github.com/NatLibFi/circulation/pkgs/container/ekirjasto-circ-scripts)
+- [ekirjasto-circ-exec](https://github.com/NatLibFi/circulation/pkgs/container/ekirjasto-circ-exec)
 
-Docker images are the preferred way to deploy this code in a production environment. -->
+Docker images are the preferred way to deploy this code in a production environment.
 
 ## Git Branch Workflow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ x-cm-variables: &cm
     PALACE_STORAGE_ANALYTICS_BUCKET: "analytics"
     PALACE_STORAGE_URL_TEMPLATE: "http://localhost:9000/{bucket}/{key}"
     PALACE_REPORTING_NAME: "TEST CM"
+    PALACE_OPENSEARCH_ANALYTICS_ENABLED: true
+    PALACE_OPENSEARCH_ANALYTICS_URL: "http://os:9200/"
+    PALACE_OPENSEARCH_ANALYTICS_INDEX_PREFIX: "circulation-events"
+    ADMIN_EKIRJASTO_AUTHENTICATION_URL: "http://localhost"
   depends_on:
     pg:
       condition: service_healthy
@@ -26,9 +30,9 @@ x-cm-build: &cm-build
   context: .
   dockerfile: docker/Dockerfile
   args:
-    - BASE_IMAGE=${BUILD_BASE_IMAGE-ghcr.io/thepalaceproject/circ-baseimage:latest}
+    - BASE_IMAGE=${BUILD_BASE_IMAGE-ghcr.io/natlibfi/ekirjasto-circ-baseimage:latest}
   cache_from:
-    - ${BUILD_CACHE_FROM-ghcr.io/thepalaceproject/circ-webapp:main}
+    - ${BUILD_CACHE_FROM-ghcr.io/natlibfi/ekirjasto-circ-webapp:main}
 
 services:
   # example docker compose configuration for testing and development

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 # The only difference are what services are enabled.
 ###############################################################################
 
-ARG BASE_IMAGE=ghcr.io/thepalaceproject/circ-baseimage:latest
+ARG BASE_IMAGE=ghcr.io/natlibfi/ekirjasto-circ-baseimage:latest
 
 FROM ${BASE_IMAGE} AS common
 


### PR DESCRIPTION
## Description

This PR enables the docker image builds in GitHub Actions for `ekirjasto-circ-scripts`, `ekirjasto-circ-exec` and `ekirjasto-circ-webapp` to be used in deployment.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
