### PR TITLE
Show default library lanes for all libraries

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -135,6 +135,8 @@ class LibrarySettingsController(AdminPermissionsControllerMixin):
             # Everyone can modify an existing library, but only a system admin can create a new one.
             self.require_system_admin()
             library, is_new = self.create_library(short_name)
+            # Initialize default library if not set already
+            Library.default(self._db)
 
         library.name = name
         library.short_name = short_name

--- a/api/controller/circulation_manager.py
+++ b/api/controller/circulation_manager.py
@@ -147,9 +147,7 @@ class CirculationManagerController(BaseCirculationManagerController):
                 pass
 
             if isinstance(lane_identifier, int):
-                lane = get_one(
-                    self._db, Lane, id=lane_identifier, library_id=library_id
-                )
+                lane = get_one(self._db, Lane, id=lane_identifier)
 
         if lane and not lane.accessible_to(self.request_patron):
             # The authenticated patron cannot access the lane they

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -101,11 +101,16 @@ def create_default_lanes(_db, library):
     be an extremely destructive method. All new Lanes will be visible
     and all Lanes based on CustomLists (but not the CustomLists
     themselves) will be destroyed.
-
     """
     # Delete existing lanes.
     for lane in _db.query(Lane).filter(Lane.library_id == library.id):
         _db.delete(lane)
+
+    # Finland: Lanes from default library are shown for all other
+    # libraries. For other libraries this reset just means deleting
+    # all custom lanes.
+    if not library.is_default:
+        return
 
     top_level_lanes = []
 

--- a/tests/api/admin/controller/test_lanes.py
+++ b/tests/api/admin/controller/test_lanes.py
@@ -547,9 +547,16 @@ class TestLanesController:
             )
             # tests/test_lanes.py tests the default lane creation, but make sure some
             # lanes were created.
-            assert (
-                0
-                < alm_fixture.ctrl.db.session.query(Lane)
+            # assert (
+            #     0
+            #     < alm_fixture.ctrl.db.session.query(Lane)
+            #     .filter(Lane.library == library)
+            #     .count()
+            # )
+
+            # Finland: no lanes created for non-default library
+            assert 0 == (
+                alm_fixture.ctrl.db.session.query(Lane)
                 .filter(Lane.library == library)
                 .count()
             )

--- a/tests/api/controller/test_scopedsession.py
+++ b/tests/api/controller/test_scopedsession.py
@@ -35,6 +35,7 @@ class ScopedHolder:
 
     def make_default_libraries(self, session: Session):
         libraries = []
+
         for i in range(2):
             name = self.fresh_id() + " (library for scoped session)"
             library, ignore = create(

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -265,6 +265,7 @@ class TestLaneCreation:
         settings.small_collection_languages = ["spa", "chi"]
         settings.tiny_collection_languages = ["ger", "fre", "ita"]
         library = library_fixture.library(settings=settings)
+        library.is_default = True
 
         create_default_lanes(db.session, library)
         lanes = (
@@ -309,6 +310,7 @@ class TestLaneCreation:
         settings = library_fixture.mock_settings()
         settings.large_collection_languages = ["eng", "fre"]
         library = library_fixture.library(settings=settings)
+        library.is_default = True
 
         session = db.session
         create_default_lanes(session, library)
@@ -485,16 +487,10 @@ class TestWorkBasedLane:
         assert True == lane.accessible_to(patron)
         work.age_appropriate_for_patron.assert_called_once_with(patron)
 
-        # The WorkList rules are still enforced -- for instance, a
-        # patron from library B can't access any kind of WorkList from
-        # library A.
+        # The WorkList in default library should be accessible by
+        # patron from another library.
         other_library_patron = db.patron(library=db.library())
-        assert False == lane.accessible_to(other_library_patron)
-
-        # age_appropriate_for_patron was never called with the new
-        # patron -- the WorkList rules answered the question before we
-        # got to that point.
-        work.age_appropriate_for_patron.assert_called_once_with(patron)
+        assert True == lane.accessible_to(other_library_patron)
 
 
 class RelatedBooksFixture:

--- a/tests/core/models/test_library.py
+++ b/tests/core/models/test_library.py
@@ -47,12 +47,10 @@ class TestLibrary:
         l1 = db.default_library()
         l2 = db.library()
 
-        # None of them are the default according to the database.
-        assert False == l1.is_default
+        assert True == l1.is_default
         assert False == l2.is_default
 
-        # If we call Library.default, the library with the lowest database
-        # ID is made the default.
+        # If we call Library.default, the library stays as default
         assert l1 == Library.default(db.session)
         assert True == l1.is_default
         assert False == l2.is_default

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -2131,9 +2131,7 @@ class TestUpdateCustomListSizeScript:
 class TestDeleteInvisibleLanesScript:
     def test_do_run(self, db: DatabaseTransactionFixture):
         """Test that invisible lanes and their visible children are deleted."""
-        # create a library
-        short_name = "TESTLIB"
-        l1 = db.library("test library", short_name=short_name)
+        l1 = db.default_library()
         # with a set of default lanes
         create_default_lanes(db.session, l1)
 
@@ -2154,7 +2152,7 @@ class TestDeleteInvisibleLanesScript:
         assert first_child_id is not None
 
         # run script and verify that it had no effect:
-        DeleteInvisibleLanesScript(_db=db.session).do_run([short_name])
+        DeleteInvisibleLanesScript(_db=db.session).do_run([l1.short_name])
         top_level_fiction_lane: Lane = (
             db.session.query(Lane)
             .filter(Lane.library == l1)
@@ -2169,7 +2167,7 @@ class TestDeleteInvisibleLanesScript:
         top_level_fiction_lane.visible = False
 
         # and now run script.
-        DeleteInvisibleLanesScript(_db=db.session).do_run([short_name])
+        DeleteInvisibleLanesScript(_db=db.session).do_run([l1.short_name])
 
         # verify the lane has now been deleted.
         deleted_lane = (

--- a/tests/fixtures/api_controller.py
+++ b/tests/fixtures/api_controller.py
@@ -189,12 +189,13 @@ class ControllerFixture:
         self.manager.d_top_level_lane = self.manager.top_level_lanes[self.library.id]  # type: ignore
         self.controller = CirculationManagerController(self.manager)
 
-        # Set a convenient default lane.
-        [self.english_adult_fiction] = [
-            x
-            for x in self.library.lanes
-            if x.display_name == "Fiction" and x.languages == ["eng"]
-        ]
+        if self.db.default_library().lanes:
+            # Set a convenient default lane.
+            [self.english_adult_fiction] = [
+                x
+                for x in self.db.default_library().lanes
+                if x.display_name == "Fiction" and x.languages == ["eng"]
+            ]
 
         return self.manager
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -166,6 +166,7 @@ class DatabaseTransactionFixture:
     def _make_default_library(self) -> Library:
         """Ensure that the default library exists in the given database."""
         library = self.library("default", "default")
+        library.is_default = True
         collection = self.collection(
             "Default Collection",
             protocol=ExternalIntegration.OPDS_IMPORT,


### PR DESCRIPTION
## Goal

Allow system admins to centrally manage a default set of lanes. 

## Solution

- Lanes defined for the default library are shown for all other libraries.
- Custom lanes defined for a library will show up on top of the lane catalog.
- Resetting lanes for any other than default library just deletes all lanes without generating new ones.
    - The library will still show lanes from default library after reset.
- Authorization rules changed to allow user from any library to fetch lanes from default library.

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-320> - Default test user from Suomi.fi cannot see lanes defined by the system administrator

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
