### PR TITLE
Add duration field to circulation events

### DIFF
--- a/alembic/versions/20240321_4915a361b082_add_duration_to_circulationevents.py
+++ b/alembic/versions/20240321_4915a361b082_add_duration_to_circulationevents.py
@@ -1,0 +1,26 @@
+"""Add duration to circulationevents
+
+Revision ID: 4915a361b082
+Revises: 9966f6f95674
+Create Date: 2024-03-21 14:06:48.744935+00:00
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4915a361b082"
+down_revision = "9966f6f95674"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "circulationevents", sa.Column("duration", sa.Integer(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("circulationevents", "duration")

--- a/api/s3_analytics_provider.py
+++ b/api/s3_analytics_provider.py
@@ -29,6 +29,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         old_value,
         new_value,
         neighborhood: str | None = None,
+        duration: int | None = None,  # Finland
     ) -> dict:
         """Create a Python dict containing required information about the event.
 
@@ -76,6 +77,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
             "old_value": old_value,
             "new_value": new_value,
             "delta": delta,
+            "duration": duration,
             "location": neighborhood,
             "license_pool_id": license_pool.id if license_pool else None,
             "publisher": edition.publisher if edition else None,
@@ -136,6 +138,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         time,
         old_value=None,
         new_value=None,
+        duration=None,  # Finland
         **kwargs,
     ):
         """Log the event using the appropriate for the specific provider's mechanism.
@@ -169,7 +172,14 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
             raise ValueError("Either library or license_pool must be provided.")
 
         event = self._create_event_object(
-            library, license_pool, event_type, time, old_value, new_value
+            library,
+            license_pool,
+            event_type,
+            time,
+            old_value,
+            new_value,
+            None,
+            duration,
         )
         content = json.dumps(
             event,

--- a/core/local_analytics_provider.py
+++ b/core/local_analytics_provider.py
@@ -13,6 +13,7 @@ class LocalAnalyticsProvider(LoggerMixin):
         time,
         old_value=None,
         new_value=None,
+        duration: int | None = None,
         **kwargs
     ):
         if not library and not license_pool:
@@ -29,5 +30,6 @@ class LocalAnalyticsProvider(LoggerMixin):
             old_value,
             new_value,
             start=time,
+            duration=duration,
             library=library,
         )

--- a/core/model/circulationevent.py
+++ b/core/model/circulationevent.py
@@ -32,6 +32,7 @@ class CirculationEvent(Base):
     old_value = Column(Integer)
     delta = Column(Integer)
     new_value = Column(Integer)
+    duration = Column(Integer)  # Finland, duration of the event in seconds
 
     # The Library associated with the event, if it happened in the
     # context of a particular Library and we know which one.
@@ -122,6 +123,7 @@ class CirculationEvent(Base):
         end=None,
         library=None,
         location=None,
+        duration: int | None = None,
     ):
         """Log a CirculationEvent to the database, assuming it
         hasn't already been recorded.
@@ -147,6 +149,7 @@ class CirculationEvent(Base):
                 delta=delta,
                 end=end,
                 location=location,
+                duration=duration,
             ),
         )
         if was_new:


### PR DESCRIPTION
## Description

This PR adds duration field to circulation events (database, OpenSearch, S3). It is used to store loan duration times (in seconds) to loan revoke events.

This adds new duration field to circulationevent model and OpenSearch event index. OpenSearch mapping change is a small addition and it is done in lightweight ad-hoc manner as currently we don't have flow for migrating from mapping version to another.

Loan durations cannot be added retroactively to the existing events since we didn't have this data earlier.

## Motivation and Context

Loan duration enables filtering out short loans from analytics (https://jira.lingsoft.fi/browse/SIMPLYE-181). This implementation will be its own PR.

## How Has This Been Tested?

I tested the local analytics events and OpenSearch events with Palace Bookshelf open access books and revoke events have correct durations in seconds stored in them.

NOTE: S3 events have not been tested. Currently they are not used in E-kirjasto.

