### PR TITLE
Compile translations during webapp image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,9 @@ COPY docker/services/uwsgi /etc/
 RUN mkdir -p /var/log/uwsgi && \
     chown -RHh simplified:simplified /var/log/uwsgi && \
     mkdir /var/run/uwsgi && \
-    chown simplified:simplified /var/run/uwsgi
+    chown simplified:simplified /var/run/uwsgi && \
+    # Search url not used but script fails if not set
+    PALACE_SEARCH_URL=http://localhost:9200 core/bin/run util/compile_translations
 
 # Setup runit
 COPY docker/runit /etc/service/


### PR DESCRIPTION
## Description

Run the `util/compile_translations` script during image build to compile the `.po` files into `.mo` files.

The script requires PALACE_SEARCH_URL to be defined, even though it doesn't use it.

## Motivation and Context

[SIMPLYE-269](https://jira.lingsoft.fi/browse/SIMPLYE-269) - Integrate translation files from Transifex into the Circulation image build

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
