### PR TITLE
Improve consortium management

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -18,6 +18,7 @@ from api.admin.form_data import ProcessFormData
 from api.admin.problem_details import *
 from api.circulation_manager import CirculationManager
 from api.config import Configuration
+from api.ekirjasto_consortium import EkirjastoConsortiumMonitor
 from api.lanes import create_default_lanes
 from core.configuration.library import LibrarySettings
 from core.model import (
@@ -31,6 +32,7 @@ from core.model import (
 from core.model.announcements import SETTING_NAME as ANNOUNCEMENT_SETTING_NAME
 from core.model.announcements import Announcement
 from core.model.library import LibraryLogo
+from core.scripts import RunMonitorScript
 from core.util.problem_detail import ProblemDetail, ProblemError
 
 
@@ -158,6 +160,11 @@ class LibrarySettingsController(AdminPermissionsControllerMixin):
 
         # Trigger a site configuration change
         site_configuration_has_changed(self._db)
+
+        # Finland, update municipality list if consortium is defined
+        consortium = library.settings.kirkanta_consortium_slug
+        if consortium and consortium != "disabled":
+            RunMonitorScript(EkirjastoConsortiumMonitor, library=library).run()
 
         if is_new:
             # Now that the configuration settings are in place, create

--- a/core/configuration/library.py
+++ b/core/configuration/library.py
@@ -135,9 +135,9 @@ class LibrarySettings(BaseSettings):
     kirkanta_consortium_slug: str | None = FormField(
         None,
         form=LibraryConfFormItem(
-            label="Synchronize consortium data form Kirkanta",
-            description="If selected, the list of municipalities is updated automatically from Kirkanta. "
-            "Has no effect if configured for the default library.",
+            label="Consortium",
+            description="If selected, the municipalities are kept automatically "
+            "in sync with Kirkanta. Has no effect if set for the default library.",
             category="Kirkanta Synchronization",
             type=ConfigurationFormItemType.SELECT,
             # The keys here should match the Kirkanta consortium slug
@@ -193,10 +193,9 @@ class LibrarySettings(BaseSettings):
         form=LibraryConfFormItem(
             label="The municipalities belonging to this consortium",
             type=ConfigurationFormItemType.LIST,
-            format="municipality-code",
             description="Each value should be a valid "
             '<a href="https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=362&versionKey=440" target="_blank">'
-            "municipality code</a>.",
+            "municipality code</a>. This list is populated automatically if the consortium is selected.",
             category="Kirkanta Synchronization",
             level=Level.ALL_ACCESS,
         ),
@@ -736,8 +735,22 @@ class LibrarySettings(BaseSettings):
         cls, value: list[str] | None, field: ModelField
     ) -> list[str] | None:
         """Verify that municipality IDs are valid."""
-        # TODO: implement validation
-        return value
+        if not value:
+            return value
+
+        for code in value:
+            if not code.isdigit():
+                raise SettingsValidationError(
+                    problem_detail=UNKNOWN_LANGUAGE.detailed(
+                        f'"{cls.get_form_field_label(field.name)}": "{code}" is not a valid language code.'
+                    )
+                )
+
+        return cls._remove_duplicates(value)
+
+    @classmethod
+    def _remove_duplicates(cls, values: list[str]):
+        return list(set(values))
 
     @validator(
         "large_collection_languages",


### PR DESCRIPTION
## Description

- Fix typo and improve wording under library settings
- Add validation for municipality codes under library settings
- Synchronize municipalities when saving a library so there is no need to wait for the cron job
- Add 1 hour cache to Kirkanta and Koodistopalvelu API calls

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-263> - Implement custom lane management for local librarians

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
