### PR TITLE
Return 401 if the circulation token is not present in the header.

### DIFF
--- a/api/ekirjasto_controller.py
+++ b/api/ekirjasto_controller.py
@@ -69,7 +69,7 @@ class EkirjastoController:
             or authorization.token is None
             or len(authorization.token) == 0
         ):
-            return EKIRJASTO_REMOTE_AUTHENTICATION_FAILED, None, None, None
+            return INVALID_EKIRJASTO_DELEGATE_TOKEN, None, None, None
 
         token = authorization.token
 
@@ -99,6 +99,9 @@ class EkirjastoController:
             # with the remote ekirjasto API. We don't do anything further validation
             # for it as it is valdiated with successful authentication.
             ekirjasto_token = token
+
+        if delegate_token == None:
+            return INVALID_EKIRJASTO_DELEGATE_TOKEN, None, None, None
 
         return delegate_token, ekirjasto_token, delegate_sub, delegate_expired
 
@@ -213,8 +216,6 @@ class EkirjastoController:
         ) = self.get_tokens(request.authorization, validate_expire=True)
         if isinstance(delegate_token, ProblemDetail):
             return delegate_token
-        elif delegate_token == None:
-            return INVALID_EKIRJASTO_DELEGATE_TOKEN
 
         return Response(
             json.dumps({"token": ekirjasto_token}), 200, mimetype="application/json"
@@ -233,8 +234,6 @@ class EkirjastoController:
         ) = self.get_tokens(request.authorization)
         if isinstance(delegate_token, ProblemDetail):
             return delegate_token
-        elif delegate_token == None:
-            return INVALID_EKIRJASTO_DELEGATE_TOKEN
 
         (
             response_json,


### PR DESCRIPTION
Related to the issue SIMPLYE-305, endpoint was returning http code 400 when circulation token is not present in the header. Instead correct http code to return is 401.
