### PR TITLE
Ekir 197 handle loan and concurrency limited licensepools

### DIFF
--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -85,9 +85,21 @@ class LicenseFunctions:
 
     @property
     def total_remaining_loans(self) -> int | None:
+        """
+        The total number of loans available for this License.
+        :return: `None` if the license is not limited by the number of checkouts
+                (=loans), otherwise the number of remaining loans, taking into account
+                both the total number of remaining checkouts and the concurrency limit.
+        """
         if self.is_inactive:
             return 0
         elif self.is_loan_limited:
+            if self.terms_concurrency is not None:
+                # We need a type ignore here because mypy doesn't understand that
+                # `is_loan_limited` implies `checkouts_left` is not None.
+                # For any loan limited license, there's always the tracker for
+                # checkouts_left.
+                return min(self.checkouts_left, self.terms_concurrency)  # type: ignore[type-var]
             return self.checkouts_left
         else:
             return self.terms_concurrency

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -1607,8 +1607,8 @@ class TestODLImporter:
         assert DeliveryMechanism.ADOBE_DRM == lpdm.delivery_mechanism.drm_scheme
         assert RightsStatus.IN_COPYRIGHT == lpdm.rights_status.uri
         assert (
-            52 == warrior_pool.licenses_owned
-        )  # 52 remaining checkouts in the License Info Document
+            1 == warrior_pool.licenses_owned
+        )  # 52 remaining checkouts in the License Info Document but also care about concurrency
         assert 1 == warrior_pool.licenses_available
         [license] = warrior_pool.licenses
         assert "1" == license.identifier
@@ -1633,7 +1633,7 @@ class TestODLImporter:
         )
         assert (
             52 == license.checkouts_left
-        )  # 52 remaining checkouts in the License Info Document
+        )  # 52 remaining checkouts in the License Info Document but only 1 concurrent user
         assert 1 == license.checkouts_available
 
         # This item is an open access audiobook.
@@ -1680,7 +1680,8 @@ class TestODLImporter:
         assert DeliveryMechanism.ADOBE_DRM == lpdm.delivery_mechanism.drm_scheme
         assert RightsStatus.IN_COPYRIGHT == lpdm.rights_status.uri
         assert (
-            41 == canadianity_pool.licenses_owned
+            11
+            == canadianity_pool.licenses_owned  # 10+1 now that concurrency is also accounted
         )  # 40 remaining checkouts + 1 perpetual license in the License Info Documents
         assert 11 == canadianity_pool.licenses_available
         [license1, license2] = sorted(
@@ -1729,7 +1730,7 @@ class TestODLImporter:
             lpdm.rights_status.uri for lpdm in lpdms
         ]
         assert (
-            72 == midnight_pool.licenses_owned
+            2 == midnight_pool.licenses_owned
         )  # 20 + 52 remaining checkouts in corresponding License Info Documents
         assert 2 == midnight_pool.licenses_available
         [license1, license2] = sorted(
@@ -1955,7 +1956,7 @@ class TestOdlAndOdl2Importer:
         assert len(imported_pool.licenses) == 5
 
         # Make sure that the license statistics are correct and include only active licenses.
-        assert imported_pool.licenses_owned == 41
+        assert imported_pool.licenses_owned == 6
         assert imported_pool.licenses_available == 6
 
         # Correct number of active and inactive licenses
@@ -2000,7 +2001,7 @@ class TestOdlAndOdl2Importer:
             [imported_pool] = imported_pools
             assert len(imported_pool.licenses) == 3
             assert imported_pool.licenses_available == 2
-            assert imported_pool.licenses_owned == 7
+            assert imported_pool.licenses_owned == 4
 
             # No licenses are expired
             assert sum(not l.is_inactive for l in imported_pool.licenses) == len(

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -150,7 +150,9 @@ class TestODL2Importer:
         assert moby_dick_license_pool.identifier.identifier == "978-3-16-148410-0"
         assert moby_dick_license_pool.identifier.type == "ISBN"
         assert not moby_dick_license_pool.open_access
-        assert 30 == moby_dick_license_pool.licenses_owned
+        assert (
+            10 == moby_dick_license_pool.licenses_owned
+        )  # There may be 30 left but 10 concurrent users
         assert 10 == moby_dick_license_pool.licenses_available
 
         assert 2 == len(moby_dick_license_pool.delivery_mechanisms)

--- a/tests/core/models/test_licensing.py
+++ b/tests/core/models/test_licensing.py
@@ -363,8 +363,8 @@ class TestLicense:
         [
             ("perpetual", True, False, False, False, 2, 1),
             ("time_limited", False, True, False, False, 1, 1),
-            ("loan_limited", False, False, True, False, 4, 2),
-            ("time_and_loan_limited", False, True, True, False, 52, 1),
+            ("loan_limited", False, False, True, False, 3, 2),
+            ("time_and_loan_limited", False, True, True, False, 1, 1),
             ("expired_time_limited", False, True, False, True, 0, 0),
             ("expired_loan_limited", False, False, True, True, 0, 0),
             ("unavailable", True, False, False, True, 0, 0),


### PR DESCRIPTION
## Description

This is the direct implementation of Palace project's [Update license pools for ODL licenses that are loan + concurrency limited](https://github.com/ThePalaceProject/circulation/pull/2085/files#top) fix. For loan limited licensepools, the code was only checking the amount of `checkouts_left` and not `concurrency`. It now returns the minimum of those.

## Motivation and Context

Users were given false information about a book's availability: the app showed the book was loanable (because there were checkouts left) but when they tried to loan it, it turned into a hold (because all the licenses were checked out and concurrent users had been reached).

## How Has This Been Tested?

Locally and unit tests.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. --> N/A
