### PR TITLE
Change operators > back to >=

### DIFF
--- a/api/odl2.py
+++ b/api/odl2.py
@@ -112,7 +112,7 @@ class ODL2API(BaseODLAPI[ODL2Settings, ODLLibrarySettings]):
                     patron.loans,
                 )
             )
-            if len(loans) > self.loan_limit:  # Changed operator >= to >
+            if len(loans) >= self.loan_limit:  # Changed back operator > to >=
                 raise PatronLoanLimitReached(limit=self.loan_limit)
         return super()._checkout(patron, licensepool, hold)
 
@@ -125,7 +125,7 @@ class ODL2API(BaseODLAPI[ODL2Settings, ODLLibrarySettings]):
                     patron.holds,
                 )
             )
-            if len(holds) > self.hold_limit:  # Changed operator >= to >
+            if len(holds) >= self.hold_limit:  # Changed back operator > to >=
                 raise PatronHoldLimitReached(limit=self.hold_limit)
         return super()._place_hold(patron, licensepool)
 


### PR DESCRIPTION
Change operators back to how they were before since the change didn't have the effect they thought should have.