### PR TITLE
Ekirjasto 20 excel export: add "isfiction" classification to report

### DIFF
--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -82,6 +82,7 @@ class LocalAnalyticsExporter:
         header = [
             "Tekijä (aakkostus)",
             "Nimeke",
+            "Fiktio",
             "Tunniste",
             "Tunnisteen tyyppi",
             "Kirjasto",
@@ -108,6 +109,8 @@ class LocalAnalyticsExporter:
                     row.get("sort_author", ""),
                     # Nimeke
                     row.get("sort_title", ""),
+                    # Fiktio
+                    "fiktio" if row.get("fiction") else "ei-fiktio",
                     # Tunniste
                     row.get("identifier", ""),
                     # Tunnisteen tyyppi
@@ -385,6 +388,10 @@ class LocalAnalyticsExporter:
                     Identifier.type.label("identifier_type"),
                     Edition.sort_title,
                     Edition.sort_author,
+                    case(
+                        [(Work.fiction == True, True)],
+                        else_=False,
+                    ).label("fiction"),
                     Work.id.label("work_id"),
                     Edition.publisher,
                     Edition.language,
@@ -505,6 +512,7 @@ class LocalAnalyticsExporter:
                 events.identifier_type,
                 events.sort_title,
                 events.sort_author,
+                events.fiction,
                 events.publisher,
                 events.language,
                 genres.label("genres"),

--- a/tests/api/finland/test_loan_excel_export.py
+++ b/tests/api/finland/test_loan_excel_export.py
@@ -26,6 +26,7 @@ LOAN_DB_FIXTURE = [
         "identifier_type": "URI",
         "sort_title": "Silas Marner",
         "sort_author": "Eliot, George",
+        "fiction": "fiction",
         "publisher": "Standard Ebooks",
         "language": "eng",
         "genres": ["Literary Fiction"],
@@ -34,6 +35,21 @@ LOAN_DB_FIXTURE = [
         "library_name": "Open Access Library",
         "medium": "Book",
         "count": 8,
+    },
+     {
+        "identifier": "https://standardebooks.org/ebooks/bertrand-russell/roads-to-freedom",
+        "identifier_type": "URI",
+        "sort_title": "Roads to Freedom",
+        "sort_author": "Russell, Bertrand",
+        "fiction": "non-fiction",
+        "publisher": "Standard Ebooks",
+        "language": "eng",
+        "genres": ["Philosophy"],
+        "contributors": ["Russell, Bertrand (Author)"],
+        "location": None,
+        "library_name": "Open Access Library",
+        "medium": "Book",
+        "count": 2,
     },
 ]
 
@@ -60,6 +76,7 @@ class TestExcelExport(unittest.TestCase):
         expected_headers = (
             "Tekijä (aakkostus)",
             "Nimeke",
+            "Fiktio",
             "Tunniste",
             "Tunnisteen tyyppi",
             "Kirjasto",

--- a/tests/api/finland/test_loan_excel_export.py
+++ b/tests/api/finland/test_loan_excel_export.py
@@ -36,7 +36,7 @@ LOAN_DB_FIXTURE = [
         "medium": "Book",
         "count": 8,
     },
-     {
+    {
         "identifier": "https://standardebooks.org/ebooks/bertrand-russell/roads-to-freedom",
         "identifier_type": "URI",
         "sort_title": "Roads to Freedom",


### PR DESCRIPTION
## Description

Added Fiction/on-fiction row to excel exporter

## Motivation and Context

[EKIRJASTO-20](https://jira.it.helsinki.fi/browse/EKIRJASTO-20)

## How Has This Been Tested?

Tested on local circulation instance using development environment databases.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
- [ ] Transifex translators have been notified.
