### PR TITLE
Give default lanes lower priority when creating default set of lanes

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -125,7 +125,8 @@ def create_default_lanes(_db, library):
     if not large and not small and not tiny:
         estimates = library.estimated_holdings_by_language()
         large, small, tiny = _lane_configuration_from_collection_sizes(estimates)
-    priority = 0
+
+    priority = 1000
 
     if large and len(large) > 0:
         language = large[0]

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -288,9 +288,9 @@ class TestLaneCreation:
         } == {x.display_name for x in lanes}
 
         [english_fiction_lane] = [x for x in lanes if x.display_name == "Fiction"]
-        assert 0 == english_fiction_lane.priority
+        assert 1000 == english_fiction_lane.priority
         [world] = [x for x in lanes if x.display_name == "World Languages"]
-        assert 5 == world.priority
+        assert 1005 == world.priority
 
         # ensure the target age is appropriately set for the children and middle grade lane
         [children_and_middle_grade_lane] = [


### PR DESCRIPTION
Give default lanes lower priority when creating default set of lanes to make the Kimppa specific curated lanes show up on top.

The endpoint for updating lane ordering was already handled in an earlier PR, but missed the case of initial lane creation and RESET.
