### PR TITLE
Ekirjasto 18 show failed items during opds import

### DIFF
--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -1958,6 +1958,13 @@ class OPDSImportMonitor(CollectionMonitor):
         return reversed(feeds)
 
     def run_once(self, progress: TimestampData) -> TimestampData:
+        """
+        Import all books in a feed.
+
+        :param progress: A TimestampData object indicating the start time of the run.
+        :return: A new TimestampData object with an achievements field
+            containing details of the operation.
+        """
         feeds = self._get_feeds()
         total_imported = 0
         total_failures = 0

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -1961,17 +1961,19 @@ class OPDSImportMonitor(CollectionMonitor):
         feeds = self._get_feeds()
         total_imported = 0
         total_failures = 0
+        failure_summary = []
 
         for link, feed in feeds:
             self.log.info("Importing next feed: %s", link)
             imported_editions, failures = self.import_one_feed(feed)
             total_imported += len(imported_editions)
             total_failures += len(failures)
+            for failure_id, failure_details in failures.items():
+                failure_summary.append(f"ISBN: {failure_id}: {failure_details}")
             self._db.commit()
-
-        achievements = "Items imported: %d. Failures: %d." % (
-            total_imported,
-            total_failures,
+        achievements = (
+            "Items imported: %d. Failures: %d.\nFailed IDs and details:\n%s"
+            % (total_imported, total_failures, "\n".join(failure_summary))
         )
 
         return TimestampData(achievements=achievements)

--- a/tests/core/test_opds_import.py
+++ b/tests/core/test_opds_import.py
@@ -1948,7 +1948,7 @@ class TestOPDSImportMonitor:
             collection=collection,
         )
         assert "Utter failure!" in failure.exception
-
+        print(failures)
         # Both failures were reported in the return value from
         # import_one_feed
         assert 2 == len(failures)
@@ -1992,7 +1992,9 @@ class TestOPDSImportMonitor:
         assert ["last page", "second page", "first page"] == monitor.imports
 
         # Every page of the import had two successes and one failure.
-        assert "Items imported: 6. Failures: 3." == progress.achievements
+        assert (
+            "Items imported: 6. Failures: 3.\nFailed IDs and details:\nISBN: identifier: Failure\nISBN: identifier: Failure\nISBN: identifier: Failure"
+        ) == progress.achievements
 
         # The TimestampData returned by run_once does not include any
         # timing information; that's provided by run().


### PR DESCRIPTION
## Description

This PR adds information to log a message about OPDS feed titles that fail during import.

## Motivation and Context

When an OPDS feed is imported, it logs information about how many titles are imported and how many fail. However, it does not log what titles fail and what causes them to fail. 
The log message in the admin UI in admin/web/troubleshooting/diagnostics/monitor under odl2 import monitor now shows which ISBNs fail and any recorded error message.

## How Has This Been Tested?

Tested locally with new feed that contains one failing title.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. --> N/A
