### PR TITLE
Fix capitalization of language facets

### DIFF
--- a/bin/util/generate_translation_template
+++ b/bin/util/generate_translation_template
@@ -1,5 +1,5 @@
 #! /bin/sh
 
-pybabel extract -F bin/util/core.babel.cfg -k _ -o core.pot .
-pybabel extract -F bin/util/circulation.babel.cfg -k _ -o circulation.pot .
-pybabel extract -F bin/util/admin.babel.cfg -k _ -o circulation-admin.pot .
+pybabel extract -F bin/util/core.babel.cfg -k _ -k lazy_pgettext:1c,2 -o core.pot .
+pybabel extract -F bin/util/circulation.babel.cfg -k _ -k lazy_pgettext:1c,2 -o circulation.pot .
+pybabel extract -F bin/util/admin.babel.cfg -k _ -k lazy_pgettext:1c,2 -o circulation-admin.pot .

--- a/core/facets.py
+++ b/core/facets.py
@@ -1,4 +1,5 @@
 from flask_babel import lazy_gettext as _
+from flask_babel import lazy_pgettext
 
 
 class FacetConstants:
@@ -118,11 +119,11 @@ class FacetConstants:
         COLLECTION_FULL: _("Everything"),
         COLLECTION_FEATURED: _("Popular Books"),
         COLLECTION_NAME_ALL: _("All"),
-        LANGUAGE_ALL: _("All"),
-        LANGUAGE_FINNISH: _("Finnish"),
-        LANGUAGE_SWEDISH: _("Swedish"),
-        LANGUAGE_ENGLISH: _("English"),
-        LANGUAGE_OTHERS: _("Others"),
+        LANGUAGE_ALL: lazy_pgettext("language", "All"),
+        LANGUAGE_FINNISH: lazy_pgettext("language", "Finnish"),
+        LANGUAGE_SWEDISH: lazy_pgettext("language", "Swedish"),
+        LANGUAGE_ENGLISH: lazy_pgettext("language", "English"),
+        LANGUAGE_OTHERS: lazy_pgettext("language", "Others"),
     }
 
     # For titles generated based on some runtime value

--- a/translations/en/LC_MESSAGES/core.po
+++ b/translations/en/LC_MESSAGES/core.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-08 08:44+0300\n"
+"POT-Creation-Date: 2024-04-18 13:04+0300\n"
 "PO-Revision-Date: 2024-02-19 22:14+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -114,7 +114,7 @@ msgid ""
 "related errors."
 msgstr ""
 
-#: core/entrypoint.py:107 core/facets.py:116 core/facets.py:120
+#: core/entrypoint.py:107 core/facets.py:117 core/facets.py:121
 msgid "All"
 msgstr ""
 
@@ -131,107 +131,116 @@ msgstr ""
 msgid "Invalid page key: %(key)s"
 msgstr ""
 
-#: core/facets.py:89
+#: core/facets.py:90
 msgid "Sort by"
 msgstr ""
 
-#: core/facets.py:90
+#: core/facets.py:91
 msgid "Availability"
 msgstr ""
 
-#: core/facets.py:91
+#: core/facets.py:92
 msgid "Collection"
 msgstr ""
 
-#: core/facets.py:92
+#: core/facets.py:93
 msgid "Distributor"
 msgstr ""
 
-#: core/facets.py:93
+#: core/facets.py:94
 msgid "Collection Name"
 msgstr ""
 
-#: core/facets.py:94
+#: core/facets.py:95
 msgid "Language"
 msgstr ""
 
-#: core/facets.py:98
+#: core/facets.py:99
 msgid "Allow patrons to sort by"
 msgstr ""
 
-#: core/facets.py:99
+#: core/facets.py:100
 msgid "Allow patrons to filter availability to"
 msgstr ""
 
-#: core/facets.py:100
+#: core/facets.py:101
 msgid "Allow patrons to filter collection to"
 msgstr ""
 
-#: core/facets.py:101
+#: core/facets.py:102
 msgid "Allow patrons to filter by distributor"
 msgstr ""
 
-#: core/facets.py:102
+#: core/facets.py:103
 msgid "Allow patrons to filter by collection name"
 msgstr ""
 
-#: core/facets.py:105
+#: core/facets.py:106
 msgid "Allow patrons to filter by language"
 msgstr ""
 
-#: core/facets.py:109
+#: core/facets.py:110
 msgid "Title"
 msgstr ""
 
-#: core/facets.py:110
+#: core/facets.py:111
 msgid "Author"
 msgstr ""
 
-#: core/facets.py:111
+#: core/facets.py:112
 msgid "Last Update"
 msgstr ""
 
-#: core/facets.py:112
+#: core/facets.py:113
 msgid "Recently Added"
 msgstr ""
 
-#: core/facets.py:113
+#: core/facets.py:114
 msgid "Series Position"
 msgstr ""
 
-#: core/facets.py:114
+#: core/facets.py:115
 msgid "Work ID"
 msgstr ""
 
-#: core/facets.py:115
+#: core/facets.py:116
 msgid "Available now"
 msgstr ""
 
-#: core/facets.py:117
+#: core/facets.py:118
 msgid "Yours to keep"
 msgstr ""
 
-#: core/facets.py:118
+#: core/facets.py:119
 msgid "Everything"
 msgstr ""
 
-#: core/facets.py:119
+#: core/facets.py:120
 msgid "Popular Books"
 msgstr ""
 
-#: core/facets.py:121
-msgid "Finnish"
-msgstr ""
-
 #: core/facets.py:122
-msgid "Swedish"
+msgctxt "language"
+msgid "All"
 msgstr ""
 
 #: core/facets.py:123
-msgid "English"
+msgctxt "language"
+msgid "Finnish"
 msgstr ""
 
 #: core/facets.py:124
+msgctxt "language"
+msgid "Swedish"
+msgstr ""
+
+#: core/facets.py:125
+msgctxt "language"
+msgid "English"
+msgstr ""
+
+#: core/facets.py:126
+msgctxt "language"
 msgid "Others"
 msgstr ""
 
@@ -1068,23 +1077,4 @@ msgstr ""
 #, python-format
 msgid "The server made a request to %(service)s, and that request timed out."
 msgstr ""
-
-#~ msgid "Index prefix"
-#~ msgstr ""
-
-#~ msgid ""
-#~ "Any Search indexes needed for this "
-#~ "application will be created with this"
-#~ " unique prefix. In most cases, the"
-#~ " default will work fine. You may "
-#~ "need to change this if you have"
-#~ " multiple application servers using a "
-#~ "single Search server."
-#~ msgstr ""
-
-#~ msgid "Test search term"
-#~ msgstr ""
-
-#~ msgid "Self tests will use this value as the search term."
-#~ msgstr ""
 

--- a/translations/es/LC_MESSAGES/core.po
+++ b/translations/es/LC_MESSAGES/core.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-08 08:44+0300\n"
+"POT-Creation-Date: 2024-04-18 13:04+0300\n"
 "PO-Revision-Date: 2016-06-14 13:24-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -110,7 +110,7 @@ msgid ""
 "related errors."
 msgstr ""
 
-#: core/entrypoint.py:107 core/facets.py:116 core/facets.py:120
+#: core/entrypoint.py:107 core/facets.py:117 core/facets.py:121
 msgid "All"
 msgstr ""
 
@@ -127,107 +127,116 @@ msgstr ""
 msgid "Invalid page key: %(key)s"
 msgstr "Tamaño de página inválido: %(size)s"
 
-#: core/facets.py:89
+#: core/facets.py:90
 msgid "Sort by"
 msgstr ""
 
-#: core/facets.py:90
+#: core/facets.py:91
 msgid "Availability"
 msgstr ""
 
-#: core/facets.py:91
+#: core/facets.py:92
 msgid "Collection"
 msgstr ""
 
-#: core/facets.py:92
+#: core/facets.py:93
 msgid "Distributor"
 msgstr ""
 
-#: core/facets.py:93
+#: core/facets.py:94
 msgid "Collection Name"
 msgstr ""
 
-#: core/facets.py:94
+#: core/facets.py:95
 msgid "Language"
 msgstr ""
 
-#: core/facets.py:98
+#: core/facets.py:99
 msgid "Allow patrons to sort by"
 msgstr ""
 
-#: core/facets.py:99
+#: core/facets.py:100
 msgid "Allow patrons to filter availability to"
 msgstr ""
 
-#: core/facets.py:100
+#: core/facets.py:101
 msgid "Allow patrons to filter collection to"
 msgstr ""
 
-#: core/facets.py:101
+#: core/facets.py:102
 msgid "Allow patrons to filter by distributor"
 msgstr ""
 
-#: core/facets.py:102
+#: core/facets.py:103
 msgid "Allow patrons to filter by collection name"
 msgstr ""
 
-#: core/facets.py:105
+#: core/facets.py:106
 msgid "Allow patrons to filter by language"
 msgstr ""
 
-#: core/facets.py:109
+#: core/facets.py:110
 msgid "Title"
 msgstr ""
 
-#: core/facets.py:110
+#: core/facets.py:111
 msgid "Author"
 msgstr ""
 
-#: core/facets.py:111
+#: core/facets.py:112
 msgid "Last Update"
 msgstr ""
 
-#: core/facets.py:112
+#: core/facets.py:113
 msgid "Recently Added"
 msgstr ""
 
-#: core/facets.py:113
+#: core/facets.py:114
 msgid "Series Position"
 msgstr ""
 
-#: core/facets.py:114
+#: core/facets.py:115
 msgid "Work ID"
 msgstr ""
 
-#: core/facets.py:115
+#: core/facets.py:116
 msgid "Available now"
 msgstr ""
 
-#: core/facets.py:117
+#: core/facets.py:118
 msgid "Yours to keep"
 msgstr ""
 
-#: core/facets.py:118
+#: core/facets.py:119
 msgid "Everything"
 msgstr ""
 
-#: core/facets.py:119
+#: core/facets.py:120
 msgid "Popular Books"
 msgstr ""
 
-#: core/facets.py:121
-msgid "Finnish"
-msgstr ""
-
 #: core/facets.py:122
-msgid "Swedish"
+msgctxt "language"
+msgid "All"
 msgstr ""
 
 #: core/facets.py:123
-msgid "English"
+msgctxt "language"
+msgid "Finnish"
 msgstr ""
 
 #: core/facets.py:124
+msgctxt "language"
+msgid "Swedish"
+msgstr ""
+
+#: core/facets.py:125
+msgctxt "language"
+msgid "English"
+msgstr ""
+
+#: core/facets.py:126
+msgctxt "language"
 msgid "Others"
 msgstr ""
 
@@ -1106,5 +1115,25 @@ msgstr "El servidor hizo una petición al servicio (%) s, y esa solicitud expir�
 #~ msgstr ""
 
 #~ msgid "Self tests will use this value as the search term."
+#~ msgstr ""
+
+#~ msgctxt "language"
+#~ msgid "Finnish"
+#~ msgstr ""
+
+#~ msgctxt "language"
+#~ msgid "Swedish"
+#~ msgstr ""
+
+#~ msgctxt "language"
+#~ msgid "English"
+#~ msgstr ""
+
+#~ msgctxt "language"
+#~ msgid "Others"
+#~ msgstr ""
+
+#~ msgctxt "language"
+#~ msgid "All"
 #~ msgstr ""
 

--- a/translations/fi/LC_MESSAGES/core.po
+++ b/translations/fi/LC_MESSAGES/core.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-08 08:44+0300\n"
+"POT-Creation-Date: 2024-04-18 13:04+0300\n"
 "PO-Revision-Date: 2024-03-01 11:37+0000\n"
 "Last-Translator: Marika Kaskinen, 2024\n"
 "Language: fi\n"
@@ -133,7 +133,7 @@ msgstr ""
 "Kuinka monta kertaa pyyntöä voi enintään yrittää uudelleen tietyissä "
 "yhteyteen liittyvissä virheissä."
 
-#: core/entrypoint.py:107 core/facets.py:116 core/facets.py:120
+#: core/entrypoint.py:107 core/facets.py:117 core/facets.py:121
 msgid "All"
 msgstr "Kaikki"
 
@@ -150,110 +150,120 @@ msgstr "Äänikirjat"
 msgid "Invalid page key: %(key)s"
 msgstr "Virheellinen sivuavain: %(key)s"
 
-#: core/facets.py:89
+#: core/facets.py:90
 msgid "Sort by"
 msgstr "Lajitteluperuste"
 
-#: core/facets.py:90
+#: core/facets.py:91
 msgid "Availability"
 msgstr "Saatavuus"
 
-#: core/facets.py:91
+#: core/facets.py:92
 msgid "Collection"
 msgstr "Kokoelma"
 
-#: core/facets.py:92
+#: core/facets.py:93
 msgid "Distributor"
 msgstr "Jakelija"
 
-#: core/facets.py:93
+#: core/facets.py:94
 msgid "Collection Name"
 msgstr "Kokoelman nimi"
 
-#: core/facets.py:94
+#: core/facets.py:95
 msgid "Language"
 msgstr "Kieli"
 
-#: core/facets.py:98
+#: core/facets.py:99
 msgid "Allow patrons to sort by"
 msgstr "Salli asiakkaiden lajitella seuraavan mukaan"
 
-#: core/facets.py:99
+#: core/facets.py:100
 msgid "Allow patrons to filter availability to"
 msgstr "Salli asiakkaiden suodattaa saatavuus"
 
-#: core/facets.py:100
+#: core/facets.py:101
 msgid "Allow patrons to filter collection to"
 msgstr "Salli asiakkaiden suodattaa kokoelma"
 
-#: core/facets.py:101
+#: core/facets.py:102
 msgid "Allow patrons to filter by distributor"
 msgstr "Salli asiakkaiden suodattaa jakelijan mukaan"
 
-#: core/facets.py:102
+#: core/facets.py:103
 msgid "Allow patrons to filter by collection name"
 msgstr "Salli asiakkaiden suodattaa kokoelman nimen mukaan"
 
-#: core/facets.py:105
+#: core/facets.py:106
 #, fuzzy
 msgid "Allow patrons to filter by language"
 msgstr "Salli asiakkaiden suodattaa jakelijan mukaan"
 
-#: core/facets.py:109
+#: core/facets.py:110
 msgid "Title"
 msgstr "Nimi"
 
-#: core/facets.py:110
+#: core/facets.py:111
 msgid "Author"
 msgstr "Tekijä"
 
-#: core/facets.py:111
+#: core/facets.py:112
 msgid "Last Update"
 msgstr "Viimeisin päivitys"
 
-#: core/facets.py:112
+#: core/facets.py:113
 msgid "Recently Added"
 msgstr "Äskettäin lisätty"
 
-#: core/facets.py:113
+#: core/facets.py:114
 msgid "Series Position"
 msgstr "Sarjan sijainti"
 
-#: core/facets.py:114
+#: core/facets.py:115
 msgid "Work ID"
 msgstr "Työn tunnus"
 
-#: core/facets.py:115
+#: core/facets.py:116
 msgid "Available now"
 msgstr "Saatavilla nyt"
 
-#: core/facets.py:117
+#: core/facets.py:118
 msgid "Yours to keep"
 msgstr "Voit pitää tämän"
 
-#: core/facets.py:118
+#: core/facets.py:119
 msgid "Everything"
 msgstr "Kaikki"
 
-#: core/facets.py:119
+#: core/facets.py:120
 msgid "Popular Books"
 msgstr "Suositut kirjat"
 
-#: core/facets.py:121
+#: core/facets.py:122
+#, fuzzy
+msgctxt "language"
+msgid "All"
+msgstr "kaikki"
+
+#: core/facets.py:123
+msgctxt "language"
 msgid "Finnish"
 msgstr "suomi"
 
-#: core/facets.py:122
+#: core/facets.py:124
+msgctxt "language"
 msgid "Swedish"
 msgstr "ruotsi"
 
-#: core/facets.py:123
+#: core/facets.py:125
+msgctxt "language"
 msgid "English"
 msgstr "englanti"
 
-#: core/facets.py:124
+#: core/facets.py:126
+msgctxt "language"
 msgid "Others"
-msgstr "Muut"
+msgstr "muut"
 
 #: core/lane.py:386
 #, python-format
@@ -1105,29 +1115,4 @@ msgstr "Aikakatkaisu"
 #, python-format
 msgid "The server made a request to %(service)s, and that request timed out."
 msgstr "Palvelin teki pyynnön palveluun %(service)s, ja pyyntö aikakatkaistiin."
-
-#~ msgid "Index prefix"
-#~ msgstr "Hakemiston etuliite"
-
-#~ msgid ""
-#~ "Any Search indexes needed for this "
-#~ "application will be created with this"
-#~ " unique prefix. In most cases, the"
-#~ " default will work fine. You may "
-#~ "need to change this if you have"
-#~ " multiple application servers using a "
-#~ "single Search server."
-#~ msgstr ""
-#~ "Kaikki tämän sovelluksen tarvitsemat "
-#~ "hakuindeksit luodaan tällä yksilöllisellä "
-#~ "etuliitteellä. Useimmissa tapauksissa oletusarvo "
-#~ "toimii hyvin. Tätä on ehkä muutettava,"
-#~ " jos useat sovelluspalvelimet käyttävät "
-#~ "yhtä hakupalvelinta."
-
-#~ msgid "Test search term"
-#~ msgstr "Testin hakusana"
-
-#~ msgid "Self tests will use this value as the search term."
-#~ msgstr "Itsetestit käyttävät tätä arvoa hakusanana."
 

--- a/translations/sv/LC_MESSAGES/core.po
+++ b/translations/sv/LC_MESSAGES/core.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-08 08:44+0300\n"
+"POT-Creation-Date: 2024-04-18 13:04+0300\n"
 "PO-Revision-Date: 2024-03-01 11:37+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: sv\n"
@@ -131,7 +131,7 @@ msgstr ""
 "Det maximala antalet gånger du kan försöka begära vissa "
 "anslutningsrelaterade fel på nytt."
 
-#: core/entrypoint.py:107 core/facets.py:116 core/facets.py:120
+#: core/entrypoint.py:107 core/facets.py:117 core/facets.py:121
 msgid "All"
 msgstr "Alla"
 
@@ -148,111 +148,120 @@ msgstr "Ljudböcker"
 msgid "Invalid page key: %(key)s"
 msgstr "Ogiltig sidnyckel: %(key)s"
 
-#: core/facets.py:89
+#: core/facets.py:90
 msgid "Sort by"
 msgstr "Sortera efter"
 
-#: core/facets.py:90
+#: core/facets.py:91
 msgid "Availability"
 msgstr "Tillgänglighet"
 
-#: core/facets.py:91
+#: core/facets.py:92
 msgid "Collection"
 msgstr "Samling"
 
-#: core/facets.py:92
+#: core/facets.py:93
 msgid "Distributor"
 msgstr "Distributör"
 
-#: core/facets.py:93
+#: core/facets.py:94
 msgid "Collection Name"
 msgstr "Samlingens namn"
 
-#: core/facets.py:94
+#: core/facets.py:95
 msgid "Language"
-msgstr ""
+msgstr "Språk"
 
-#: core/facets.py:98
+#: core/facets.py:99
 msgid "Allow patrons to sort by"
 msgstr "Tillåt kunder sortera efter"
 
-#: core/facets.py:99
+#: core/facets.py:100
 msgid "Allow patrons to filter availability to"
 msgstr "Tillåt kunder sortera tillgängligheten"
 
-#: core/facets.py:100
+#: core/facets.py:101
 msgid "Allow patrons to filter collection to"
 msgstr "Tillåt kunder sortera samlingen"
 
-#: core/facets.py:101
+#: core/facets.py:102
 msgid "Allow patrons to filter by distributor"
 msgstr "Tillåt kunder sortera efter distributör"
 
-#: core/facets.py:102
+#: core/facets.py:103
 msgid "Allow patrons to filter by collection name"
 msgstr "Tillåt kunder sortera efter samlingens namn"
 
-#: core/facets.py:105
+#: core/facets.py:106
 #, fuzzy
 msgid "Allow patrons to filter by language"
 msgstr "Tillåt kunder sortera efter distributör"
 
-#: core/facets.py:109
+#: core/facets.py:110
 msgid "Title"
 msgstr "Titel"
 
-#: core/facets.py:110
+#: core/facets.py:111
 msgid "Author"
 msgstr "Författare"
 
-#: core/facets.py:111
+#: core/facets.py:112
 msgid "Last Update"
 msgstr "Senaste uppdatering"
 
-#: core/facets.py:112
+#: core/facets.py:113
 msgid "Recently Added"
 msgstr "Nyligen tillagd"
 
-#: core/facets.py:113
+#: core/facets.py:114
 msgid "Series Position"
 msgstr "Seriens position"
 
-#: core/facets.py:114
+#: core/facets.py:115
 msgid "Work ID"
 msgstr "Jobbets ID"
 
-#: core/facets.py:115
+#: core/facets.py:116
 msgid "Available now"
 msgstr "Tillgänglig nu"
 
-#: core/facets.py:117
+#: core/facets.py:118
 msgid "Yours to keep"
 msgstr "Du kan behålla den"
 
-#: core/facets.py:118
+#: core/facets.py:119
 msgid "Everything"
 msgstr "Allt"
 
-#: core/facets.py:119
+#: core/facets.py:120
 msgid "Popular Books"
 msgstr "Populära böcker"
 
-#: core/facets.py:121
+#: core/facets.py:122
+msgctxt "language"
+msgid "All"
+msgstr "alla"
+
+#: core/facets.py:123
+msgctxt "language"
 msgid "Finnish"
 msgstr "finska"
 
-#: core/facets.py:122
+#: core/facets.py:124
+msgctxt "language"
 msgid "Swedish"
 msgstr "svenska"
 
-#: core/facets.py:123
+#: core/facets.py:125
+msgctxt "language"
 msgid "English"
 msgstr "engelska"
 
-#: core/facets.py:124
+#: core/facets.py:126
 #, fuzzy
+msgctxt "language"
 msgid "Others"
-msgstr "Andra"
+msgstr "andra"
 
 #: core/lane.py:386
 #, python-format
@@ -1103,29 +1112,4 @@ msgid "The server made a request to %(service)s, and that request timed out."
 msgstr ""
 "Servern skickade en begäran till %(service)s och tidsgränsen för begäran "
 "överskreds."
-
-#~ msgid "Index prefix"
-#~ msgstr "Katalogens prefix"
-
-#~ msgid ""
-#~ "Any Search indexes needed for this "
-#~ "application will be created with this"
-#~ " unique prefix. In most cases, the"
-#~ " default will work fine. You may "
-#~ "need to change this if you have"
-#~ " multiple application servers using a "
-#~ "single Search server."
-#~ msgstr ""
-#~ "Alla sökkataloger som denna app behöver"
-#~ " skapas med detta unika prefix. I "
-#~ "de flesta fallen fungerar standard "
-#~ "värdet bra. Detta måste kanske ändras"
-#~ " om flera appservrar använder en "
-#~ "sökserver."
-
-#~ msgid "Test search term"
-#~ msgstr "Testets sökord"
-
-#~ msgid "Self tests will use this value as the search term."
-#~ msgstr "Självtestet kommer att använda detta värde som sökord."
 


### PR DESCRIPTION
Language name capitalization differs between languages. This PR adds context for the translation strings so these differences can be properly handled.

For Finnish and Swedish, the language facets (including the "Others" and "All" option) are now switched to lowercase.

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-321> - Translated items in the Language menu should be capitalized
