### PR TITLE
Enable all entrypoints by default

### DIFF
--- a/core/entrypoint.py
+++ b/core/entrypoint.py
@@ -108,7 +108,7 @@ class EverythingEntryPoint(EntryPoint):
     URI = "http://schema.org/CreativeWork"
 
 
-EntryPoint.register(EverythingEntryPoint, "All")
+EntryPoint.register(EverythingEntryPoint, "All", default_enabled=True)
 
 
 class MediumEntryPoint(EntryPoint):
@@ -154,4 +154,4 @@ class AudiobooksEntryPoint(MediumEntryPoint):
     URI = "http://bib.schema.org/Audiobook"
 
 
-EntryPoint.register(AudiobooksEntryPoint, "Audiobooks")
+EntryPoint.register(AudiobooksEntryPoint, "Audiobooks", default_enabled=True)

--- a/tests/core/models/test_library.py
+++ b/tests/core/models/test_library.py
@@ -178,7 +178,7 @@ Configuration settings:
 -----------------------
 website='http://library.com'
 allow_holds='True'
-enabled_entry_points='['Book']'
+enabled_entry_points='['All', 'Book', 'Audio']'
 featured_lane_size='15'
 minimum_featured_quality='0.65'
 facets_enabled_order='['author', 'title', 'added']'


### PR DESCRIPTION
## Description

Enable all entrypoints (i.e. eBooks/All/Audiobooks) by default when creating a new library.

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-329> - Audiobooks are not available in Kimppa collections

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
