### PR TITLE
EKIR-380 Replace Literary with General

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -450,7 +450,7 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
         lane_from_genres(
             _db,
             library,
-            [genres.Literary_Fiction],
+            [genres.General_Fiction],
             display_name="Contemporary Fiction",
             priority=ya_fiction_priority,
             **ya_common_args
@@ -717,7 +717,7 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
         **children_common_args
     )
     children_priority += 1
-    realistic_fiction.add_genre(genres.Literary_Fiction.name)
+    realistic_fiction.add_genre(genres.General_Fiction.name)
     children.sublanes.append(realistic_fiction)
 
     children_graphic_novels, ignore = create(

--- a/core/classifier/__init__.py
+++ b/core/classifier/__init__.py
@@ -602,7 +602,7 @@ fiction_genres = [
         ],
     ),
     "Humorous Fiction",
-    "Literary Fiction",
+    "General Fiction",
     "LGBTQ Fiction",
     dict(
         name="Mystery",

--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -385,7 +385,7 @@ class BISACClassifier(Classifier):
         m(Historical_Fiction, anything, "Historical"),
         m(Humorous_Fiction, fiction, "Humorous"),
         m(Humorous_Fiction, fiction, "Satire"),
-        m(Literary_Fiction, fiction, "Literary"),
+        m(General_Fiction, fiction, "Literary"),
         m(LGBTQ_Fiction, fiction, "Gay"),
         m(LGBTQ_Fiction, fiction, "Lesbian"),
         m(LGBTQ_Fiction, fiction, "Gay & Lesbian"),

--- a/core/classifier/keyword.py
+++ b/core/classifier/keyword.py
@@ -575,7 +575,7 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         Literary_Criticism: match_kw(
             "criticism, interpretation",
         ),
-        Literary_Fiction: match_kw(
+        General_Fiction: match_kw(
             "literary",
             "literary fiction",
             "general fiction",

--- a/tests/api/finland/test_loan_excel_export.py
+++ b/tests/api/finland/test_loan_excel_export.py
@@ -28,7 +28,7 @@ LOAN_DB_FIXTURE = [
         "sort_author": "Eliot, George",
         "publisher": "Standard Ebooks",
         "language": "eng",
-        "genres": ["Literary Fiction"],
+        "genres": ["General Fiction"],
         "contributors": ["Eliot, George (Author)", "Fake contributor (Author)"],
         "location": None,
         "library_name": "Open Access Library",

--- a/tests/core/classifiers/test_keyword.py
+++ b/tests/core/classifiers/test_keyword.py
@@ -154,3 +154,5 @@ class TestKeyword:
         assert None == Keyword.genre(None, "Fiction/Urban")
 
         assert classifier.Folklore == Keyword.genre(None, "fables")
+
+        assert classifier.General_Fiction == Keyword.genre(None, "literary fiction")

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -3290,7 +3290,7 @@ class FilterFixture:
     """A fixture preconfigured with data for testing filters."""
 
     transaction: DatabaseTransactionFixture
-    literary_fiction: Genre
+    general_fiction: Genre
     fantasy: Genre
     horror: Genre
     best_sellers: CustomList
@@ -3302,7 +3302,7 @@ class FilterFixture:
         data.transaction = transaction
         session = transaction.session
         # Look up three Genre objects which can be used to make filters.
-        data.literary_fiction, ignore = Genre.lookup(session, "Literary Fiction")
+        data.general_fiction, ignore = Genre.lookup(session, "General Fiction")
         data.fantasy, ignore = Genre.lookup(session, "Fantasy")
         data.horror, ignore = Genre.lookup(session, "Horror")
 
@@ -3407,17 +3407,17 @@ class TestFilter:
         assert [] == Filter(genre_restriction_sets=[]).genre_restriction_sets
         assert [] == Filter(genre_restriction_sets=None).genre_restriction_sets
 
-        # Restrict to books that are literary fiction AND (horror OR
+        # Restrict to books that are general fiction AND (horror OR
         # fantasy).
         restricted = Filter(
             genre_restriction_sets=[
                 [data.horror, data.fantasy],
-                [data.literary_fiction],
+                [data.general_fiction],
             ]
         )
         assert [
             [data.horror.id, data.fantasy.id],
-            [data.literary_fiction.id],
+            [data.general_fiction.id],
         ] == restricted.genre_restriction_sets
 
         # This is a restriction: 'only books that have no genre'
@@ -3516,7 +3516,7 @@ class TestFilter:
 
         # This lane inherits most of its configuration from its parent.
         inherits = transaction.lane(display_name="Child who inherits", parent=parent)
-        inherits.genres = [data.literary_fiction]
+        inherits.genres = [data.general_fiction]
         inherits.customlists = [data.staff_picks]
 
         class Mock:
@@ -3778,10 +3778,10 @@ class TestFilter:
         # We want books by a specific author.
         filter.author = ContributorData(sort_name="Ebrity, Sel")
 
-        # We want books that are literary fiction, *and* either
+        # We want books that are general fiction, *and* either
         # fantasy or horror.
         filter.genre_restriction_sets = [
-            [data.literary_fiction],
+            [data.general_fiction],
             [data.fantasy, data.horror],
         ]
 
@@ -3852,13 +3852,13 @@ class TestFilter:
         assert filter.author_filter == contributor_filter
 
         # The genre restrictions are also expressed as nested filters.
-        literary_fiction_filter, fantasy_or_horror_filter = nested.pop("genres")
+        general_fiction_filter, fantasy_or_horror_filter = nested.pop("genres")
 
         # There are two different restrictions on genre, because
         # genre_restriction_sets was set to two lists of genres.
         assert {
-            "terms": {"genres.term": [data.literary_fiction.id]}
-        } == literary_fiction_filter.to_dict()
+            "terms": {"genres.term": [data.general_fiction.id]}
+        } == general_fiction_filter.to_dict()
         assert {
             "terms": {"genres.term": [data.fantasy.id, data.horror.id]}
         } == fantasy_or_horror_filter.to_dict()


### PR DESCRIPTION
## Description

Replace Literary Fiction with General Fiction.

## Motivation and Context

Literary Fiction isn't a preferred classification name so it needed to be replaced with General Fiction instead.

## How Has This Been Tested?

Unit tests and checking imported collection locally with pgadmin. Screenshot in the Jira ticket.

## Checklist

- [x] I have updated the documentation accordingly. (no documentation needed)
- [x] All new and existing tests passed.
