### PR TITLE
EKIR-219 Fix 502 response when loaning

### DIFF
--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -210,8 +210,6 @@ class LoanController(CirculationManagerController):
         except AuthorizationBlocked as e:
             result = e.as_problem_detail_document(debug=False)
         except CannotLoan as e:
-            result = CHECKOUT_FAILED.with_debug(str(e))
-        except CannotLoan as e:
             if isinstance(e, NoAvailableCopiesWhenReserved):
                 result = e.as_problem_detail_document()
             else:

--- a/api/odl.py
+++ b/api/odl.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import binascii
 import datetime
 import json
+import logging
 import uuid
 from abc import ABC
 from collections.abc import Callable
@@ -71,7 +72,7 @@ from core.opds_import import (
 from core.service.container import Services
 from core.util import base64
 from core.util.datetime_helpers import to_utc, utc_now
-from core.util.http import HTTP, BadResponseException
+from core.util.http import HTTP, BadResponseException, RemoteIntegrationException
 
 
 class ODLAPIConstants:
@@ -242,7 +243,12 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
 
         return self._hasher_instance
 
-    def _get(self, url: str, headers: dict[str, str] | None = None) -> Response:
+    def _get(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        allowed_response_codes=None,
+    ) -> Response:
         """Make a normal HTTP request, but include an authentication
         header with the credentials for the collection.
         """
@@ -322,14 +328,31 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
                 hint_url=self.settings.passphrase_hint_url,
             )
 
-        response = self._get(url)
+        try:
+            response = self._get(url, allowed_response_codes=["2xx"])
+        except BadResponseException as e:
+            response = e.response
+            header_string = ", ".join(
+                {f"{k}: {v}" for k, v in response.headers.items()}
+            )
+            response_string = (
+                response.text
+                if len(response.text) < 100
+                else response.text[:100] + "..."
+            )
+            logging.getLogger().error(
+                f"Error getting License Status Document for loan ({loan.id}):  Url '{url}' returned "
+                f"status code {response.status_code}. Expected 2XX. Response headers: {header_string}. "
+                f"Response content: {response_string}."
+            )
+            raise
 
         try:
             status_doc = json.loads(response.content)
         except ValueError as e:
-            raise BadResponseException(
+            raise RemoteIntegrationException(
                 url, "License Status Document was not valid JSON."
-            )
+            ) from e
         if status_doc.get("status") not in self.STATUS_VALUES:
             raise BadResponseException(
                 url, "License Status Document had an unknown status value."

--- a/api/odl.py
+++ b/api/odl.py
@@ -491,7 +491,29 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             raise NoAvailableCopies()
         loan, ignore = license.loan_to(patron)
 
-        doc = self.get_license_status_document(loan)
+        try:
+            doc = self.get_license_status_document(loan)
+        except BadResponseException as e:
+            _db.delete(loan)
+            response = e.response
+            # DeMarque sends "application/api-problem+json", but the ODL spec says we should
+            # expect "application/problem+json", so we need to check for both.
+            if response.headers.get("Content-Type") in [
+                "application/api-problem+json",
+                "application/problem+json",
+            ]:
+                try:
+                    json_response = response.json()
+                except ValueError:
+                    json_response = {}
+
+                if (
+                    json_response.get("type")
+                    == "http://opds-spec.org/odl/error/checkout/unavailable"
+                ):
+                    raise NoAvailableCopies()
+            raise
+
         status = doc.get("status")
 
         if status not in [self.READY_STATUS, self.ACTIVE_STATUS]:

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -545,10 +545,10 @@ class OverdriveAPI(
         if status_code == 401:
             if exception_on_401:
                 # This is our second try. Give up.
-                raise BadResponseException.from_response(
+                raise BadResponseException(
                     url,
                     "Something's wrong with the Overdrive OAuth Bearer Token!",
-                    (status_code, headers, content),
+                    response,
                 )
             else:
                 # Refresh the token and try again.

--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin, urlparse
 
 import webpub_manifest_parser.opds2.ast as opds2_ast
 from flask_babel import lazy_gettext as _
+from requests import Response
 from sqlalchemy.orm import Session
 from uritemplate import URITemplate
 from webpub_manifest_parser.core import ManifestParserFactory, ManifestParserResult
@@ -1163,20 +1164,16 @@ class OPDS2ImportMonitor(OPDSImportMonitor):
     PROTOCOL = ExternalIntegration.OPDS2_IMPORT
     MEDIA_TYPE = OPDS2MediaTypesRegistry.OPDS_FEED.key, "application/json"
 
-    def _verify_media_type(
-        self, url: str, status_code: int, headers: dict[str, str], feed: bytes
-    ) -> None:
+    def _verify_media_type(self, url: str, response: Response) -> None:
         # Make sure we got an OPDS feed, and not an error page that was
         # sent with a 200 status code.
-        media_type = headers.get("content-type")
+        media_type = response.headers.get("content-type")
         if not media_type or not any(x in media_type for x in self.MEDIA_TYPE):
             message = "Expected {} OPDS 2.0 feed, got {}".format(
                 self.MEDIA_TYPE, media_type
             )
 
-            raise BadResponseException(
-                url, message=message, debug_message=feed, status_code=status_code
-            )
+            raise BadResponseException(url, message=message, response=response)
 
     def _get_accept_header(self) -> str:
         return "{}, {};q=0.9, */*;q=0.1".format(

--- a/core/util/http.py
+++ b/core/util/http.py
@@ -82,15 +82,27 @@ class BadResponseException(RemoteIntegrationException):
         "Got status code %s from external server, cannot continue."
     )
 
-    def __init__(self, url_or_service, message, debug_message=None, status_code=None):
+    def __init__(
+        self,
+        url_or_service,
+        message,
+        response=None,
+        debug_message=None,
+        status_code=None,
+    ):
         """Indicate that a remote integration has failed.
 
         `param url_or_service` The name of the service that failed
            (e.g. "Overdrive"), or the specific URL that had the problem.
         """
+        if debug_message is None:
+            debug_message = (
+                f"Status code: {response.status_code}\nContent: {response.text}"
+            )
         super().__init__(url_or_service, message, debug_message)
         # to be set to 500, etc.
         self.status_code = status_code
+        self.response = response
 
     def document_debug_message(self, debug=True):
         if debug:

--- a/core/util/http.py
+++ b/core/util/http.py
@@ -86,23 +86,20 @@ class BadResponseException(RemoteIntegrationException):
         self,
         url_or_service,
         message,
-        response=None,
+        response=Response,
         debug_message=None,
-        status_code=None,
     ):
         """Indicate that a remote integration has failed.
 
         `param url_or_service` The name of the service that failed
            (e.g. "Overdrive"), or the specific URL that had the problem.
         """
+        self.response = response
         if debug_message is None:
             debug_message = (
                 f"Status code: {response.status_code}\nContent: {response.text}"
             )
         super().__init__(url_or_service, message, debug_message)
-        # to be set to 500, etc.
-        self.status_code = status_code
-        self.response = response
 
     def document_debug_message(self, debug=True):
         if debug:
@@ -113,37 +110,10 @@ class BadResponseException(RemoteIntegrationException):
         return None
 
     @classmethod
-    def from_response(cls, url, message, response):
-        """Helper method to turn a `requests` Response object into
-        a BadResponseException.
-        """
-        if isinstance(response, tuple):
-            # The response has been unrolled into a (status_code,
-            # headers, body) 3-tuple.
-            status_code, headers, content = response
-        else:
-            status_code = response.status_code
-            content = response.content
-        # The HTTP content response is a bytestring that we want to
-        # convert to unicode for the debug message.
-        if content and isinstance(content, bytes):
-            content = content.decode("utf-8")
-        return BadResponseException(
-            url,
-            message,
-            status_code=status_code,
-            debug_message="Status code: %s\nContent: %s"
-            % (
-                status_code,
-                content,
-            ),
-        )
-
-    @classmethod
     def bad_status_code(cls, url, response):
         """The response is bad because the status code is wrong."""
         message = cls.BAD_STATUS_CODE_MESSAGE % response.status_code
-        return cls.from_response(
+        return cls(
             url,
             message,
             response,
@@ -321,12 +291,11 @@ class HTTP(LoggerMixin):
             # a generic RequestNetworkException.
             raise RequestNetworkException(url, e)
 
-        return process_response_with(
+        return process_response_with(  # type: ignore[no-any-return]
             url,
             response,
             allowed_response_codes,
             disallowed_response_codes,
-            expected_encoding,
         )
 
     @classmethod
@@ -336,7 +305,6 @@ class HTTP(LoggerMixin):
         response,
         allowed_response_codes=None,
         disallowed_response_codes=None,
-        expected_encoding: str = "utf-8",
     ):
         """Raise a RequestNetworkException if the response code indicates a
         server-side failure, or behavior so unpredictable that we can't
@@ -350,61 +318,52 @@ class HTTP(LoggerMixin):
         :param expected_encoding Typically we expect HTTP responses to be UTF-8
             encoded, but for certain requests we can change the encoding type.
         """
-        if allowed_response_codes:
-            allowed_response_codes = list(map(str, allowed_response_codes))
-            status_code_not_in_allowed = (
-                "Got status code %%s from external server, but can only continue on: %s."
-                % (", ".join(sorted(allowed_response_codes)),)
-            )
-        if disallowed_response_codes:
-            disallowed_response_codes = list(map(str, disallowed_response_codes))
-        else:
-            disallowed_response_codes = []
-
-        code = response.status_code
-        series = cls.series(code)
-        code = str(code)
-
-        if allowed_response_codes and (
-            code in allowed_response_codes or series in allowed_response_codes
-        ):
+        allowed_response_codes_str = (
+            list(map(str, allowed_response_codes)) if allowed_response_codes else []
+        )
+        disallowed_response_codes_str = (
+            list(map(str, disallowed_response_codes))
+            if disallowed_response_codes
+            else []
+        )
+        series = cls.series(response.status_code)
+        code = str(response.status_code)
+        if code in allowed_response_codes_str or series in allowed_response_codes_str:
             # The code or series has been explicitly allowed. Allow
             # the request to be processed.
             return response
-
         error_message = None
         if (
             series == "5xx"
-            or code in disallowed_response_codes
-            or series in disallowed_response_codes
+            or code in disallowed_response_codes_str
+            or series in disallowed_response_codes_str
         ):
             # Unless explicitly allowed, the 5xx series always results in
             # an exception.
             error_message = BadResponseException.BAD_STATUS_CODE_MESSAGE
         elif allowed_response_codes and not (
-            code in allowed_response_codes or series in allowed_response_codes
+            code in allowed_response_codes_str or series in allowed_response_codes_str
         ):
-            error_message = status_code_not_in_allowed
-
+            error_message = (
+                "Got status code %%s from external server, but can only continue on: %s."
+                % (", ".join(sorted(allowed_response_codes_str)),)
+            )
         if error_message:
             raise BadResponseException(
                 url,
                 error_message % code,
-                status_code=code,
                 debug_message="Response content: %s"
-                % cls._decode_response_content(expected_encoding, response, url),
+                % cls._decode_response_content(response, url),
+                response=response,
             )
         return response
 
     @classmethod
-    def _decode_response_content(cls, expected_encoding, response, url) -> str:
-        response_content = response.content
-        if response_content and isinstance(response_content, bytes):
-            try:
-                response_content = response_content.decode(expected_encoding)
-            except Exception as e:
-                raise RequestNetworkException(url, e)
-        return response_content
+    def _decode_response_content(cls, response: Response, url: str) -> str:
+        try:
+            return response.text
+        except Exception as e:
+            raise RequestNetworkException(url, str(e)) from e
 
     @classmethod
     def series(cls, status_code):

--- a/customlists/customlist_import.py
+++ b/customlists/customlist_import.py
@@ -50,7 +50,7 @@ class CustomListImporter:
 
     @staticmethod
     def _error_response(message: str, response: Response) -> str:
-        if response.headers.get("content-type") == "application/api-problem+json":
+        if response.headers.get("Content-Type") == "application/api-problem+json":
             error_text = json.loads(response.content)
             return f"{message}: {response.status_code} {response.reason}: {error_text['title']}: {error_text['detail']}"
         else:

--- a/tests/api/files/odl/unavailable.json
+++ b/tests/api/files/odl/unavailable.json
@@ -1,0 +1,2 @@
+
+{"type":"http://opds-spec.org/odl/error/checkout/unavailable","title":"the license has reached its concurrent checkouts limit","detail":"all 1 of 1 concurrent loans exceeded","status":400}

--- a/tests/api/mockapi/mock.py
+++ b/tests/api/mockapi/mock.py
@@ -1,13 +1,7 @@
 import json
-import logging
-from collections.abc import Generator
-from contextlib import contextmanager
-from typing import Any, NamedTuple
-from unittest.mock import patch
+from typing import Any
 
 from requests import Request, Response
-
-from core.util.http import HTTP
 
 
 class MockRequestsResponse(Response):

--- a/tests/api/mockapi/mock.py
+++ b/tests/api/mockapi/mock.py
@@ -1,0 +1,49 @@
+import json
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any, NamedTuple
+from unittest.mock import patch
+
+from requests import Request, Response
+
+from core.util.http import HTTP
+
+
+class MockRequestsResponse(Response):
+    """A mock object that simulates an HTTP response from the
+    `requests` library.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        headers: dict[str, str] | None = None,
+        content: Any = None,
+        url: str | None = None,
+        request: Request | None = None,
+    ):
+        super().__init__()
+
+        self.status_code = status_code
+        if headers is not None:
+            for k, v in headers.items():
+                self.headers[k] = v
+
+        # We want to enforce that the mocked content is a bytestring
+        # just like a real response.
+        if content is not None:
+            if isinstance(content, str):
+                content_bytes = content.encode("utf-8")
+            elif isinstance(content, bytes):
+                content_bytes = content
+            else:
+                content_bytes = json.dumps(content).encode("utf-8")
+            self._content = content_bytes
+
+        if request and not url:
+            url = request.url
+        self.url = url or "http://url/"
+        self.encoding = "utf-8"
+        if request:
+            self.request = request.prepare()

--- a/tests/api/test_opds_for_distributors.py
+++ b/tests/api/test_opds_for_distributors.py
@@ -32,6 +32,7 @@ from core.model import (
 )
 from core.util.datetime_helpers import utc_now
 from core.util.opds_writer import OPDSFeed
+from tests.api.mockapi.mock import MockRequestsResponse
 from tests.api.mockapi.opds_for_distributors import MockOPDSForDistributorsAPI
 from tests.fixtures.api_opds_dist_files import OPDSForDistributorsFilesFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -759,7 +760,9 @@ class TestOPDSForDistributorsReaperMonitor:
             """An OPDSForDistributorsReaperMonitor that overrides _get."""
 
             def _get(self, url, headers):
-                return (200, {"content-type": OPDSFeed.ACQUISITION_FEED_TYPE}, feed)
+                return MockRequestsResponse(
+                    200, {"content-type": OPDSFeed.ACQUISITION_FEED_TYPE}, feed
+                )
 
         data_source = DataSource.lookup(
             opds_dist_api_fixture.db.session, "Biblioboard", autocreate=True

--- a/tests/core/util/test_http.py
+++ b/tests/core/util/test_http.py
@@ -331,7 +331,7 @@ class TestRemoteIntegrationException:
 class TestBadResponseException:
     def test_helper_constructor(self):
         response = MockRequestsResponse(102, content="nonsense")
-        exc = BadResponseException.from_response(
+        exc = BadResponseException(
             "http://url/", "Terrible response, just terrible", response
         )
 

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -40,10 +40,10 @@ class MonkeyPatchedODLFixture:
         )
 
     @staticmethod
-    def _get(patched_self, url, headers=None):
+    def _get(patched_self, url, headers=None, *args, **kwargs):
         patched_self.requests.append([url, headers])
         response = patched_self.responses.pop()
-        return HTTP._process_response(url, response)
+        return HTTP._process_response(url, response, *args, **kwargs)
 
     @staticmethod
     def _url_for(patched_self, *args, **kwargs):


### PR DESCRIPTION
## Description

Handle the case where we think there are available licenses, but when we reach out to the content provider, it turns out there are no licenses available.

## Motivation and Context

We were getting a lot of 502 responses with no specific debugging info. It turned out that the content provider was responding with a `application/api-problem+json` and not a `application/problem+json` when there were no copies left when trying to checkout a book.

During the implementation, some needed refactoring of how HTTP responses in general were needed. These changes were done in `core/util/http.py` which had some minor changes needed in `api/overdrive.py`, `customlists/customlist_import.py`,  `core/opds2_import.py` and `core/opds_import.py`.

## How Has This Been Tested?

Locally tested and unit tests.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. NEEDS UPDATE
