### PR TITLE
Create reaper monitor for deleting inactive admins

### DIFF
--- a/alembic/versions/20240404_be8ed331efcc_add_last_signed_in_column_to_.py
+++ b/alembic/versions/20240404_be8ed331efcc_add_last_signed_in_column_to_.py
@@ -1,0 +1,32 @@
+"""Add last_signed_in column to admincredentials
+
+Revision ID: be8ed331efcc
+Revises: 4915a361b082
+Create Date: 2024-04-04 11:34:33.755399+00:00
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "be8ed331efcc"
+down_revision = "4915a361b082"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "admincredentials",
+        sa.Column(
+            "last_signed_in",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("admincredentials", "last_signed_in")

--- a/api/admin/controller/sign_in.py
+++ b/api/admin/controller/sign_in.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from urllib.parse import urlsplit
 
 import flask
@@ -101,6 +102,7 @@ class SignInController(AdminController):
         try:
             credentials = get_one(self._db, AdminCredential, external_id=user_info.sub)
             if credentials:
+                credentials.last_signed_in = datetime.now(timezone.utc)
                 admin = credentials.admin
             else:
                 admin = self._create_admin_with_external_credentials(user_info)

--- a/core/model/admin.py
+++ b/core/model/admin.py
@@ -9,6 +9,7 @@ from flask_babel import lazy_gettext as _
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from sqlalchemy import (
     Column,
+    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -346,6 +347,7 @@ class AdminCredential(Base):
 
     id = Column(Integer, primary_key=True)
     external_id = Column(Unicode, nullable=False)
+    last_signed_in = Column(DateTime, nullable=False, server_default=func.now())
 
     admin_id = Column(
         Integer, ForeignKey("admins.id", ondelete="CASCADE"), index=True, nullable=False


### PR DESCRIPTION
## Description

New reaper monitor created for deleting externally authenticated admin users with over 180 days since last login.

A new column `last_signed_in` added in `admincredentials` table. This field is updated each time an admin signs in.

This reaper is registered as part of the already existing `bin/database_reaper` script, which is run once per day.

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-226> - Clean inactive e-kirjasto admins from circulation DB

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
