### PR TITLE
EKIR-208 Change token expiration

### DIFF
--- a/api/controller/patron_auth_token.py
+++ b/api/controller/patron_auth_token.py
@@ -16,7 +16,7 @@ class PatronAuthTokenController(CirculationManagerController):
         """Create a Patron Auth access token for an authenticated patron"""
         patron = flask.request.patron
         auth = flask.request.authorization
-        token_expiry = 3600
+        token_expiry = 604800  # Changed from 1h to 1 week
 
         if not patron or auth.type.lower() != "basic":
             return PATRON_AUTH_ACCESS_TOKEN_NOT_POSSIBLE

--- a/tests/api/controller/test_patron_access_token.py
+++ b/tests/api/controller/test_patron_access_token.py
@@ -36,7 +36,7 @@ class TestPatronAuthTokenController:
             ctx.request.patron = patron
             token = fxtr.controller.get_token()
             assert ("accessToken", "tokenType", "expiresIn") == tuple(token.keys())
-            assert token["expiresIn"] == 3600
+            assert token["expiresIn"] == 604800
             assert token["tokenType"] == "Bearer"
 
     def test_get_token_errors(


### PR DESCRIPTION
This PR increases the duration of patron auth token to one week so that patrons don't have to sign in so frequently.