### PR TITLE
Ignore Accept-Language header in search results

### DIFF
--- a/core/lane.py
+++ b/core/lane.py
@@ -65,7 +65,6 @@ from core.model.hybrid import hybrid_property
 from core.model.listeners import site_configuration_has_changed
 from core.problem_details import *
 from core.util import LanguageCodes
-from core.util.accept_language import parse_accept_language
 from core.util.datetime_helpers import utc_now
 from core.util.opds_writer import OPDSFeed
 from core.util.problem_detail import ProblemDetail
@@ -1080,16 +1079,12 @@ class SearchFacets(Facets):
         # Searches against a WorkList will use the union of the
         # languages allowed by the WorkList and the languages found in
         # the client's Accept-Language header.
-        language_header = get_header("Accept-Language")
+
+        # Finland: Accept-Language header usage removed from here
+        # in favor of the added language facet
+
         languages = get_argument("language") or None
         extra["language_from_query"] = languages is not None
-        if not languages:
-            if language_header:
-                languages = parse_accept_language(language_header)
-                languages = [l[0] for l in languages]
-                languages = list(map(LanguageCodes.iso_639_2_for_locale, languages))
-                languages = [l for l in languages if l]
-            languages = languages or None
         extra["languages"] = languages
 
         # The client can request a minimum score for search results.

--- a/tests/core/test_app_server.py
+++ b/tests/core/test_app_server.py
@@ -390,12 +390,13 @@ class TestLoadMethods:
             assert default_entrypoint == facets.entrypoint
             assert facets.entrypoint_is_default is True
 
-        # Load a SearchFacets object that pulls information from an
-        # HTTP header.
-        with fixture.app.test_request_context("/", headers={"Accept-Language": "ja"}):
+        # Finland: Load a SearchFacets object with language as facet and ignore Accept-Language header.
+        with fixture.app.test_request_context(
+            "/?language=eng", headers={"Accept-Language": "ja"}
+        ):
             flask.request.library = data.default_library()  # type: ignore[attr-defined]
             facets = load_facets_from_request(base_class=SearchFacets)
-            assert ["jpn"] == facets.languages
+            assert ["eng"] == facets.languages
 
     def test_load_facets_from_request_class_instantiation(
         self, load_methods_fixture: LoadMethodsFixture

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -1434,7 +1434,11 @@ class TestSearchFacets:
 
         # The SearchFacets implementation turned the 'Accept-Language'
         # header into a set of language codes.
-        assert ["dan", "eng"] == facets.languages
+
+        # Finland: Language-header usage removed in favor of added language facet
+        # Before: assert ["dan", "eng"] == facets.languages
+        assert None == facets.languages
+
         assert False == facets._language_from_query
 
         # Try again with bogus media, languages, and minimum score.


### PR DESCRIPTION
## Description

Accept-Language header check seems to cause inconsistencies in top-level search. Also, we handle languages as facets in search.

## Motivation and Context

https://jira.lingsoft.fi/browse/SIMPLYE-388

