### PR TITLE
updated opds presentation hints schema url

### DIFF
--- a/core/resources/opds2_schema/readium-metadata.schema.json
+++ b/core/resources/opds2_schema/readium-metadata.schema.json
@@ -141,7 +141,7 @@
       "$ref": "https://readium.org/webpub-manifest/schema/extensions/epub/metadata.schema.json"
     },
     {
-      "$ref": "https://readium.org/webpub-manifest/schema/extensions/presentation/metadata.schema.json"
+      "$ref": "https://readium.org/webpub-manifest/schema/experimental/presentation/metadata.schema.json"
     }
   ]
 }


### PR DESCRIPTION
Url for opds2 presentation hints schema has changed, hence url updated.
Local core tests passes.
api tests fixed in https://github.com/NatLibFi/ekirjasto-circulation/pull/89

