### PR TITLE
Classify poetry under fiction

### DIFF
--- a/core/classifier/keyword.py
+++ b/core/classifier/keyword.py
@@ -41,7 +41,6 @@ class Eg:
 
 
 class KeywordBasedClassifier(AgeOrGradeClassifier):
-
     """Classify a book based on keywords."""
 
     # We have to handle these first because otherwise '\bfiction\b'
@@ -54,6 +53,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         Eg("tales"),
         Eg("literature"),
         Eg("bildungsromans"),
+        Eg("poetry"),  # Finland
         "fictitious",
     )
     LEVEL_2_NONFICTION_INDICATORS = match_kw(

--- a/tests/core/classifiers/test_keyword.py
+++ b/tests/core/classifiers/test_keyword.py
@@ -21,6 +21,7 @@ class TestLCSH:
         assert False == fic("Biography")
         assert None == fic("Kentucky")
         assert None == fic("Social life and customs")
+        assert True == fic("Poetry")  # Finland
 
     def test_audience(self):
         child = Classifier.AUDIENCE_CHILDREN


### PR DESCRIPTION
## Description

Add "poetry" to fiction classifier indicators.

## Motivation and Context

https://jira.lingsoft.fi/browse/SIMPLYE-410

## How Has This Been Tested?

An assert added to test_keyword to check that "Poetry" as keyword makes is_fiction classification true.
