### PR TITLE
SIMPLYE-261 - Municipality and consortium management

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -83,6 +83,7 @@ class LibrarySettingsController(AdminPermissionsControllerMixin):
                     name=library.name,
                     short_name=library.short_name,
                     settings=settings,
+                    is_default=library.is_default,
                 )
             ]
         return Response(

--- a/api/admin/ekirjasto_admin_authentication_provider.py
+++ b/api/admin/ekirjasto_admin_authentication_provider.py
@@ -25,7 +25,10 @@ class EkirjastoUserInfo(BaseModel):
     role: str
     sub: str
     sid: str
+    # Municipality of residence, used to link patrons to a consortium
     municipality: str
+    # Municipalities the admin/librarian is allowed to manage. For admins and librarians only.
+    municipalities: list[str] = []
     verified: bool = False
     passkeys: list[dict] = []
 

--- a/api/ekirjasto_authentication.py
+++ b/api/ekirjasto_authentication.py
@@ -45,6 +45,7 @@ from core.integration.settings import (
     FormField,
 )
 from core.model import ConfigurationSetting, Credential, DataSource, Patron, get_one
+from core.model.library import Library
 from core.util.datetime_helpers import from_timestamp, utc_now
 from core.util.log import elapsed_time_logging
 from core.util.problem_detail import ProblemDetail
@@ -674,9 +675,16 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
                 _db, self.library_id, analytics=self.analytics
             )
             new_patron.last_external_sync = utc_now()
+            self._update_patron_library(_db, new_patron)
             return new_patron, is_new
 
+        if isinstance(auth_result, Patron):
+            self._update_patron_library(_db, auth_result)
         return auth_result, is_new
+
+    def _update_patron_library(self, _db: Session, patron: Patron):
+        """Assigns the patron to a library based on municipality"""
+        patron.library = Library.lookup_by_municipality(_db, patron.cached_neighborhood)
 
     def authenticated_patron(
         self, _db: Session, authorization: dict | str

--- a/api/ekirjasto_consortium.py
+++ b/api/ekirjasto_consortium.py
@@ -1,0 +1,303 @@
+import logging
+from dataclasses import dataclass
+from typing import Literal, TypeVar
+
+import requests
+from pydantic import BaseModel
+
+from api.circulation_exceptions import RemoteInitiatedServerError
+from core.configuration.library import LibrarySettings
+from core.metadata_layer import TimestampData
+from core.model.library import Library
+from core.monitor import Monitor
+
+
+class KirkantaConsortium(BaseModel):
+    id: str
+    name: str
+    slug: str
+
+
+class KirkantaConsortiums(BaseModel):
+    items: list[KirkantaConsortium]
+    type: Literal["consortium"]
+
+
+class KirkantaCity(BaseModel):
+    id: str
+    consortium: str | None
+    name: str
+
+
+class KirkantaCities(BaseModel):
+    items: list[KirkantaCity]
+    type: Literal["city"]
+
+
+class KoodistoConceptCodeAttribute(BaseModel):
+    attributeName: str
+    attributeValue: list[str]
+
+
+class KoodistoConceptCode(BaseModel):
+    attributes: list[KoodistoConceptCodeAttribute]
+    status: Literal["ACTIVE", "PROPOSAL", "DELETED"]
+    conceptCodeId: str
+
+    def findAttribute(self, attributeName: str) -> str | None:
+        for attribute in self.attributes:
+            if attribute.attributeName == attributeName and attribute.attributeValue:
+                return attribute.attributeValue[0]
+        return None
+
+
+class KoodistoConceptCodes(BaseModel):
+    conceptCodes: list[KoodistoConceptCode]
+    page: int
+    totalItems: int
+    totalPages: int
+
+
+@dataclass(frozen=True)
+class EkirjastoConsortium:
+    name: str
+    kirkanta_slug: str
+    municipality_codes: list[str]
+
+
+# Finland
+class EkirjastoConsortiumMonitor(Monitor):
+    """For E-kirjasto, each library represents a consortium, aka "Kimppa".
+    Each consortium has multiple member municipalities.
+
+    This utility updates the mapping between municipality codes (received
+    from authentication app) and Consortiums.
+
+    Two 3rd party public APIs are utilized for this: Kirkanta and Kansallinen
+    Koodistopalvelu.
+    """
+
+    SERVICE_NAME: str = "E-Kirjasto Consortium Monitor"
+
+    # Kirkanta provides two endpoints, one that lists all consortiums and
+    # another that lists all cities.
+    _KIRKANTA_API_URL: str = "https://api.kirjastot.fi/v4"
+
+    # Kansallinen koodistopalvelu provides the list of municipality codes. These
+    # are the codes used by the authentication application.
+    # The ids of "cities" in Kirkanta do not match the municipality codes in
+    # Koodistopalvelu, and need to be matched by name.
+    _KOODISTO_API_URL: str = "https://koodistopalvelu.kanta.fi/codeserver/csapi/v6"
+    _KOODISTO_CLASSIFICATION_ID: str = "1.2.246.537.6.21"
+    _KOODISTO_MAX_ALLOWED_PAGESIZE: int = 500
+
+    # City names that we want to skip in Kirkanta.
+    _KIRKANTA_JUNK_CITIES: list[str] = ["Äävekaupunki"]
+
+    # Manually managed list of Kirkanta city names don't match with Koodistopalvelu
+    KIRKANTA_CITY_NAME_ALIASES: dict[str, str] = {"Pedersöre": "Pedersören kunta"}
+
+    def run_once(self, progress):
+        kirkanta_consortiums = self._fetch_kirkanta_consortiums()
+        kirkanta_cities = self._fetch_kirkanta_cities()
+        kirkanta_cities = self._filter_out_junk_data(kirkanta_cities)
+        koodisto_concept_codes = self._fetch_koodisto_concept_codes()
+
+        missing_cities = self._verify_all_kirkanta_cities_found_in_koodisto(
+            kirkanta_cities, koodisto_concept_codes
+        )
+
+        logging.info(
+            f"The following cities do not belong to any consortium: "
+            f"{[city.name for city in kirkanta_cities if not city.consortium]}. "
+            f"Unless a library is created manually, patrons from these cities "
+            f"will be assigned to the default library."
+        )
+
+        libraries = self._db.query(Library).all()
+
+        for library in libraries:
+            self._synchronize_library(
+                library, kirkanta_consortiums, kirkanta_cities, koodisto_concept_codes
+            )
+
+        if missing_cities:
+            return TimestampData(
+                achievements=f"Kirkanta synchronization done! NOTE: "
+                f"The following Kirkanta city names were "
+                f"not found in Koodistopalvelu: {missing_cities}. "
+                f"Please add the missing city names manually to "
+                f"KIRKANTA_CITY_NAME_ALIASES."
+            )
+        return TimestampData(
+            achievements=f"Kirkanta synchronization done!",
+        )
+
+    def _fetch_kirkanta_cities(self) -> list[KirkantaCity]:
+        return self._get(
+            KirkantaCities, f"{self._KIRKANTA_API_URL}/city", {"limit": 9999}
+        ).items
+
+    def _fetch_kirkanta_consortiums(self) -> list[KirkantaConsortium]:
+        return self._get(
+            KirkantaConsortiums,
+            f"{self._KIRKANTA_API_URL}/consortium",
+            {"status": "ACTIVE", "limit": 9999},
+        ).items
+
+    def _fetch_koodisto_concept_codes(self, page: int = 1) -> list[KoodistoConceptCode]:
+        response: KoodistoConceptCodes = self._get(
+            KoodistoConceptCodes,
+            f"{self._KOODISTO_API_URL}/classifications/{self._KOODISTO_CLASSIFICATION_ID}/conceptcodes",
+            {"pageSize": self._KOODISTO_MAX_ALLOWED_PAGESIZE, "page": page},
+        )
+        if response.page < response.totalPages:
+            return response.conceptCodes + self._fetch_koodisto_concept_codes(
+                page=page + 1
+            )
+
+        return response.conceptCodes
+
+    def _build_circulation_consortium(
+        self,
+        kirkanta_consortium: KirkantaConsortium,
+        kirkanta_cities: list[KirkantaCity],
+        koodisto_concept_codes: list[KoodistoConceptCode],
+    ) -> EkirjastoConsortium:
+        """Combines the the Kirkanta and Koodistopalvelu data into a model usable within Circulation"""
+
+        cities_in_consortium = [
+            city
+            for city in kirkanta_cities
+            if city.consortium == kirkanta_consortium.id
+        ]
+        koodisto_codes = [
+            self._to_koodisto_code(city, koodisto_concept_codes)
+            for city in cities_in_consortium
+        ]
+
+        return EkirjastoConsortium(
+            name=kirkanta_consortium.name,
+            kirkanta_slug=kirkanta_consortium.slug,
+            municipality_codes=[code.conceptCodeId for code in koodisto_codes if code],
+        )
+
+    def _synchronize_library(
+        self,
+        library: Library,
+        kirkanta_consortiums: list[KirkantaConsortium],
+        kirkanta_cities: list[KirkantaCity],
+        koodisto_codes: list[KoodistoConceptCode],
+    ) -> None:
+        if library.is_default:
+            logging.info(
+                'Skipping default library "%s".',
+                library.name,
+            )
+            return
+
+        slug = library.settings_dict.get(
+            "kirkanta_consortium_slug",
+            "disabled",
+        )
+        if not slug or slug == "disabled":
+            logging.info(
+                'Skipping library "%s": not configured for automatic sync.',
+                library.name,
+            )
+            return
+
+        matched_consortiums = [
+            consortium for consortium in kirkanta_consortiums if consortium.slug == slug
+        ]
+        if not matched_consortiums:
+            logging.error(
+                "A consortium with slug %s was not found in Kirkanta. Can't update library. "
+                "This can happen if the library slug selection does not match Kirkanta value.",
+                slug,
+            )
+            return
+
+        logging.info('Synchronizing library "%s"', library.name)
+
+        circulation_consortium: EkirjastoConsortium = (
+            self._build_circulation_consortium(
+                matched_consortiums[0], kirkanta_cities, koodisto_codes
+            )
+        )
+
+        library.update_settings(
+            LibrarySettings.construct(
+                municipalities=circulation_consortium.municipality_codes,
+            )
+        )
+
+    def _filter_out_junk_data(self, cities: list[KirkantaCity]) -> list[KirkantaCity]:
+        return [city for city in cities if city.name not in self._KIRKANTA_JUNK_CITIES]
+
+    def _verify_all_kirkanta_cities_found_in_koodisto(
+        self, cities: list[KirkantaCity], concept_codes: list[KoodistoConceptCode]
+    ) -> list[str] | None:
+        """Compares the city names in Kirkanta and Koodistopalvelu. Logs an
+        error if some names are.
+
+        :returns: List of city names found in Kirkanta but not in koodisto
+        """
+        missing_names = [
+            city.name
+            for city in cities
+            if not self._to_koodisto_code(city, concept_codes)
+        ]
+
+        if missing_names:
+            logging.warning(
+                "The following Kirkanta city names are not found in Koodistopalvelu: %s. "
+                "Please add the missing city name manually to KIRKANTA_CITY_NAME_ALIASES.",
+                str(missing_names),
+            )
+            return missing_names
+        else:
+            logging.info("Nice! All Kirkanta city names found in Koodistopalvelu.")
+            return None
+
+    def _to_koodisto_code(
+        self, kirkanta_city: KirkantaCity, concept_codes: list[KoodistoConceptCode]
+    ) -> KoodistoConceptCode | None:
+        """Finds a matching Koodistopalvelu code for a kirkanta city"""
+
+        for code in concept_codes:
+            koodisto_city_name = code.findAttribute("ShortName")
+            if koodisto_city_name == kirkanta_city.name:
+                return code
+
+            alias: str | None = self.KIRKANTA_CITY_NAME_ALIASES.get(
+                kirkanta_city.name,
+            )
+            if alias and koodisto_city_name == alias:
+                return code
+
+        return None
+
+    R = TypeVar("R", bound=BaseModel)
+
+    def _get(self, response_type: type[R], url: str, params=None) -> R:
+        """Perform HTTP GET request and parse the response into a pydantic model of type R"""
+        try:
+            response = requests.get(url, params)
+        except requests.exceptions.ConnectionError as e:
+            raise RemoteInitiatedServerError(str(e), url)
+
+        if response.status_code != 200:
+            content: str = "No content"
+            if response.content:
+                content = response.content.decode("utf-8", errors="replace")
+
+            raise RemoteInitiatedServerError(
+                f"Unexpected response status {response.status_code}, url={url}, content={content}",
+                url,
+            )
+        else:
+            try:
+                return response_type(**response.json())
+            except requests.exceptions.JSONDecodeError as e:
+                raise RemoteInitiatedServerError(str(e), url)

--- a/bin/ekirjasto_consortium_monitor
+++ b/bin/ekirjasto_consortium_monitor
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""Update the circulation manager with latest consortium and municipality data
+from Kirkanta and Koodistopalvelu."""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from api.ekirjasto_consortium import EkirjastoConsortiumMonitor
+from core.scripts import RunMonitorScript
+
+RunMonitorScript(
+    EkirjastoConsortiumMonitor,
+).run()

--- a/core/configuration/library.py
+++ b/core/configuration/library.py
@@ -555,6 +555,21 @@ class LibrarySettings(BaseSettings):
         ),
         alias="http://librarysimplified.org/terms/rel/patron-password-reset",
     )
+    # Finland
+    municipalities: list[str] | None = FormField(
+        None,
+        form=LibraryConfFormItem(
+            label="The municipalities belonging to this consortium",
+            type=ConfigurationFormItemType.LIST,
+            format="municipality-code",
+            description="Each value should be a valid "
+            '<a href="https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=362&versionKey=440" target="_blank">'
+            "municipality code</a>.",
+            category="Municipalities",
+            level=Level.ALL_ACCESS,
+        ),
+        alias="municipalities",
+    )
     large_collection_languages: list[str] | None = FormField(
         None,
         form=LibraryConfFormItem(
@@ -656,6 +671,16 @@ class LibrarySettings(BaseSettings):
                     "target='_blank'>here</a>."
                 )
             )
+        return value
+
+    @validator(
+        "municipalities",
+    )
+    def validate_municipalities(
+        cls, value: list[str] | None, field: ModelField
+    ) -> list[str] | None:
+        """Verify that municipality IDs are valid."""
+        # TODO: implement validation
         return value
 
     @validator(

--- a/core/configuration/library.py
+++ b/core/configuration/library.py
@@ -131,6 +131,77 @@ class LibrarySettings(BaseSettings):
             level=Level.SYS_ADMIN_ONLY,
         ),
     )
+    # Finland
+    kirkanta_consortium_slug: str | None = FormField(
+        None,
+        form=LibraryConfFormItem(
+            label="Synchronize consortium data form Kirkanta",
+            description="If selected, the list of municipalities is updated automatically from Kirkanta. "
+            "Has no effect if configured for the default library.",
+            category="Kirkanta Synchronization",
+            type=ConfigurationFormItemType.SELECT,
+            # The keys here should match the Kirkanta consortium slug
+            # See https://api.kirjastot.fi/v4/consortium?limit=9999
+            options={
+                "disabled": "None (don't sync)",
+                "kirkkonummi": "Kirkkonummi",
+                "fredrika": "Fredrikabiblioteken",
+                "siilinjarvikoha": "Siilinjärvi",
+                "ratamo-kirjastot": "RATAMO-kirjastot",
+                "keski-kirjastot": "Keski-kirjastot",
+                "sotkamo": "Sotkamo",
+                "kyyti": "Kyyti",
+                "joki-kirjastot": "Joki-kirjastot",
+                "blanka": "Blanka",
+                "lapin-kirjasto": "Lapin kirjasto",
+                "toki": "TOKI-kirjastot",
+                "leppavirta": "Leppävirta",
+                "loisto": "Loisto",
+                "rutakko": "Rutakko-kirjastot",
+                "lumme": "Lumme-kirjastot",
+                "tritonia-2": "Tritonia",
+                "helle": "Helle-kirjastot",
+                "satakirjastot": "Satakirjastot",
+                "anders": "Anders",
+                "somero": "Somero",
+                "sulkava2": "Sulkava",
+                "kirkes-kirjastot": "Kirkes-kirjastot",
+                "vaara-kirjastot": "Vaara-kirjastot",
+                "lukki-kirjastot": "Lukki-kirjastot",
+                "heili": "Heili-kirjastot",
+                "kuopionkirjasto": "Kuopion kaupunginkirjasto",
+                "piki": "PIKI-kirjastot",
+                "louna-kirjastot": "Louna-kirjastot",
+                "stepkoulutus-kirjastot": "STEP-koulutus, kirjastot",
+                "eepos": "Eepos-kirjastot",
+                "vaasa": "Vaasa",
+                "lastu": "Lastu",
+                "kansallisgalleria-kirjasto": "Kansallisgalleria / Kirjasto",
+                "outi": "OUTI-kirjastot",
+                "helmet": "Helmet",
+                "vaski-kirjastot": "Vaski-kirjastot",
+                "kainet": "Kainet-kirjastot",
+                "vanamo": "Vanamo",
+            },
+            level=Level.SYS_ADMIN_ONLY,
+        ),
+        alias="kirkanta_consortium_slug",
+    )
+    # Finland
+    municipalities: list[str] | None = FormField(
+        None,
+        form=LibraryConfFormItem(
+            label="The municipalities belonging to this consortium",
+            type=ConfigurationFormItemType.LIST,
+            format="municipality-code",
+            description="Each value should be a valid "
+            '<a href="https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=362&versionKey=440" target="_blank">'
+            "municipality code</a>.",
+            category="Kirkanta Synchronization",
+            level=Level.ALL_ACCESS,
+        ),
+        alias="municipalities",
+    )
     allow_holds: bool = FormField(
         True,
         form=LibraryConfFormItem(
@@ -554,21 +625,6 @@ class LibrarySettings(BaseSettings):
             level=Level.SYS_ADMIN_ONLY,
         ),
         alias="http://librarysimplified.org/terms/rel/patron-password-reset",
-    )
-    # Finland
-    municipalities: list[str] | None = FormField(
-        None,
-        form=LibraryConfFormItem(
-            label="The municipalities belonging to this consortium",
-            type=ConfigurationFormItemType.LIST,
-            format="municipality-code",
-            description="Each value should be a valid "
-            '<a href="https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=362&versionKey=440" target="_blank">'
-            "municipality code</a>.",
-            category="Municipalities",
-            level=Level.ALL_ACCESS,
-        ),
-        alias="municipalities",
     )
     large_collection_languages: list[str] | None = FormField(
         None,

--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -116,3 +116,8 @@ HOME=/var/www/circulation
 # Update the status of the different Authentication Providers
 #
 */5 * * * * root core/bin/run update_integration_statuses >> /var/log/cron.log 2>&1
+
+# Finland, synchronize library municipalities from Kirkanta and Koodistopalvelu
+# Run once every two hours
+#
+0 */2 * * * root core/bin/run ekirjasto_consortium_monitor >> /var/log/cron.log 2>&1

--- a/tests/api/admin/controller/test_collections.py
+++ b/tests/api/admin/controller/test_collections.py
@@ -352,6 +352,10 @@ class TestCollectionSettings:
         flask_app_fixture: FlaskAppFixture,
         db: DatabaseTransactionFixture,
     ):
+        # Finland: the logic has been changed so that collections from default
+        # library are available for all libraries
+
+        # Default library
         l1 = db.library(
             name="Library 1",
             short_name="L1",
@@ -383,7 +387,7 @@ class TestCollectionSettings:
                     ("overdrive_client_key", "username"),
                     ("overdrive_client_secret", "password"),
                     ("overdrive_website_id", "1234"),
-                ]
+                ],
             )
             response = controller.process_collections()
             assert isinstance(response, Response)
@@ -391,7 +395,9 @@ class TestCollectionSettings:
 
         # The collection was created and configured properly.
         collection = Collection.by_name(db.session, name="New Collection")
+
         assert isinstance(collection, Collection)
+
         assert collection.integration_configuration.id == int(response.get_data())
         assert "New Collection" == collection.name
         assert (
@@ -412,9 +418,10 @@ class TestCollectionSettings:
         )
 
         # Two libraries now have access to the collection.
+        # Finland: because l1 is the default library, l3 will have the collection as well
         assert [collection] == l1.collections
         assert [collection] == l2.collections
-        assert [] == l3.collections
+        assert [collection] == l3.collections
 
         # Additional settings were set on the collection.
         assert (
@@ -466,7 +473,8 @@ class TestCollectionSettings:
         assert "website_id" not in child.integration_configuration.settings_dict
 
         # One library has access to the collection.
-        assert [child] == l3.collections
+        # Finland: l3 will also have the collection from default library
+        assert [collection, child] == l3.collections
         assert isinstance(l3.id, int)
         l3_settings = child.integration_configuration.for_library(l3.id)
         assert l3_settings is not None

--- a/tests/api/admin/controller/test_sign_in.py
+++ b/tests/api/admin/controller/test_sign_in.py
@@ -307,14 +307,14 @@ class TestSignInController:
         for role in initial_roles:
             admin.add_role(AdminRole.SYSTEM_ADMIN, library=None)
 
-        SignInController._update_roles_if_changed(admin, AdminRole.SYSTEM_ADMIN)
+        SignInController._update_roles_if_changed(admin, (AdminRole.SYSTEM_ADMIN, None))
         sign_in_fixture.ctrl.db.session.refresh(admin)
         assert initial_roles == [(role.role, role.library) for role in admin.roles]
 
         admin.add_role(role=AdminRole.LIBRARY_MANAGER, library=None)
         admin.add_role(role=AdminRole.LIBRARIAN, library=None)
         SignInController._update_roles_if_changed(
-            admin, new_role=AdminRole.SYSTEM_ADMIN
+            admin, new_role=(AdminRole.SYSTEM_ADMIN, None)
         )
         sign_in_fixture.ctrl.db.session.refresh(admin)
         assert initial_roles == [(role.role, role.library) for role in admin.roles]

--- a/tests/api/admin/controller/test_sign_in.py
+++ b/tests/api/admin/controller/test_sign_in.py
@@ -307,14 +307,16 @@ class TestSignInController:
         for role in initial_roles:
             admin.add_role(AdminRole.SYSTEM_ADMIN, library=None)
 
-        SignInController._update_roles_if_changed(admin, (AdminRole.SYSTEM_ADMIN, None))
+        SignInController._update_roles_if_changed(
+            admin, [(AdminRole.SYSTEM_ADMIN, None)]
+        )
         sign_in_fixture.ctrl.db.session.refresh(admin)
         assert initial_roles == [(role.role, role.library) for role in admin.roles]
 
         admin.add_role(role=AdminRole.LIBRARY_MANAGER, library=None)
         admin.add_role(role=AdminRole.LIBRARIAN, library=None)
         SignInController._update_roles_if_changed(
-            admin, new_role=(AdminRole.SYSTEM_ADMIN, None)
+            admin, new_roles=[(AdminRole.SYSTEM_ADMIN, None)]
         )
         sign_in_fixture.ctrl.db.session.refresh(admin)
         assert initial_roles == [(role.role, role.library) for role in admin.roles]

--- a/tests/api/test_selftest.py
+++ b/tests/api/test_selftest.py
@@ -190,7 +190,9 @@ class TestRunSelfTestsScript:
 
         # The default library is the only one with a collection;
         # test_collection() was called on that collection.
-        [(collection, api_map)] = script.tested
+        # Finland: The difference from upstream is that the other
+        # library will also include the collection from default library.
+        [(collection, api_map), (collection, api_map)] = script.tested
         assert [collection] == library1.collections
 
         # The API lookup map passed into test_collection() is based on
@@ -209,9 +211,9 @@ class TestRunSelfTestsScript:
         script = MockScript2(db.session, out)
         script.do_run()
         assert (
-            out.getvalue()
-            == "Testing %s\n  Exception while running self-test: 'blah'\nTesting %s\n"
+            "Testing %s\n  Exception while running self-test: 'blah'\nTesting %s\n"
             % (library1.name, library2.name)
+            in out.getvalue()
         )
 
     def test_test_collection(self, db: DatabaseTransactionFixture):

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1702,6 +1702,11 @@ class TestWork:
         self, db: DatabaseTransactionFixture
     ):
         """2 libraries, 2 collections, and 2 pools, always select the right pool in a scoped request"""
+
+        # Finland: Create and ignore a default library, because collections for default library
+        # are applied to all libraries.
+        _ = db.default_library()
+
         l1 = db.library()
         l2 = db.library()
         c1 = db.collection()

--- a/tests/core/test_ekirjasto_consortium_monitor.py
+++ b/tests/core/test_ekirjasto_consortium_monitor.py
@@ -1,0 +1,90 @@
+import re
+
+from requests_mock import Mocker
+
+from api.ekirjasto_consortium import EkirjastoConsortiumMonitor
+from core.configuration.library import LibrarySettings
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+class TestEkirjastoConsortiumMonitor:
+    def test_library_sync_happy_case(self, db: DatabaseTransactionFixture):
+        _ = db.default_library()
+        library = db.library(name="my_library")
+        library.update_settings(
+            LibrarySettings.construct(kirkanta_consortium_slug="vaski-kirjastot")
+        )
+
+        with Mocker() as mocker:
+            self._mock_kirkanta_api(mocker)
+            self._mock_koodisto_api(mocker)
+            EkirjastoConsortiumMonitor(db.session).run()
+
+        assert ["100"] == library.settings.municipalities
+
+    def _mock_koodisto_api(self, mocker: Mocker) -> None:
+        mocker.get(
+            re.compile(r"https://koodistopalvelu.kanta.fi/.*"),
+            status_code=200,
+            json={
+                "conceptCodes": [
+                    {
+                        "attributes": [
+                            {
+                                "attributeName": "ShortName",
+                                "attributeValue": ["Turku"],
+                            }
+                        ],
+                        "status": "ACTIVE",
+                        "conceptCodeId": 100,
+                    },
+                    {
+                        "attributes": [
+                            {
+                                "attributeName": "ShortName",
+                                "attributeValue": ["Kangasniemi"],
+                            }
+                        ],
+                        "status": "ACTIVE",
+                        "conceptCodeId": 200,
+                    },
+                ],
+                "totalItems": 2,
+                "totalPages": 1,
+                "page": 1,
+            },
+        )
+
+    def _mock_kirkanta_api(self, mocker: Mocker) -> None:
+        mocker.get(
+            re.compile(r"https://api.kirjastot.fi/v4/city.*"),
+            status_code=200,
+            json={
+                "type": "city",
+                "items": [
+                    {"id": "1", "name": "Turku", "consortium": "10"},
+                    {"id": "2", "name": "Helsinki", "consortium": "20"},
+                    {"id": "3", "name": "Kangasniemi", "consortium": None},
+                ],
+            },
+        )
+
+        mocker.get(
+            re.compile(r"https://api.kirjastot.fi/v4/consortium.*"),
+            status_code=200,
+            json={
+                "type": "consortium",
+                "items": [
+                    {
+                        "id": "10",
+                        "name": "Vaski-kirjastot",
+                        "slug": "vaski-kirjastot",
+                    },
+                    {
+                        "id": "20",
+                        "name": "Helmet",
+                        "slug": "helmet",
+                    },
+                ],
+            },
+        )

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -3623,14 +3623,21 @@ class TestFilter:
         for_default_library.append_child(for_other_library)
 
         # Its filter uses the collection from the second library.
+        # Finland: Also the collection from default library is included
         filter = Filter.from_worklist(session, for_other_library, None)
-        assert [collection2.id] == filter.collection_ids
+        assert [
+            transaction.default_collection().id,
+            collection2.id,
+        ] == filter.collection_ids
 
         # If for whatever reason, collection_ids on the child is not set,
         # all collections associated with the WorkList's library will be used.
         for_other_library.collection_ids = None
         filter = Filter.from_worklist(session, for_other_library, None)
-        assert [collection2.id] == filter.collection_ids
+        assert [
+            transaction.default_collection().id,
+            collection2.id,
+        ] == filter.collection_ids
 
         # If no library is associated with a WorkList, we assume that
         # holds are allowed. (Usually this is controleld by a library

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -1217,9 +1217,10 @@ class TestConfigureCollectionScript:
         )
 
         # Two libraries now have access to the collection.
+        # Finland: because l1 is the default library, l3 will have the collection as well
         assert [collection] == l1.collections
         assert [collection] == l2.collections
-        assert [] == l3.collections
+        assert [collection] == l3.collections
 
         # One CollectionSetting was set on the collection, in addition
         # to url, username, and password.
@@ -1705,7 +1706,6 @@ class TestWhereAreMyBooksScript:
         script.check_library(library2)
         checking, no_collection, no_lanes = script.output
         assert ("Checking library %s", [library2.name]) == checking
-        assert " This library has no collections -- that's a problem." == no_collection
         assert " This library has no lanes -- that's a problem." == no_lanes
 
     @staticmethod


### PR DESCRIPTION
## Description

### Goal

- Possibility to customize lanes for each Kimppa (aka consortium)
- All Kimppas share the same collections, i.e.:
    -> License pools shared between all Kimppas
    -> All patrons will have access to the same works regardless of Kimppa
- Easy handling for municipality and Kimppa data and mapping. Mapping done based on municipality code received during sign in.

### Available data

1) Municipality code for patron and admin during authentication
2) Two 3rd party APIs:
    - Kirkanta, <https://api.kirjastot.fi/>
        - Provides list of cities and Kimppas
    - Kansallinen koodistopalvelu, <https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=362&versionKey=440>
        - Provides list of municipality codes and names. The authentication system uses these codes to define the users' municipality

### Solution

- One library per Kimppa (+ default library) configured in circulation
  - Each library configured with list of member municipalities
- Patrons and admins automatically assigned to library during sign in
- Unauthenticated users will see the default library lanes
- Collections defined for default library apply to all other libraries
- New monitor script (`ekirjasto_consortium_monitor`) to automatically keep libraries (i.e. Kimppas) synced with Kirkanta data

### Other notes

- No database changes needed
- No changes to authorization logic for list/lane management
- Some municipalities don't belong to a Kimppa
- Users with "turvakielto" have municipality code `000`, i.e. they won't belong to any Kimppa

## Motivation and Context

https://docs.google.com/document/d/1oq9_YBgfY5JMh_zDROZyDHts5FZfH_PQ1FRz1IVxv-k/edit#heading=h.y5cwsxdy2zq5

<https://jira.lingsoft.fi/browse/SIMPLYE-261> - Prepare the data foundation to handle municipality and library patron info 
<https://jira.lingsoft.fi/browse/SIMPLYE-262> - Implement the mapping between municipalities and libraries 
<https://jira.lingsoft.fi/browse/SIMPLYE-263> - Implement custom lane management for local librarians

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
