### PR TITLE
Misc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Pyenv
+
+.python-version
+
 # Editors
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ Run the application with:
 poetry run python app.py
 ```
 
-psear
 Check that there is now a web server listening on port `6500`:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ sudo apt install libxmlsec1 libxmlsec1-dev
 [installed](https://github.com/pyenv/pyenv-installer) using the command `curl https://pyenv.run | bash`. You can then
 install the version of Python you want to work with.
 
+Check if you already have pyenv-virtualenv as a plugin with your pyenv:
+
+```sh
+ls $PYENV_ROOT/plugins/pyenv-virtualenv/
+```
+
+If you have it installed already you can skip the next part.
+
 It is recommended that [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) be used to allow `pyenv`
 to manage _virtual environments_ in a manner that can be used by the [poetry](#poetry) tool. The `pyenv-virtualenv`
 plugin can be installed by cloning the relevant repository into the `plugins` subdirectory of your `$PYENV_ROOT`:


### PR DESCRIPTION
Three small misc changes:

1. Update the readme with a note that the pyenv-virtualenv step can possibly be skipped as it is already installed by default in newer versions.
2. Removed a typo in the readme.
3. Remove and gitignore the .python-version file.