### PR TITLE
Ekir 213 enable loan when not at loan limit

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1086,14 +1086,15 @@ class CirculationAPI:
                 # Update availability information immediately
                 api.update_availability(licensepool)
                 
-                # Update the hold
+                # Update the hold so the patron doesn't lose their hold. Extend the hold to expire in the
+                # next 3 days.
                 hold_info = HoldInfo(
                 licensepool.collection,
                 licensepool.data_source,
                 licensepool.identifier.type,
                 licensepool.identifier.identifier,
                 existing_hold.start,
-                datetime.datetime.now() + datetime.timedelta(weeks=2),
+                datetime.datetime.now() + datetime.timedelta(days=3),
                 existing_hold.position,
             )
             else:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1213,6 +1213,11 @@ class CirculationAPI:
             # This patron can take out either a loan or a hold, so the
             # limits don't apply.
             return
+        
+        if not at_loan_limit and at_hold_limit:
+            # This patron can take out a loan, but not a hold. This is relevant when
+            # the book is not available, but the patron is at their hold limit.
+            return
 
         if at_loan_limit and at_hold_limit:
             # This patron can neither take out a loan or place a hold.

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -926,7 +926,7 @@ class CirculationAPI:
         delivery_mechanism: LicensePoolDeliveryMechanism,
         hold_notification_email: str | None = None,
     ) -> tuple[Loan | None, Hold | None, bool]:
-        """Either borrow a book or put it on hold. Don't worry about fulfilling
+        """Either borrow a book or put it or leave it on hold. Don't worry about fulfilling
         the loan yet.
 
         :return: A 3-tuple (`Loan`, `Hold`, `is_new`). Either `Loan`
@@ -1080,7 +1080,7 @@ class CirculationAPI:
                 )
             
             # The patron had a hold and was in the hold queue's 0th position believing
-            # there were copies available. 
+            # there were copies available for them to checkout. 
             if existing_hold and existing_hold.position == 0:  # Do we want to also check the position?
                 
                 # Update availability information immediately
@@ -1244,7 +1244,7 @@ class CirculationAPI:
         
         if not at_loan_limit and at_hold_limit:
             # This patron can take out a loan, but not a hold. This is relevant when
-            # the book is not available, but the patron is at their hold limit.
+            # the book is not available, but the patron is at their hold limit and at position 0 in the hold queue.
             return
 
         if at_loan_limit and at_hold_limit:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1093,7 +1093,7 @@ class CirculationAPI:
                 licensepool.identifier.type,
                 licensepool.identifier.identifier,
                 existing_hold.start,
-                None,
+                datetime.datetime.now() + datetime.timedelta(weeks=2),
                 existing_hold.position,
             )
             else:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1083,12 +1083,10 @@ class CirculationAPI:
                 raise CannotRenew(
                     _("You cannot renew a loan if other patrons have the work on hold.")
                 )
-            
+
             # The patron had a hold and was in the hold queue's 0th position believing
             # there were copies available for them to checkout.
-            if (
-                existing_hold and existing_hold.position == 0
-            ):
+            if existing_hold and existing_hold.position == 0:
                 # Update the hold so the patron doesn't lose their hold. Extend the hold to expire in the
                 # next 3 days.
                 hold_info = HoldInfo(
@@ -1260,7 +1258,7 @@ class CirculationAPI:
             # This patron can take out either a loan or a hold, so the
             # limits don't apply.
             return
-        
+
         if not at_loan_limit and at_hold_limit:
             # This patron can take out a loan, but not a hold. This is relevant when
             # the patron can't place a hold but can take out a loan.

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1263,7 +1263,7 @@ class CirculationAPI:
         
         if not at_loan_limit and at_hold_limit:
             # This patron can take out a loan, but not a hold. This is relevant when
-            # the book is not available, but the patron is at their hold limit and at position 0 in the hold queue.
+            # the patron can't place a hold but can take out a loan.
             return
 
         if at_loan_limit and at_hold_limit:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1085,23 +1085,24 @@ class CirculationAPI:
                 )
             
             # The patron had a hold and was in the hold queue's 0th position believing
-            # there were copies available for them to checkout. 
-            if existing_hold and existing_hold.position == 0:  # Do we want to also check the position?
-                
-                # Update availability information immediately
-                api.update_availability(licensepool)
-                
+            # there were copies available for them to checkout.
+            if (
+                existing_hold and existing_hold.position == 0
+            ):
                 # Update the hold so the patron doesn't lose their hold. Extend the hold to expire in the
                 # next 3 days.
                 hold_info = HoldInfo(
-                licensepool.collection,
-                licensepool.data_source,
-                licensepool.identifier.type,
-                licensepool.identifier.identifier,
-                existing_hold.start,
-                datetime.datetime.now() + datetime.timedelta(days=3),
-                existing_hold.position,
-            )
+                    licensepool.collection,
+                    licensepool.data_source,
+                    licensepool.identifier.type,
+                    licensepool.identifier.identifier,
+                    existing_hold.start,
+                    datetime.datetime.now() + datetime.timedelta(days=3),
+                    existing_hold.position,
+                )
+                # Update availability information
+                api.update_availability(licensepool)
+                reserved_license_exception = True
             else:
                 # That's fine, we'll just (try to) place a hold.
                 #

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -217,6 +217,17 @@ class CannotRenew(CirculationException):
     status_code = 400
 
 
+class NoAvailableCopiesWhenReserved(CannotLoan):
+    """The patron can't check this book out because all available
+    copies are already checked out. The book is "reserved" to the
+    patron.
+    """
+
+    def as_problem_detail_document(self, debug=False):
+        """Return a suitable problem detail document."""
+        return NO_COPIES_WHEN_RESERVED
+
+
 class NoAvailableCopies(CannotLoan):
     """The patron can't check this book out because all available
     copies are already checked out.

--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -22,6 +22,7 @@ from api.circulation_exceptions import (
     DeliveryMechanismError,
     FormatNotAvailable,
     NoActiveLoan,
+    NoAvailableCopiesWhenReserved,
     NoOpenAccessDownload,
     NotFoundOnRemote,
     OutstandingFines,
@@ -203,6 +204,11 @@ class LoanController(CirculationManagerController):
             result = e.as_problem_detail_document(debug=False)
         except CannotLoan as e:
             result = CHECKOUT_FAILED.with_debug(str(e))
+        except CannotLoan as e:
+            if isinstance(e, NoAvailableCopiesWhenReserved):
+                result = e.as_problem_detail_document()
+            else:
+                result = CHECKOUT_FAILED.with_debug(str(e))
         except CannotHold as e:
             result = HOLD_FAILED.with_debug(str(e))
         except CannotRenew as e:

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -58,8 +58,8 @@ NO_AVAILABLE_LICENSE = pd(
 
 # E-kirjasto
 NO_COPIES_WHEN_RESERVED = pd(
-    "http://librarysimplified.org/terms/problem/no-available-license",
-    403,
+    "http://librarysimplified.org/terms/problem/cannot-issue-loan",
+    502,
     _("No available license."),
     _("All copies of this book are loaned out after all. You are still next in line."),
 )

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -56,6 +56,14 @@ NO_AVAILABLE_LICENSE = pd(
     _("All licenses for this book are loaned out."),
 )
 
+# E-kirjasto
+NO_COPIES_WHEN_RESERVED = pd(
+    "http://librarysimplified.org/terms/problem/no-available-license",
+    403,
+    _("No available license."),
+    _("All copies of this book are loaned out after all. You are still next in line."),
+)
+
 NO_ACCEPTABLE_FORMAT = pd(
     "http://librarysimplified.org/terms/problem/no-acceptable-format",
     400,

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -1111,7 +1111,7 @@ class TestLoanController:
             )
             assert isinstance(response, ProblemDetail)
             assert NO_COPIES_WHEN_RESERVED.uri == response.uri
-            assert 403 == response.status_code
+            assert 502 == response.status_code
 
     def test_borrow_fails_with_outstanding_fines(
         self, loan_fixture: LoanFixture, library_fixture: LibraryFixture

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -21,6 +21,7 @@ from api.circulation import (
 from api.circulation_exceptions import (
     AlreadyOnHold,
     NoAvailableCopies,
+    NoAvailableCopiesWhenReserved,
     NoLicenses,
     NotFoundOnRemote,
     PatronHoldLimitReached,
@@ -30,6 +31,7 @@ from api.problem_details import (
     CANNOT_RELEASE_HOLD,
     HOLD_LIMIT_REACHED,
     NO_ACTIVE_LOAN,
+    NO_COPIES_WHEN_RESERVED,
     NOT_FOUND_ON_REMOTE,
     OUTSTANDING_FINES,
 )
@@ -1090,6 +1092,26 @@ class TestLoanController:
             )
             assert isinstance(response, ProblemDetail)
             assert HOLD_LIMIT_REACHED.uri == response.uri
+
+    def test_loan_fails_when_patron_is_at_hold_limit_and_hold_position_zero(
+        self, loan_fixture: LoanFixture
+    ):
+        edition, pool = loan_fixture.db.edition(with_license_pool=True)
+        pool.open_access = False
+        with loan_fixture.request_context_with_library(
+            "/", headers=dict(Authorization=loan_fixture.valid_auth)
+        ):
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            loan_fixture.manager.d_circulation.queue_checkout(pool, NoAvailableCopies())
+            loan_fixture.manager.d_circulation.queue_hold(
+                pool, NoAvailableCopiesWhenReserved()
+            )
+            response = loan_fixture.manager.loans.borrow(
+                pool.identifier.type, pool.identifier.identifier
+            )
+            assert isinstance(response, ProblemDetail)
+            assert NO_COPIES_WHEN_RESERVED.uri == response.uri
+            assert 403 == response.status_code
 
     def test_borrow_fails_with_outstanding_fines(
         self, loan_fixture: LoanFixture, library_fixture: LibraryFixture

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -864,7 +864,7 @@ class TestCirculationAPI:
         assert patron == circulation.patron_at_hold_limit_calls.pop()
         assert pool == api.availability_updated.pop()
 
-        # Sub-test 3: patron is at hold limit but not loan limit
+        # Sub-test 4: patron is at hold limit but not loan limit
         #
         circulation.at_loan_limit = False
         circulation.at_hold_limit = True

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -944,14 +944,11 @@ class TestCirculationAPI:
         trying to checkout. When the patron tries to borrow the book but it turns out to not be available, the
         hold is updated to have a new end date with all other properties unchanged.
         The circulation information for the book is immediately updated, to reduce the risk that other patrons
-        would encounter the same problem.
-        """ 
+        would encounter the same problem. Finally, the patron gets a NoAvailableCopiesWhenReserved exception.
+        """
 
         # The hold limit is 1
         library_fixture.settings(circulation_api.patron.library).hold_limit = 1
-
-        other_pool = circulation_api.db.licensepool(None)
-        other_pool.open_access = False
 
         # The patron has a hold with position 0 in the hold queue
         existing_hold, is_new = circulation_api.pool.on_hold_to(
@@ -963,19 +960,19 @@ class TestCirculationAPI:
         original_hold_end_date = existing_hold.end
 
         # The patron wants to take out their hold for loan but which turns out to not be available.
-        circulation_api.pool.licenses_available = 0
         circulation_api.remote.queue_checkout(NoAvailableCopies())
 
-        # We want to ensure that the update hasn't yet happened when NoAvailableCopies was raised
-        assert [] == circulation_api.remote.availability_updated_for
+        # The patron tries to borrow the book but gets a NoAvailableCopiesWhenReserved exception
+        try:
+            self.borrow(circulation_api)
+        except Exception as e:
+            assert isinstance(e, NoAvailableCopiesWhenReserved)
 
-        loan, hold, is_new = self.borrow(circulation_api)
-
-        assert loan is None
-        assert hold is not None # It should be a hold, not loan.
-        assert not is_new   # The hold is updated, it shouldn't be a new hold.
-        assert hold.position == 0
-        assert hold.end != original_hold_end_date # The updated hold should have a new end date.
+        # Nonetheless, the hold is updated to have a new extended end date.
+        assert existing_hold.position == 0
+        assert (
+            existing_hold.end != original_hold_end_date
+        )  # The updated hold should have a new end date.
         # When NoAvailableCopies was raised, the circulation
         # information for the book was immediately updated, to reduce
         # the risk that other patrons would encounter the same

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -872,12 +872,16 @@ class TestCirculationAPI:
         # Test updated: If the book is not available, we should NOT yet
         # raise PatronHoldLimitReached. The patron is at their hold limit
         # but they may be trying to take out a loan on a book that is
-        # reserved for them (hold position 0).
+        # reserved for them (hold position 0). We want to let them proceed
+        # at this point.
         pool.licenses_available = 0
         try:
             circulation.enforce_limits(patron, pool)
         except PatronHoldLimitReached:
-            assert not PatronHoldLimitReached
+            assert False, "PatronHoldLimitReached is raised when it shouldn't"
+        else:
+            # If no exception is raised, the test should pass
+            assert True
 
         # Reaching this conclusion required checking both patron
         # limits. The remote API isn't queried for updated availability

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -886,7 +886,6 @@ class TestCirculationAPI:
         assert patron == circulation.patron_at_hold_limit_calls.pop()
         assert [] == api.availability_updated
 
-
         # If the book is available, we're fine -- we're not at our loan limit.
         # The remote API isn't queried for updated availability
         # information for this LicensePool.
@@ -895,7 +894,6 @@ class TestCirculationAPI:
         assert patron == circulation.patron_at_loan_limit_calls.pop()
         assert patron == circulation.patron_at_hold_limit_calls.pop()
         assert [] == api.availability_updated
-
 
     def test_borrow_hold_limit_reached(
         self, circulation_api: CirculationAPIFixture, library_fixture: LibraryFixture


### PR DESCRIPTION
## Description

Circulation will give response 502 NoAvailableCopiesWhenReserved when a patron tries to checkout a loan that was "reserved" for them but turns out not to be available. Their hold is updated with a new end date.

## Motivation and Context
When the patron was at the top of a license pool's hold queue and at their hold limit, circulation gave response 403 that they had reached their hold limit when they tried to checkout a presumably (and notified) available license. This was, based on comments and tests, a by design functionality.

When a patron tries to loan/hold a book, the request goes to route "/works/<identifier_type>/<path:identifier>/borrow" and the process loan.py <-> circulationapi.py <-> odl.py.

This PR changes functionality:

- 403 PatronHoldLimitReached is not raised in enforce_limits() when a patron is not at their loan limit but at their hold limit so that we can check the situation more carefully later in borrow().

- When checkout() (in odl.py which is the api we're using) in borrow() is run and gives a NoAvailableCopies, the code checks if the patron has an existing hold on that license at hold position 0, updates the hold with a new end date and updates the license's availability information. Finally, borrow() raises a NoAvailableCopiesWhenReserved exception at the end when it's been set to True  during the hold update.

- Borrow() is called in loans.py _checkout() which raises 502 NoAvailableCopiesWhenReserved except with a new NO_COPIES_WHEN_RESERVED problem detail to the client.

## How Has This Been Tested?
This is purely based on unit tests that check hold limits and hold positions. This may be tricky to test in practice due to circulation not being fully in sync with the remote which causes this situation of a license being checked out by somebody else (most likely) == not available.

## Checklist

- Internal documentation updated.
- All new and existing tests passed.
