### PR TITLE
Increase facet bucket max size in statistics

### DIFF
--- a/api/opensearch_analytics_search.py
+++ b/api/opensearch_analytics_search.py
@@ -231,7 +231,7 @@ class OpenSearchAnalyticsSearch:
         # Add all term fields to aggregations
         aggs = {}
         for field in self.FACET_FIELDS:
-            aggs[field] = {"terms": {"field": field}}
+            aggs[field] = {"terms": {"field": field, "size": 1000}}
 
         # Prepare and run the query (with 0 size)
         query = {"size": 0, "query": {"bool": {"must": filters}}, "aggs": aggs}


### PR DESCRIPTION
## Description

Increase facet bucket max size in OpenSearch statistics so that we'll have all options available in the console.
 
