### PR TITLE
Recalculate fiction and genres

### DIFF
--- a/core/classifier/__init__.py
+++ b/core/classifier/__init__.py
@@ -797,7 +797,7 @@ class GenreData:
         self.audience_restriction = audience_restriction
 
     def __repr__(self):
-        return "<GenreData: %s fiction=%s>" % (self.name, self.is_fiction)
+        return f"<GenreData: {self.name} fiction={self.is_fiction}>"
 
     @property
     def self_and_subgenres(self):
@@ -1578,7 +1578,6 @@ class WorkClassifier:
                 # If there's only one genre, we don't want to lose it or its
                 # fiction status.
                 else:
-                    # 
                     fiction = genre.default_fiction
 
         # Consolidate parent genres into their heaviest subgenre.

--- a/core/classifier/__init__.py
+++ b/core/classifier/__init__.py
@@ -1590,6 +1590,8 @@ class WorkClassifier:
         """A helper method that ensure we always use database Genre
         objects, not GenreData objects, when weighting genres.
         """
+        # TO DO: E-kirjasto: This function is mostly used to weigh
+        # a genre based on its publisher. Could be teared down.
         try:
             from core.model import Genre
         except ValueError:

--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -387,6 +387,14 @@ class BISACClassifier(Classifier):
         m(Adventure, fiction, "War & Military"),
         m(Classics, fiction, "Classics"),
         m(Folklore, fiction, "Fairy Tales, Folk Tales, Legends & Mythology"),
+        m(Music, nonfiction, "Biography & Autobiography", "Music"),
+        m(
+            Entertainment,
+            nonfiction,
+            "Biography & Autobiography",
+            "Entertainment & Performing Arts",
+        ),
+        m(Biography_Memoir, nonfiction, "Biography & Autobiography"),
         m(Historical_Fiction, anything, "Historical"),
         m(Humorous_Fiction, fiction, "Humorous"),
         m(Humorous_Fiction, fiction, "Satire"),
@@ -528,14 +536,6 @@ class BISACClassifier(Classifier):
         # Then handle the less complicated genres of nonfiction.
         # n.b. no BISAC for Periodicals.
         # n.b. no BISAC for Humorous Nonfiction per se.
-        m(Music, nonfiction, "Biography & Autobiography", "Music"),
-        m(
-            Entertainment,
-            nonfiction,
-            "Biography & Autobiography",
-            "Entertainment & Performing Arts",
-        ),
-        m(Biography_Memoir, nonfiction, "Biography & Autobiography"),
         m(Education, nonfiction, "Education"),
         m(Philosophy, nonfiction, "Philosophy"),
         m(Political_Science, nonfiction, "Political Science"),
@@ -669,7 +669,7 @@ class BISACClassifier(Classifier):
         m(Historical_Fiction, fiction, "World Literature", something, "18th Century"),
         m(Historical_Fiction, fiction, "World Literature", something, "19th Century"),
         m(General_Fiction, fiction, "World Literature"),
-        m(General_Fiction, fiction, "General")
+        m(General_Fiction, fiction, "General"),
     ]
 
     @classmethod

--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -669,7 +669,7 @@ class BISACClassifier(Classifier):
         m(Historical_Fiction, fiction, "World Literature", something, "18th Century"),
         m(Historical_Fiction, fiction, "World Literature", something, "19th Century"),
         m(General_Fiction, fiction, "World Literature"),
-        m(General_Fiction, fiction, "General")
+        m(General_Fiction, fiction, "General"),
     ]
 
     @classmethod

--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -272,6 +272,7 @@ class BISACClassifier(Classifier):
         m(stop, "Humor"),
         m(stop, "Drama"),
         m(True, "Poetry"),
+        m(True, "Comics & Graphic Novels"),
         m(False, anything),
     ]
 
@@ -726,8 +727,12 @@ class BISACClassifier(Classifier):
     def scrub_identifier(cls, identifier):
         if not identifier:
             return identifier
+        # Feedbooks can use prefix FB
         if identifier.startswith("FB"):
             identifier = identifier[2:]
+        # And Feedbooks can use postfix N
+        if identifier.endswith("N"):
+            identifier = identifier[:-1]
         if identifier in cls.NAMES:
             # We know the canonical name for this BISAC identifier,
             # and we are better equipped to classify the canonical

--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -669,6 +669,7 @@ class BISACClassifier(Classifier):
         m(Historical_Fiction, fiction, "World Literature", something, "18th Century"),
         m(Historical_Fiction, fiction, "World Literature", something, "19th Century"),
         m(General_Fiction, fiction, "World Literature"),
+        m(General_Fiction, fiction, "General")
     ]
 
     @classmethod

--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -302,9 +302,9 @@ class BISACClassifier(Classifier):
         m(Erotica, anything, "Erotica"),
         # Put all non-erotica comics into the same bucket, regardless
         # of their content.
-        m(Comics_Graphic_Novels, "Comics & Graphic Novels"),
-        m(Comics_Graphic_Novels, nonfiction, "Comics & Graphic Novels"),
         m(Comics_Graphic_Novels, fiction, "Comics & Graphic Novels"),
+        # TO DO: What should nonfiction comics be assigned to?
+        m(Comics_Graphic_Novels, nonfiction, "Comics & Graphic Novels"),
         # "Literary Criticism / Foo" implies Literary Criticism, not Foo.
         m(Literary_Criticism, anything, literary_criticism),
         # "Fiction / Christian / Foo" implies Religious Fiction
@@ -669,7 +669,7 @@ class BISACClassifier(Classifier):
         m(Historical_Fiction, fiction, "World Literature", something, "18th Century"),
         m(Historical_Fiction, fiction, "World Literature", something, "19th Century"),
         m(General_Fiction, fiction, "World Literature"),
-        m(General_Fiction, fiction, "General"),
+        m(General_Fiction, fiction, "General")
     ]
 
     @classmethod

--- a/core/model/classification.py
+++ b/core/model/classification.py
@@ -507,14 +507,14 @@ class Genre(Base, HasSessionCache):
             len(self.works),
             length,
         )
-        genre_data += "\n  <Subjects: %s>" % (
-            ", ".join(
-                [
-                    f"{subject.name} ({subject.type}, {subject.identifier})"
-                    for subject in self.subjects
-                ]
-            )
-        )
+        # genre_data += "\n  <Subjects: %s>" % (
+        #     ", ".join(
+        #         [
+        #             f"{subject.name} ({subject.type}, {subject.identifier})"
+        #             for subject in self.subjects
+        #         ]
+        #     )
+        # )
 
         return genre_data
 

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1331,7 +1331,19 @@ class Work(Base):
         return classification_changed
 
     def assign_genres_from_weights(self, genre_weights):
-        # Assign WorkGenre objects to the remainder.
+        """
+        Assigns genres to a work based on existing genre associations.
+
+        This method updates the work's genres by removing any genres that are no longer
+        associated with the work and adding any new genres that are not already
+        associated.
+
+        Returns:
+            tuple: A tuple containing the updated list of genres and a boolean
+                indicating whether any changes were made.
+        """
+        # TO DO: E-kirjasto: Tear down the need for passing in weights because we won't
+        # be using them.
         from core.model.classification import Genre
 
         changed = False

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1336,14 +1336,12 @@ class Work(Base):
 
         changed = False
         _db = Session.object_session(self)
-        total_genre_weight = float(sum(genre_weights.values()))
         workgenres = []
         current_workgenres = _db.query(WorkGenre).filter(WorkGenre.work == self)
         by_genre = dict()
         for wg in current_workgenres:
             by_genre[wg.genre] = wg
         for g, score in list(genre_weights.items()):
-            affinity = score / total_genre_weight
             if not isinstance(g, Genre):
                 g, ignore = Genre.lookup(_db, g.name)
             if g in by_genre:
@@ -1352,9 +1350,8 @@ class Work(Base):
                 del by_genre[g]
             else:
                 wg, is_new = get_one_or_create(_db, WorkGenre, work=self, genre=g)
-            if is_new or round(wg.affinity, 2) != round(affinity, 2):
+            if is_new:
                 changed = True
-            wg.affinity = affinity
             workgenres.append(wg)
 
         # Any WorkGenre objects left over represent genres the Work
@@ -1365,7 +1362,6 @@ class Work(Base):
 
         # ensure that work_genres is up to date without having to read from database again
         self.work_genres = workgenres
-
         return workgenres, changed
 
     def assign_appeals(self, character, language, setting, story, cutoff=0.20):

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,157 @@
+version: "3.9"
+
+# Common CM setup
+# see: https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
+x-cm-variables: &cm
+  platform: "${BUILD_PLATFORM-}"
+  environment:
+    SIMPLIFIED_PRODUCTION_DATABASE: "postgresql://palace:test@postgres:5432/circ"
+    PALACE_SEARCH_URL: "http://opensearch:9200"
+    PALACE_STORAGE_ACCESS_KEY: "palace"
+    PALACE_STORAGE_SECRET_KEY: "test123456789"
+    PALACE_STORAGE_ENDPOINT_URL: "http://minio:9000"
+    PALACE_STORAGE_PUBLIC_ACCESS_BUCKET: "public"
+    PALACE_STORAGE_ANALYTICS_BUCKET: "analytics"
+    PALACE_STORAGE_URL_TEMPLATE: "http://minio:9000/{bucket}/{key}"
+    PALACE_REPORTING_NAME: "TEST CM"
+    PALACE_OPENSEARCH_ANALYTICS_ENABLED: true
+    PALACE_OPENSEARCH_ANALYTICS_URL: "http://opensearch:9200/"
+    PALACE_OPENSEARCH_ANALYTICS_INDEX_PREFIX: "circulation-events"
+    EKIRJASTO_TOKEN_SIGNING_SECRET: "234"
+    EKIRJASTO_TOKEN_ENCRYPTING_SECRET: "321"
+    ADMIN_EKIRJASTO_AUTHENTICATION_URL: "https://" # Apply actual dev url
+
+  depends_on:
+    pg:
+      condition: service_healthy
+    minio:
+      condition: service_healthy
+    os:
+      condition: service_healthy
+
+x-cm-build: &cm-build
+  context: .
+  dockerfile: docker/Dockerfile
+  args:
+    - BASE_IMAGE=${BUILD_BASE_IMAGE-ghcr.io/natlibfi/ekirjasto-circ-baseimage:latest}
+  cache_from:
+    - ${BUILD_CACHE_FROM-ghcr.io/natlibfi/ekirjasto-circ-webapp:main}
+
+services:
+  # docker compose configuration
+  # with permanent storage volumes for database and search index
+  # + pgadmin & opensearch dashboard (remove if you don't need them)
+  webapp:
+    <<: *cm
+    build:
+      <<: *cm-build
+      target: webapp
+    ports:
+      - "6500:80"
+
+
+  scripts:
+      container_name: scripts
+      <<: *cm
+      build:
+        <<: *cm-build
+        target: scripts
+
+  pg:
+    image: "postgres:12"
+    container_name: postgres
+    environment:
+      POSTGRES_USER: palace
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: circ
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U palace -d circ"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+    ports:
+      - "5432:5432"
+    volumes:
+      - "$HOME/src/circ_psql_data:/var/lib/postgresql/data"
+
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: root
+      PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION: "False"
+    ports:
+      - "5050:80"
+
+  minio:
+    image: "bitnami/minio:2023.2.27"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: "palace"
+      MINIO_ROOT_PASSWORD: "test123456789"
+      MINIO_SCHEME: "http"
+      MINIO_DEFAULT_BUCKETS: "public:download,analytics"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  os:
+    container_name: opensearch
+    build:
+      dockerfile: docker/Dockerfile.ci
+      target: opensearch
+      context: .
+    environment:
+      discovery.type: "single-node"
+      DISABLE_SECURITY_PLUGIN: "true"
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: curl --silent http://localhost:9200 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+      - $HOME/src/circ_os_data:/usr/share/opensearch/data
+
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:1.3.19
+    container_name: opensearch-dashboards
+    ports:
+      - "5601:5601"
+    expose:
+      - "5601"
+    environment:
+      cluster.routing.allocation.disk.threshold_enabled: false
+      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: true
+
+  data-api:
+    image: ghcr.io/natlibfi/ekirjasto-data-api:main
+    container_name: data-api
+    #platform: linux/x86_64
+    environment:
+      POSTGRES_URL: "postgresql://palace:test@postgres:5432/circ"
+      OPENSEARCH_URL: "http://opensearch:9200"
+      OPENSEARCH_EVENT_INDEX: "circulation-events-v1"
+      OPENSEARCH_WORK_INDEX: "circulation-works-v5"
+      ROOT_PATH: "/abu"
+
+    ports:
+      - "8000:80"
+    expose:
+      - "8000"
+    networks:
+      - circ-net
+
+networks:
+  circ-net:
+
+volumes:
+  circ-postgres-postrelease:
+  circ-opensearch-postrelease:

--- a/tests/core/classifiers/test_bisac.py
+++ b/tests/core/classifiers/test_bisac.py
@@ -1133,7 +1133,9 @@ class TestBISACClassifier:
         genre_is("YOUNG ADULT NONFICTION / Places / Middle East", None)
         genre_is("YOUNG ADULT NONFICTION / Places / United States", None)
         genre_is("YOUNG ADULT NONFICTION / Recycling & Green Living", None)
-        genre_is("YOUNG ADULT NONFICTION / Volunteering", None)
+        genre_is("FICTION / Mystery & Detective / Amateur Sleuth", "Mystery")
+        genre_is("BIOGRAPHY & AUTOBIOGRAPHY / Historical", "Biography & Memoir")
+        genre_is("FICTION / General", "General Fiction")
 
     def test_deprecated_bisac_terms(self):
         """These BISAC terms have been deprecated. We classify them

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -546,13 +546,13 @@ class TestWork:
         work.assign_genres_from_weights({Romance: 1000, Fantasy: 1000})
         db.session.commit()
         before = sorted((x.genre.name, x.affinity) for x in work.work_genres)
-        assert [("Fantasy", 0.5), ("Romance", 0.5)] == before
+        assert [("Fantasy", 0.0), ("Romance", 0.0)] == before
 
         # But now it's classified under Science Fiction and Romance.
         work.assign_genres_from_weights({Romance: 100, Science_Fiction: 300})
         db.session.commit()
         after = sorted((x.genre.name, x.affinity) for x in work.work_genres)
-        assert [("Romance", 0.25), ("Science Fiction", 0.75)] == after
+        assert [("Romance", 0.0), ("Science Fiction", 0.0)] == after
 
     def test_classifications_with_genre(self, db: DatabaseTransactionFixture):
         work = db.work(with_open_access_download=True)


### PR DESCRIPTION
## Description

Feedbooks BISAC codes with postfix "N" are now mapped to circulation's BISAC codes.
Some BISAC subjects are mapped to their appropriate genres (comics, autobiographies, general fiction).
Fiction status is reassessed when assessing all found genres. If a work only has one genre, the fiction status will be determined by that genre's fiction status.
Calculating genre weights is left out in most part of the code now.

Also, commiting our docker compose file for development so it's available for everyone.

## Motivation and Context

We had noticed that a lot of works were missing genre(s) despite having BISAC codes in the feed, and that their fiction status was either None or incorrect. After these fixes, there's only some juvanile and YA works still missing genres but we'll address those in later PRs.

## How Has This Been Tested?

Locally reclassifying our productions feeds and also comparing the results with our production works' classifications.

## Checklist

Locally reclassifying our productions feeds and comparing the results with our production works' classifications.

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. --N/A
