### PR TITLE
Ekir 298 nginx uwsgi

### DIFF
--- a/docker/services/nginx/nginx.conf
+++ b/docker/services/nginx/nginx.conf
@@ -5,7 +5,7 @@ include /etc/nginx/modules-enabled/*.conf;
 daemon off;
 
 events {
-    worker_connections 768;
+    worker_connections 4096;
     # multi_accept on;
 }
 

--- a/docker/services/uwsgi/uwsgi.d/60_processes.ini
+++ b/docker/services/uwsgi/uwsgi.d/60_processes.ini
@@ -1,4 +1,4 @@
 [uwsgi]
 # Default number of processes and threads for the app
-processes = 3
+processes = 6
 threads = 2


### PR DESCRIPTION
## Description

- Nginx ran out of connections per worker, hence we increase worker_connections.
- Increase uwsgi process count form 3-6 as implied in readme to get better use for resources.

Tested with local vm.
