### PR TITLE
EKIR-220 Enable classification always

### DIFF
--- a/core/classifier/__init__.py
+++ b/core/classifier/__init__.py
@@ -1112,9 +1112,11 @@ class WorkClassifier:
         if self.debug:
             self.classifications.append(classification)
 
-        # Make sure the Subject is ready to be used in calculations.
-        if not classification.subject.checked:  # or self.debug
-            classification.subject.assign_to_genre()
+        # E-kirjasto: Commenting out the below check but leaving
+        # it in case we want to use it later. We want to force classification
+        # for all subjects so that they are up to date.
+        # if not classification.subject.checked  # or self.debug
+        classification.subject.assign_to_genre()
 
         if classification.comes_from_license_source:
             self.direct_from_license_source.add(classification)

--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -1571,6 +1571,9 @@ class Metadata:
                         # to do anything.
                         del new_subjects[key]
                         surviving_classifications.append(classification)
+                        # E-kirjasto: We want to re-classify all existing
+                        # classifications.
+                        work_requires_full_recalculation = True
                 else:
                     # This classification comes from some other data
                     # source.  Don't mess with it.


### PR DESCRIPTION
## Description

Re-classify (assign a genre to a subject) imported works always.

## Motivation and Context

Genres for a work were not updated despite changing the assignment of a new genre for a subject. This was due to two things: During OPDS import, existing subjects were considered ok, and secondly that a subject once assigned to a genre was considered final. The code now marks each work subjects to be marked for classification, and forces each subject to go through subject-genre assignment.

## How Has This Been Tested?

Local circ:
- Database checks of genres and subjects (and lanes) for works after OPDS import and work_classification script runs.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. --> N/A
