### PR TITLE
Add apitokens table to database for E-kirjasto Data API

### DIFF
--- a/alembic/versions/20240405_b28ac9090d40_add_apitoken_model.py
+++ b/alembic/versions/20240405_b28ac9090d40_add_apitoken_model.py
@@ -1,0 +1,38 @@
+"""Add ApiToken model
+
+Revision ID: b28ac9090d40
+Revises: be8ed331efcc
+Create Date: 2024-04-05 12:18:48.616932+00:00
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b28ac9090d40"
+down_revision = "be8ed331efcc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "apitokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("token", sa.String(), nullable=False),
+        sa.Column("label", sa.String(), nullable=False),
+        sa.Column("collection_id", sa.Integer(), nullable=True),
+        sa.Column("created", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["collection_id"], ["collections.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("label"),
+        sa.UniqueConstraint("token"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("apitokens")

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -515,6 +515,7 @@ from api.saml.metadata.federations.model import (
     SAMLFederation,
 )
 from core.model.admin import Admin, AdminRole
+from core.model.apitokens import ApiToken
 from core.model.circulationevent import CirculationEvent
 from core.model.classification import Classification, Genre, Subject
 from core.model.collection import (

--- a/core/model/apitokens.py
+++ b/core/model/apitokens.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, relationship
+
+from core.model import Base
+from core.model.collection import Collection
+
+
+class ApiToken(Base):
+    __tablename__ = "apitokens"
+
+    id = Column(Integer, primary_key=True)
+    token = Column(String, unique=True, nullable=False)
+    label = Column(String, unique=True, nullable=False)
+    collection_id = Column(Integer, ForeignKey("collections.id", ondelete="CASCADE"))
+    created = Column(DateTime(timezone=True), nullable=False, default=datetime.now())
+
+    collection: Mapped[list[Collection]] = relationship("Collection")
+
+    def __repr__(self):
+        return f"<ApiToken id={self.id} token={self.token} label={self.label} collection_id={self.collection_id}>"


### PR DESCRIPTION
## Description

This PR adds apitokens table to the database to be used by [E-kirjasto Data API](https://github.com/NatLibFi/ekirjasto-data-api).

## Motivation and Context

https://jira.lingsoft.fi/browse/SIMPLYE-292