### PR TITLE
Override library for authenticated patron requests

### DIFF
--- a/api/controller/base.py
+++ b/api/controller/base.py
@@ -120,4 +120,16 @@ class BaseCirculationManagerController(LoggerMixin):
         if not library:
             return LIBRARY_NOT_FOUND
         flask.request.library = library
+
+        # Finland: For authenticated patrons, override the library defined in the request
+        # and use the library assigned to that patron.
+        #
+        # This is a bit sketchy as the authentication requires library to be set already.
+        # So in practice the library in the URL path is used for authentication, but after
+        # that the request is performed with the patron's assigned library.
+        patron = self.manager.index_controller.authenticated_patron_from_request()
+        if isinstance(patron, Patron):
+            library = patron.library
+            flask.request.library = patron.library
+
         return library


### PR DESCRIPTION
Each patron is assigned one library based on municipality. The clients are currently sending all requests towards the default library. For patrons assigned to a library, this fails due to authorization. 

The clients don't need to have access to multiple libraries so we can just override the library for the requests coming from authenticated patrons.

The alternative would be to make the clients choose the library based on the authentication response.

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
