### PR TITLE
Inherit settings from default library

### DIFF
--- a/core/model/library.py
+++ b/core/model/library.py
@@ -334,7 +334,18 @@ class Library(Base, HasSessionCache):
                 )
             settings = integration_settings_load(LibrarySettings, self)
             self._settings = settings
-        return settings
+
+        # Finland, use default library settings as defaults
+
+        # This is the default, don't need to merge anything
+        if self.is_default:
+            return settings
+
+        default_library: Library | None = self.default(Session.object_session(self))
+        if not default_library:
+            return settings
+
+        return settings.merge_with(default_library.settings)
 
     def update_settings(self, new_settings: LibrarySettings) -> None:
         """Update the settings for this integration"""

--- a/tests/api/admin/controller/test_library.py
+++ b/tests/api/admin/controller/test_library.py
@@ -306,25 +306,6 @@ class TestLibrarySettings:
                 controller.process_post()
             assert excinfo.value.problem_detail.uri == INCOMPLETE_CONFIGURATION.uri
 
-        # Either patron support email or website MUST be present
-        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
-                [
-                    ("name", "Email or Website Library"),
-                    ("short_name", "Email or Website"),
-                    ("website", "http://example.org"),
-                    ("default_notification_email_address", "email@example.org"),
-                ]
-            )
-            with pytest.raises(ProblemError) as excinfo:
-                controller.process_post()
-            assert excinfo.value.problem_detail.uri == INCOMPLETE_CONFIGURATION.uri
-            assert excinfo.value.problem_detail.detail is not None
-            assert (
-                "'Patron support email address' or 'Patron support website'"
-                in excinfo.value.problem_detail.detail
-            )
-
         # Test a web primary and secondary color that doesn't contrast
         # well on white. Here primary will, secondary should not.
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -1087,8 +1087,8 @@ class TestLibraryAuthenticator:
         library_settings.color_scheme = "plaid"
 
         # Set the colors a web client should use.
-        library_settings.web_primary_color = "#012345"
-        library_settings.web_secondary_color = "#abcdef"
+        library_settings.web_primary_color = "#000001"
+        library_settings.web_secondary_color = "#000002"
 
         # Configure the various ways a patron can get help.
         library_settings.help_email = "help@library.org"  # type: ignore[assignment]
@@ -1165,8 +1165,8 @@ class TestLibraryAuthenticator:
 
             # The mobile color scheme and web colors are correctly reported.
             assert "plaid" == doc["color_scheme"]
-            assert "#012345" == doc["web_color_scheme"]["primary"]
-            assert "#abcdef" == doc["web_color_scheme"]["secondary"]
+            assert "#000001" == doc["web_color_scheme"]["primary"]
+            assert "#000002" == doc["web_color_scheme"]["secondary"]
 
             # We also need to test that the links got pulled in
             # from the configuration.

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -1560,12 +1560,12 @@ class TestBaseCirculationAPI:
         # Test the ability to get the default notification email address
         # for a patron or a library.
         settings = library_fixture.mock_settings()
-        settings.default_notification_email_address = "help@library"  # type: ignore[assignment]
+        settings.default_notification_email_address = "help@example.com"  # type: ignore[assignment]
         library = library_fixture.library(settings=settings)
         patron = db.patron(library=library)
         m = BaseCirculationAPI.default_notification_email_address
-        assert "help@library" == m(library, "")
-        assert "help@library" == m(patron, "")
+        assert "help@example.com" == m(library, "")
+        assert "help@example.com" == m(patron, "")
         other_library = library_fixture.library()
         assert "noreply@thepalaceproject.org" == m(other_library, "")
 

--- a/tests/core/models/test_library.py
+++ b/tests/core/models/test_library.py
@@ -234,7 +234,3 @@ username='someuser'
         library.settings_dict = []
         with pytest.raises(ValueError):
             library.settings
-
-        # Test with a properly formatted settings dict.
-        library2 = db.library()
-        assert library2.settings.website == "http://library.com"

--- a/tests/fixtures/library.py
+++ b/tests/fixtures/library.py
@@ -54,7 +54,10 @@ class LibraryFixture:
         return settings
 
     def mock_settings(self) -> MockLibrarySettings:
-        return MockLibrarySettings.construct()
+        settings = MockLibrarySettings.construct()
+        settings.color_scheme = "blue"
+        settings.website = "https://example.com"  # type: ignore[assignment]
+        return settings
 
     def set_mock_on_library(
         self, library: Library, settings: MockLibrarySettings


### PR DESCRIPTION
Other libraries now inherit any unset setting value from the default library.

Also, add new options to show/hide library settings in UI based on whether the library is the default or not. This allows:

- Hiding the Kirkanta synchronization panel from default library.
- Showing Filter&lane panel only for default library.
- Hiding settings that don't need to be customized per Kimppa library.

The support e-mail and website are now optional to allow leaving those empty for Kimppa libraries.

## Motivation and Context

<https://jira.lingsoft.fi/browse/SIMPLYE-354> - Improve library settings handling