### PR TITLE
Ekir 299 set removed license as unavailable

### DIFF
--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -1034,8 +1034,10 @@ class CirculationData:
                 ]
                 for license in old_licenses:
                     if license not in new_licenses:
+                        # In case a license is removed from the feed we need to set it to be unavailable so that it's not used for loans or statistics.
+                        license.status = LicenseStatus.unavailable
                         self.log.warning(
-                            f"License {license.identifier} has been removed from feed."
+                            f"License {license.identifier} has been removed from feed and set to be unavailable"
                         )
                 changed_availability = pool.update_availability_from_licenses(
                     as_of=self.last_checked,


### PR DESCRIPTION
## Description

Set all removed licenses to status "unavailable".

## Motivation and Context

Old licenses have been used for loans because circulation has had outdated information about them. This is due to the Licenses Info Documents having inaccurate information about `checkouts_left`. The licenses had actually reached their loan limit and they had been removed from the feed. But because circulation reads the details from License Info Documents during each import to be in sync with the provider, and since that information could not have been read due to removing the licenses, the licenses were left as valid ones to be used for loans.
Setting removed licenses to be "unavailable" will cause them to be ignored for loan checkouts and statistics.

## How Has This Been Tested?

Unit test.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. -> N/A
