### PR TITLE
EKIR-389 Classify poetry as fiction

### DIFF
--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -266,7 +266,7 @@ class BISACClassifier(Classifier):
         m(True, "Literary Collections"),
         m(stop, "Humor"),
         m(stop, "Drama"),
-        m(stop, "Poetry"),
+        m(True, "Poetry"),
         m(False, anything),
     ]
 

--- a/core/model/classification.py
+++ b/core/model/classification.py
@@ -501,12 +501,22 @@ class Genre(Base, HasSessionCache):
             length = len(classifier.genres[self.name].subgenres)
         else:
             length = 0
-        return "<Genre %s (%d subjects, %d works, %d subcategories)>" % (
+        genre_data = "<Genre %s (%d subjects, %d works, %d subcategories)>" % (
             self.name,
             len(self.subjects),
             len(self.works),
             length,
         )
+        genre_data += "\n  <Subjects: %s>" % (
+            ", ".join(
+                [
+                    f"{subject.name} ({subject.type}, {subject.identifier})"
+                    for subject in self.subjects
+                ]
+            )
+        )
+
+        return genre_data
 
     def cache_key(self):
         return self.name

--- a/tests/core/classifiers/test_bisac.py
+++ b/tests/core/classifiers/test_bisac.py
@@ -169,9 +169,7 @@ class TestBISACClassifier:
         # We determined fiction/nonfiction status for every BISAC
         # subject except for humor, drama, and poetry.
         for subject in need_fiction:
-            assert any(
-                subject.name.lower().startswith(x) for x in ["humor", "drama", "poetry"]
-            )
+            assert any(subject.name.lower().startswith(x) for x in ["humor", "drama"])
 
         # We determined the target audience for every BISAC subject.
         assert [] == need_audience
@@ -262,13 +260,16 @@ class TestBISACClassifier:
         fiction_is("Fiction / Science Fiction", True)
         fiction_is("Antiques & Collectibles / Kitchenware", False)
 
-        # Humor, drama and poetry do not have fiction classifications
+        # Humor and drama do not have fiction classifications
         # unless the fiction classification comes from elsewhere in the
-        # subject.
+        # subject. Poetry used y´to be in this category but as changed in
+        # e-kirjasto.
         fiction_is("Humor", None)
         fiction_is("Drama", None)
-        fiction_is("Poetry", None)
+        fiction_is("Poetry / Russian & Former Soviet Union", True)
         fiction_is("Young Adult Fiction / Poetry", True)
+        # When Poetry is a subclass, fiction status is based on the upper class.
+        fiction_is("Literary Criticism / Poetry", False)
 
         fiction_is("Young Adult Nonfiction / Humor", False)
         fiction_is("Juvenile Fiction / Humorous Stories", True)

--- a/tests/core/classifiers/test_bisac.py
+++ b/tests/core/classifiers/test_bisac.py
@@ -226,6 +226,10 @@ class TestBISACClassifier:
 
         genre_is("Young Adult Fiction / Poetry", "Poetry")
         genre_is("Poetry", "Poetry")
+        # Making sure we classify Poetry as Poetry
+        genre_is("Poetry / European / General", "Poetry")
+        # Making sure we classify Literary Criticism as such, not Poetry
+        genre_is("Literary Criticism / Poetry", "Literary Criticism")
 
         # Grandfathered in from an older test to validate that the new
         # BISAC algorithm gives the same results as the old one.


### PR DESCRIPTION
## Description

Classify Poetry as Fiction.

## Motivation and Context

Poetry was classified as None. These changes classify Poetry as fiction except if it's a subclass of something non-fiction. Note though, that our test feed does not have any book with a BISAC code where Poetry is a subclass of a non-fiction book so this behaviour can only be observed in unit tests.

## How Has This Been Tested?

Unit testing and local backend testing (run opds_import_monitor, check results in opensearch dashoard).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
