### PR TITLE
EKIR-209 Add bigger timeout for loans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for setting up a virtual enviroment and running the application.
 
-.PHONY: install dependencies install_libxmlsec1 
+.PHONY: install dependencies install_libxmlsec1
 
 # SECTION 1: Install dependencies
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 ```
+
 and source it with:
 
 ```shell

--- a/api/odl.py
+++ b/api/odl.py
@@ -253,7 +253,9 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         auth_header = "Basic %s" % base64.b64encode(f"{username}:{password}")
         headers["Authorization"] = auth_header
 
-        return HTTP.get_with_timeout(url, headers=headers)
+        return HTTP.get_with_timeout(
+            url, headers=headers, timeout=30
+        )  # Added a bigger timeout for loan checkouts
 
     def _url_for(self, *args: Any, **kwargs: Any) -> str:
         """Wrapper around flask's url_for to be overridden for tests."""


### PR DESCRIPTION
An attempt to prevent patrons getting a connection abort when checking out a loan that takes a long time to go through by increasing the get request timeout.