### PR TITLE
Make Links optional

### DIFF
--- a/api/controller/odl_notification.py
+++ b/api/controller/odl_notification.py
@@ -62,6 +62,9 @@ class ODLNotificationController(CirculationManagerController):
     def notify(
         self, patron_identifier: str | None, license_identifier: str | None
     ) -> Response:
+        self.log.info(
+            f"Loan notification received [patron: {patron_identifier}] [license: {license_identifier}]"
+        )
         loan = self._get_loan(patron_identifier, license_identifier)
         return self._process_notification(loan)
 

--- a/api/lcp/status.py
+++ b/api/lcp/status.py
@@ -132,7 +132,7 @@ class LoanStatus(BaseModel):
     status: Status
     message: str | None = None
     updated: Updated | None = None
-    links: LinkCollection
+    links: LinkCollection | None = None
     potential_rights: PotentialRights = Field(default_factory=PotentialRights)
     events: list[Event] | None = Field(default_factory=list)
 

--- a/api/odl.py
+++ b/api/odl.py
@@ -349,6 +349,7 @@ class BaseODLAPI(
             self.update_licensepool_and_hold_queue(loan.license_pool)
             return
 
+        assert loan_status.links  # To satisfy mypy
         return_link = loan_status.links.get(
             rel="return", content_type=LoanStatus.content_type()
         )
@@ -486,6 +487,7 @@ class BaseODLAPI(
             )
             raise CannotLoan()
 
+        assert loan_status.links  # To satisfy mypy
         # We save the link to the loan status document in the loan's external_identifier field, so
         # we are able to retrieve it later.
         loan_status_document_link: Link | None = loan_status.links.get(
@@ -639,6 +641,7 @@ class BaseODLAPI(
 
         drm_scheme = delivery_mechanism.delivery_mechanism.drm_scheme
         fulfill_cls: Callable[[str, str | None], UrlFulfillment]
+        assert loan_status.links  # To satisfy mypy
         if drm_scheme == DeliveryMechanism.NO_DRM:
             # If we have no DRM, we can just redirect to the content link and let the patron download the book.
             fulfill_link = loan_status.links.get(


### PR DESCRIPTION
## Description

Make Links an optional field in Loan Status Document.

## Motivation and Context

Missing Links field caused a validation error when getting ODL loan notification requests. It should be a MUST field according to https://readium.org/lcp-specs/releases/lsd/latest.html#25-links but make it optional for now.

## How Has This Been Tested?

Can't really be tested locally, only in our test environment.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. N/A
