### PR TITLE
Ekir 427 push notification texts to finnish

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -694,10 +694,10 @@ class BaseODLAPI(
         for hold in ready_for_checkout:
             if hold.position != 0:
                 hold.position = 0
-                # And start the reservation period.
-                hold.end = utc_now() + datetime.timedelta(
-                    days=default_reservation_period
-                )
+                # And start the reservation period which ends end of day.
+                hold.end = (
+                    utc_now() + datetime.timedelta(days=default_reservation_period)
+                ).replace(hour=23, minute=59, second=59, microsecond=999999)
 
         # Update the rest of the queue.
         for idx, hold in enumerate(waiting):

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2745,7 +2745,7 @@ class LoanNotificationsScript(Script):
     are expiring"""
 
     # Days before on which to send out a notification
-    LOAN_EXPIRATION_DAYS = [5, 1]
+    LOAN_EXPIRATION_DAYS = [3, 1]
     BATCH_SIZE = 100
 
     def do_run(self):

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -196,9 +196,8 @@ class PushNotifications(LoggerMixin):
             loans_api = f"{url}/{hold.patron.library.short_name}/loans"
             work: Work = hold.work
             identifier: Identifier = hold.license_pool.identifier
-            hold_end = hold.end.strftime("%-d.%-m.%Y")
             title = f'Varauksesi "{work.title}" on lainattavissa!'
-            body = f"Varaus on lainattava viimeistään {hold_end}."
+            body = f"Varaus on lainattava viimeistään {hold.end.strftime('%-d.%-m.%Y') if hold.end else '3 päivän päästä'}."
             print(body)
             data = dict(
                 title=title,

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -116,8 +116,8 @@ class PushNotifications(LoggerMixin):
         edition = loan.license_pool.presentation_edition
         identifier = loan.license_pool.identifier
         library_short_name = loan.library.short_name
-        title = f"Only {days_to_expiry} {'days' if days_to_expiry != 1 else 'day'} left on your loan!"
-        body = f"Your loan on {edition.title} is expiring soon"
+        title = f'"{edition.title}" laina-aika on päättymässä!'
+        body = f'"{edition.title}" laina-aika päättyy {days_to_expiry} päivän päästä.'
         data = dict(
             title=title,
             body=body,
@@ -196,8 +196,10 @@ class PushNotifications(LoggerMixin):
             loans_api = f"{url}/{hold.patron.library.short_name}/loans"
             work: Work = hold.work
             identifier: Identifier = hold.license_pool.identifier
-            title = "Your hold is available!"
-            body = f'Your hold on "{work.title}" is available!'
+            hold_end = hold.end.strftime("%-d.%-m.%Y")
+            title = f'Varauksesi "{work.title}" on lainattavissa!'
+            body = f"Varaus on lainattava viimeistään {hold_end}."
+            print(body)
             data = dict(
                 title=title,
                 body=body,

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -1137,9 +1137,10 @@ class TestODLAPI:
 
         # And the first hold changed.
         assert 0 == hold.position
-        assert hold.end - utc_now() - datetime.timedelta(days=3) < datetime.timedelta(
-            hours=1
-        )
+        # assert hold.end - utc_now() - datetime.timedelta(days=3) < datetime.timedelta(
+        #     hours=1
+        # )
+        assert hold.end.hour == 23 and hold.end.minute == 59
 
         # The later hold also moved one position.
         assert 1 == later_hold.position
@@ -1158,9 +1159,10 @@ class TestODLAPI:
         assert 2 == opds2_with_odl_api_fixture.pool.licenses_reserved
         assert 2 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
         assert 0 == later_hold.position
-        assert later_hold.end - utc_now() - datetime.timedelta(
-            days=3
-        ) < datetime.timedelta(hours=1)
+        # assert later_hold.end - utc_now() - datetime.timedelta(
+        #     days=3
+        # ) < datetime.timedelta(hours=1)
+        assert later_hold.end.hour == 23 and later_hold.end.minute == 59
 
         # Now there are no more holds. If we add another license,
         # it ends up being available.
@@ -1217,12 +1219,8 @@ class TestODLAPI:
         assert 0 == holds[0].position
         assert 0 == holds[1].position
         assert 1 == holds[2].position
-        assert holds[0].end - utc_now() - datetime.timedelta(
-            days=3
-        ) < datetime.timedelta(hours=1)
-        assert holds[1].end - utc_now() - datetime.timedelta(
-            days=3
-        ) < datetime.timedelta(hours=1)
+        assert holds[0].end.hour == 23 and holds[0].end.minute == 59
+        assert holds[1].end.hour == 23 and holds[1].end.minute == 59
 
         # If there are more licenses that change than holds, some of them become available.
         with opds2_with_odl_api_fixture.mock_http.patch():

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -147,7 +147,6 @@ class TestPushNotifications:
         loan, _ = work.active_license_pool().loan_to(patron)  # type: ignore
         work2: Work = db.work(with_license_pool=True)
         hold, _ = work2.active_license_pool().on_hold_to(patron)  # type: ignore
-        hold.end = utc_now() + timedelta(days=3)
 
         with mock.patch(
             "core.util.notifications.PushNotifications.send_messages"


### PR DESCRIPTION
## Description

Hardcode notification texts into Finnish for now. Loan notifications should be sent 3 and 1 days before expiry.

## Motivation and Context

To enable the quick release of push notifications, using Finnish texts is the fastest way until we figure out how to translate the notifications.

## How Has This Been Tested?

Tests.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Transifex translators have been notified. N/A
