### PR TITLE
Fix library ID handling during patron auth

### DIFF
--- a/api/authentication/base.py
+++ b/api/authentication/base.py
@@ -404,7 +404,9 @@ class PatronData:
             value = None
         setattr(patron, field_name, value)
 
-    def get_or_create_patron(self, _db, library_id, analytics=None):
+    def get_or_create_patron(
+        self, _db, library_id, analytics=None, create_method_kwargs=None
+    ):
         """Create a Patron with this information.
 
         TODO: I'm concerned in the general case with race
@@ -449,7 +451,9 @@ class PatronData:
             )
         search_by["library_id"] = library_id
         __transaction = _db.begin_nested()
-        patron, is_new = get_one_or_create(_db, Patron, **search_by)
+        patron, is_new = get_one_or_create(
+            _db, Patron, **search_by, create_method_kwargs=create_method_kwargs
+        )
 
         if is_new and analytics:
             # Send out an analytics event to record the fact


### PR DESCRIPTION
## Description

The current logic is flawed in that it does not recognize if a patron has already signed in and been assigned to a library. When authenticating, the patron lookup is filtered by library id (of the default library), and the existing patron is not found.

Now changed to search for patrons within any library so it finds (and updates) the existing patron instead of trying to create a duplicate.

This issue was introduced in an earlier PR (<https://github.com/NatLibFi/ekirjasto-circulation/pull/30>).

