### PR TITLE
increased nginx worker connections & uwsgi processes

### DIFF
--- a/docker/services/nginx/nginx.conf
+++ b/docker/services/nginx/nginx.conf
@@ -5,7 +5,7 @@ include /etc/nginx/modules-enabled/*.conf;
 daemon off;
 
 events {
-    worker_connections 768;
+    worker_connections 4096;
     # multi_accept on;
 }
 

--- a/docker/services/uwsgi/uwsgi.d/60_processes.ini
+++ b/docker/services/uwsgi/uwsgi.d/60_processes.ini
@@ -1,4 +1,4 @@
 [uwsgi]
 # Default number of processes and threads for the app
-processes = 3
+processes = 6
 threads = 2


### PR DESCRIPTION
- Increase nginx worker_connections from 768 -> 4096
- Increase uwsgi process count 3 -> 6

Tests fails, because of unmerged fixes, and unaccessible resource for json schema validation:
Work in progress...

```
# this returns 404
url = 'https://readium.org/webpub-manifest/schema/extensions/presentation/metadata.schema.json
```