### PR TITLE
Store patron's cached municipality code to circulation events.

### DIFF
--- a/api/authentication/base.py
+++ b/api/authentication/base.py
@@ -458,7 +458,12 @@ class PatronData:
         if is_new and analytics:
             # Send out an analytics event to record the fact
             # that a new patron was created.
-            analytics.collect_event(patron.library, None, CirculationEvent.NEW_PATRON)
+            analytics.collect_event(
+                patron.library,
+                None,
+                CirculationEvent.NEW_PATRON,
+                include_neighborhood=True,
+            )
 
         # This makes sure the Patron is brought into sync with the
         # other fields of this PatronData object, regardless of

--- a/api/controller/analytics.py
+++ b/api/controller/analytics.py
@@ -22,7 +22,9 @@ class AnalyticsController(CirculationManagerController):
             patron = getattr(flask.request, "patron", None)
             neighborhood = None
             if patron:
-                neighborhood = getattr(patron, "neighborhood", None)
+                neighborhood = getattr(patron, "neighborhood", None) or getattr(
+                    patron, "cached_neighborhood", None
+                )  # Finland: add cached_neighborhood option
             pools = self.load_licensepools(library, identifier_type, identifier)
             if isinstance(pools, ProblemDetail):
                 return pools

--- a/api/opensearch_analytics_provider.py
+++ b/api/opensearch_analytics_provider.py
@@ -248,6 +248,7 @@ class OpenSearchAnalyticsProvider(LocalAnalyticsProvider):
         time,
         old_value=None,
         new_value=None,
+        neighborhood: str | None = None,
         duration: int | None = None,
         **kwargs,
     ):
@@ -277,6 +278,9 @@ class OpenSearchAnalyticsProvider(LocalAnalyticsProvider):
         :param new_value: New value of the metric changed by the event
         :type new_value: Any
 
+        :param neighborhood: Geographic location of the event (most often municipality code)
+        :type neighborhood: str
+
         :param duration: Duration of the event in seconds
         :type duration: int
         """
@@ -291,7 +295,7 @@ class OpenSearchAnalyticsProvider(LocalAnalyticsProvider):
             time,
             old_value,
             new_value,
-            None,
+            neighborhood,
             duration,
         )
 

--- a/core/local_analytics_provider.py
+++ b/core/local_analytics_provider.py
@@ -13,6 +13,7 @@ class LocalAnalyticsProvider(LoggerMixin):
         time,
         old_value=None,
         new_value=None,
+        neighborhood: str | None = None,
         duration: int | None = None,
         **kwargs
     ):
@@ -30,6 +31,7 @@ class LocalAnalyticsProvider(LoggerMixin):
             old_value,
             new_value,
             start=time,
+            location=neighborhood,
             duration=duration,
             library=library,
         )

--- a/tests/api/controller/test_analytics.py
+++ b/tests/api/controller/test_analytics.py
@@ -33,7 +33,7 @@ class TestAnalyticsController:
             assert INVALID_ANALYTICS_EVENT_TYPE.uri == response.uri
 
         patron = db.patron()
-        patron.neighborhood = "Mars Grid 4810579"
+        patron.cached_neighborhood = "Mars Grid 4810579"
         with analytics_fixture.request_context_with_library("/"):
             flask.request.patron = patron  # type: ignore
             response = analytics_fixture.manager.analytics_controller.track_event(
@@ -51,6 +51,6 @@ class TestAnalyticsController:
             )
             assert circulation_event is not None
             assert (
-                circulation_event.location == None
-            )  # We no longer use the location source
+                circulation_event.location == "Mars Grid 4810579"
+            )  # Finland: We store municipality codes to events
             db.session.delete(circulation_event)


### PR DESCRIPTION
## Description

Change circulation analytics to store patron's municipality code ("cached_neighborhood") to circulation events in local db and OpenSearch.

## Motivation and Context

This change will eventually enable municipality-specific statistics for librarians. Relates to: https://jira.lingsoft.fi/browse/SIMPLYE-239

## How Has This Been Tested?

I Tested this locally with patron borrowing, opening and returning books and location data was stored in circulationevents rows and OpenSearch documents. Related automated tests have been updated.

## Checklist

- [x] All new and existing tests passed.
