### PR TITLE
Ekir 384 handle null contributor names

### DIFF
--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -353,7 +353,7 @@ class ContributorData:
         """Try as hard as possible to find this person's sort name."""
         if self.sort_name:
             return True
-
+        # This shouldn't happen but let's keep this error
         if not self.display_name:
             raise ValueError(
                 "Cannot find sort name for a contributor with no display name!"

--- a/core/model/contributor.py
+++ b/core/model/contributor.py
@@ -202,11 +202,10 @@ class Contributor(Base):
             Contributor.aliases.name: aliases,
             Contributor.extra.name: extra,
         }
-
+        # This situation should not happen anymore so replace error with warning log.
         if not sort_name and not lc and not viaf:
-            raise ValueError(
-                "Cannot look up a Contributor without any identifying "
-                "information whatsoever!"
+            logging.warning(
+                "Contributor without any identifying " "information whatsoever!"
             )
 
         if sort_name and not lc and not viaf:

--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -19,6 +19,7 @@ from webpub_manifest_parser.core.ast import (
     Manifestlike,
 )
 from webpub_manifest_parser.core.properties import BooleanProperty
+from webpub_manifest_parser.core.syntax import MissingPropertyError
 from webpub_manifest_parser.errors import BaseError
 from webpub_manifest_parser.opds2 import (
     ManifestParser,
@@ -1099,6 +1100,8 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
         :param feed: OPDS 2.0 feed
         :param feed_url: Feed URL used to resolve relative links
         """
+        from webpub_manifest_parser.core.ast import Contributor
+
         parser_result = self._parser.parse_manifest(feed)
         feed = parser_result.root
         publication_metadata_dictionary = {}
@@ -1138,6 +1141,15 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
                     recognized_identifier
                 ):
                     self._record_publication_unrecognizable_identifier(publication)
+                    # In the case of missing name properties of a Contributor, we proceed to not record them.
+                if (
+                    isinstance(error, MissingPropertyError)
+                    and isinstance(error.node, Contributor)
+                    and not error.node.name
+                ):
+                    self.log.info(
+                        f"Publication # {recognized_identifier} ({publication.metadata.title}) Contributor was missing name property values but this error is skipped."
+                    )
                 else:
                     self._record_coverage_failure(
                         failures, recognized_identifier, error.error_message

--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -436,6 +436,18 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
                 wikipedia_name=None,
                 roles=contributor.roles if contributor.roles else default_role,
             )
+            # If the feed is missing contributor name information, record the information to our metadata
+            if (
+                contributor_metadata.sort_name is None
+                and contributor_metadata.display_name is None
+            ):
+                contributor_metadata.sort_name = Edition.UNKNOWN_AUTHOR
+                contributor_metadata.display_name = Edition.UNKNOWN_AUTHOR
+                self.log.info(
+                    "Extracted contributor metadata with missing name from {}: {}".format(
+                        encode(contributor), encode(contributor_metadata)
+                    )
+                )
 
             self.log.debug(
                 "Finished extracting contributor metadata from {}: {}".format(

--- a/tests/core/files/opds2/feed.json
+++ b/tests/core/files/opds2/feed.json
@@ -140,7 +140,7 @@
         }
       ]
     },
-        {
+    {
       "metadata": {
         "identifier": "urn:proquest.com/document-id/181639",
         "@type": "http://schema.org/Book",
@@ -203,6 +203,76 @@
           "type": "image/jpeg",
           "height": 350,
           "width": 250
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "@type": "http://schema.org/Book",
+        "title": "Test Book with author null",
+        "author": {
+          "name": null
+      },
+        "description": "Test Book description with author null",
+        "identifier": "urn:isbn:9789523565593",
+        "language": [
+          "eng"
+        ],
+        "publisher": {
+          "name": "Test Publisher"
+        },
+        "published": "2014-09-28T00:00:00Z",
+        "modified": "2015-09-29T17:00:00Z",
+        "subject": [
+          {
+            "scheme": "http://schema.org/audience",
+            "code": "juvenile-fiction",
+            "name": "Juvenile Fiction",
+            "links": []
+          }
+        ]
+      },
+      "links": [
+        {
+          "type": "application/opds-publication+json",
+          "rel": "http://opds-spec.org/acquisition/borrow",
+          "href": "http://example.org/huckleberry-finn",
+          "properties": {
+            "availability": {
+              "state": "available"
+            },
+            "indirectAcquisition": [
+              {
+                "type": "application/vnd.adobe.adept+xml",
+                "child": [
+                  {
+                    "type": "application/epub+zip"
+                  }
+                ]
+              },
+              {
+                "type": "application/vnd.readium.lcp.license.v1.0+json",
+                "child": [
+                  {
+                    "type": "application/epub+zip"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "rel": "http://opds-spec.org/acquisition/sample",
+          "type": "application/epub+zip",
+          "href": "https://example.com/medias/e5/318061475b11cf8c8e3752da2a1cf68384d8bf.epub"
+        }
+      ],
+      "images": [
+        {
+          "href": "http://example.org/cover.jpg",
+          "type": "image/jpeg",
+          "height": 1400,
+          "width": 800
         }
       ]
     }


### PR DESCRIPTION
## Description

If an OPDS2 feed publication has an `author` but the `name` value in `null`, import the author's name as `[Unknown]` to Circulation.

## Motivation and Context

When the name of a contributor was missing, it raised an error which prevented a book's import into Circulation. This PR changes the functionality so that 
- When a name property of a webpub_manifest_parser Contributor object is missing, the missing properties are saved as `[Unknown]` values into Circulation's contributor data.
- Since the missing properties caused an error during the parser's extraction, that error is no longer recorded as a coverage fail which lead to the book not being imported to Circulation.
- The functionality for edited books without an author is kept intact.

## How Has This Been Tested?

Based on unit tests since our test feed doesn't contain an appropriate item.

## Checklist

- [x] I have updated the documentation accordingly --> Backend documentation updated in Kupoli.
- [x] All new and existing tests passed --> Added some test cases also for existing ones to clarify edited books' author handling.
- [ ] Transifex translators have been notified. ---> Not yet, only once we figure out how new or modified strings are uploaded to Transifex.
