### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -1,11 +1,11 @@
-name: 'Poetry'
-description: 'Install python poetry'
+name: "Poetry"
+description: "Install python poetry"
 
 inputs:
   version:
     description: "Version of poetry to install"
     required: false
-    default: "1.5.1"
+    default: "1.8.5"
 
 outputs:
   version:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     versioning-strategy: increase-if-necessary
     # Install a specific version of Poetry before running updates
     pre-commands:
-      - curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
+      - curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
       - poetry config virtualenvs.create false
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,12 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: increase-if-necessary
-    # Ignore everything for now (and stay in pace with the upstream)
-    # ignore:
-    #    - dependency-name: "*"
+    # Install a specific version of Poetry before running updates
+    pre-commands:
+      - curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
+      - poetry config virtualenvs.create false
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    # Ignore everything for now (and stay in pace with the upstream)
-    # ignore:
-    #    - dependency-name: "*"

--- a/api/axis.py
+++ b/api/axis.py
@@ -389,7 +389,7 @@ class Axis360API(
                 response.content
             )
         except etree.XMLSyntaxError as e:
-            raise RemoteInitiatedServerError(response.content, self.label())
+            raise RemoteInitiatedServerError(response.content, self.label())  # type: ignore
 
     def _checkin(self, title_id: str | None, patron_id: str | None) -> RequestsResponse:
         """Make a request to the EarlyCheckInTitle endpoint."""
@@ -431,7 +431,7 @@ class Axis360API(
                 raise CannotLoan()
             return loan_info
         except etree.XMLSyntaxError as e:
-            raise RemoteInitiatedServerError(response.content, self.label())
+            raise RemoteInitiatedServerError(response.content, self.label())  # type: ignore
 
     def _checkout(
         self, title_id: str | None, patron_id: str | None, internal_format: str

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -942,7 +942,7 @@ class ErrorParser(BibliothecaParser[Exception]):
         except Exception as e:
             # The server sent us an error with an incorrect or
             # nonstandard syntax.
-            return RemoteInitiatedServerError(string, BibliothecaAPI.SERVICE_NAME)
+            return RemoteInitiatedServerError(string, BibliothecaAPI.SERVICE_NAME)  # type: ignore
 
         if return_val is None:
             # We were not able to interpret the result as an error.

--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -1,87 +1,116 @@
+from abc import ABC, abstractmethod
+
 from flask_babel import lazy_gettext as _
 
 from api.problem_details import *
 from core.config import IntegrationException
 from core.problem_details import INTEGRATION_ERROR, INTERNAL_SERVER_ERROR
-from core.util.problem_detail import ProblemDetail
+from core.util.problem_detail import BaseProblemDetailException, ProblemDetail
 
 
-class CirculationException(IntegrationException):
+class CirculationException(IntegrationException, BaseProblemDetailException, ABC):
     """An exception occured when carrying out a circulation operation.
 
     `status_code` is the status code that should be returned to the patron.
     """
 
-    status_code = 400
-
     def __init__(self, message=None, debug_info=None):
-        message = message or self.__class__.__name__
-        super().__init__(message, debug_info)
+        super().__init__(message or self.__class__.__name__, debug_info)
+        self.message = message
 
+    @property
+    def detail(self) -> str | None:
+        return self.message
 
-class InternalServerError(IntegrationException):
-    status_code = 500
+    @property
+    @abstractmethod
+    def base(self) -> ProblemDetail:
+        """A ProblemDetail, used as the basis for conversion of this exception into a
+        problem detail document."""
 
-    def as_problem_detail_document(self, debug=False):
+    @property
+    def problem_detail(self) -> ProblemDetail:
         """Return a suitable problem detail document."""
+        if self.detail is not None:
+            return self.base.detailed(
+                detail=self.detail, debug_message=self.debug_message
+            )
+        elif self.debug_message is not None:
+            return self.base.with_debug(self.debug_message)
+        else:
+            return self.base
+
+
+class InternalServerError(IntegrationException, BaseProblemDetailException):
+    @property
+    def problem_detail(self) -> ProblemDetail:
         return INTERNAL_SERVER_ERROR
 
 
 class RemoteInitiatedServerError(InternalServerError):
     """One of the servers we communicate with had an internal error."""
 
-    status_code = 502
-
-    def __init__(self, message, service_name):
-        super().__init__(message)
+    def __init__(self, debug_info: str, service_name: str):
+        super().__init__(debug_info)
         self.service_name = service_name
 
-    def as_problem_detail_document(self, debug=False):
-        """Return a suitable problem detail document."""
+    @property
+    def problem_detail(self) -> ProblemDetail:
         msg = _(
             "Integration error communicating with %(service_name)s",
             service_name=self.service_name,
         )
-        return INTEGRATION_ERROR.detailed(msg)
-
-
-class NoOpenAccessDownload(CirculationException):
-    """We expected a book to have an open-access download, but it didn't."""
-
-    status_code = 500
+        return INTEGRATION_ERROR.detailed(msg, debug_message=str(self))
 
 
 class AuthorizationFailedException(CirculationException):
-    status_code = 401
+    @property
+    def base(self) -> ProblemDetail:
+        return INVALID_CREDENTIALS
 
 
-class PatronAuthorizationFailedException(AuthorizationFailedException):
-    status_code = 400
+class PatronAuthorizationFailedException(CirculationException):
+    @property
+    def base(self) -> ProblemDetail:
+        return INVALID_CREDENTIALS
 
 
 class RemotePatronCreationFailedException(CirculationException):
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return MISSING_USER_INFO
 
 
 class LibraryAuthorizationFailedException(CirculationException):
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return INTEGRATION_ERROR
 
 
 class InvalidInputException(CirculationException):
     """The patron gave invalid input to the library."""
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return INVALID_INPUT.detailed("The patron gave invalid input to the library.")
 
 
 class LibraryInvalidInputException(InvalidInputException):
     """The library gave invalid input to the book provider."""
 
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return INVALID_INPUT.detailed(
+            "The library gave invalid input to the book provider."
+        )
 
 
 class DeliveryMechanismError(InvalidInputException):
-    status_code = 400
     """The patron broke the rules about delivery mechanisms."""
+
+    @property
+    def base(self) -> ProblemDetail:
+        return BAD_DELIVERY_MECHANISM
 
 
 class DeliveryMechanismMissing(DeliveryMechanismError):
@@ -93,25 +122,31 @@ class DeliveryMechanismConflict(DeliveryMechanismError):
     one already set in stone.
     """
 
+    @property
+    def base(self) -> ProblemDetail:
+        return DELIVERY_CONFLICT
+
 
 class CannotLoan(CirculationException):
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return CHECKOUT_FAILED
 
 
 class OutstandingFines(CannotLoan):
     """The patron has outstanding fines above the limit in the library's
     policy."""
 
-    status_code = 403
+    @property
+    def base(self) -> ProblemDetail:
+        return OUTSTANDING_FINES
 
 
 class AuthorizationExpired(CannotLoan):
     """The patron's authorization has expired."""
 
-    status_code = 403
-
-    def as_problem_detail_document(self, debug=False):
-        """Return a suitable problem detail document."""
+    @property
+    def base(self) -> ProblemDetail:
         return EXPIRED_CREDENTIALS
 
 
@@ -122,89 +157,105 @@ class AuthorizationBlocked(CannotLoan):
     For instance, the patron has been banned from the library.
     """
 
-    status_code = 403
-
-    def as_problem_detail_document(self, debug=False):
-        """Return a suitable problem detail document."""
+    @property
+    def base(self) -> ProblemDetail:
         return BLOCKED_CREDENTIALS
 
 
 class LimitReached(CirculationException):
     """The patron cannot carry out an operation because it would push them above
-    some limit set by library policy.
+    some limit set by library policy."""
 
-    This exception cannot be used on its own. It must be subclassed and the following constants defined:
-        * `BASE_DOC`: A ProblemDetail, used as the basis for conversion of this exception into a
-           problem detail document.
-        * `MESSAGE_WITH_LIMIT` A string containing the interpolation value "%(limit)s", which
-          offers a more specific explanation of the limit exceeded.
-    """
+    def __init__(
+        self,
+        message: str | None = None,
+        debug_info: str | None = None,
+        limit: int | None = None,
+    ):
+        super().__init__(message, debug_info=debug_info)
+        self.limit = limit
 
-    status_code = 403
-    BASE_DOC: ProblemDetail | None = None
-    MESSAGE_WITH_LIMIT = None
+    @property
+    @abstractmethod
+    def message_with_limit(self) -> str:
+        """A string containing the interpolation value "%(limit)s", which
+        offers a more specific explanation of the limit exceeded."""
 
-    def __init__(self, message=None, debug_info=None, limit=None):
-        super().__init__(message=message, debug_info=debug_info)
-        self.limit = limit if limit else None
-
-    def as_problem_detail_document(self, debug=False):
-        """Return a suitable problem detail document."""
-        doc = self.BASE_DOC
-        if not self.limit:
-            return doc
-        detail = self.MESSAGE_WITH_LIMIT % dict(limit=self.limit)
-        return doc.detailed(detail=detail)
+    @property
+    def detail(self) -> str | None:
+        if self.limit:
+            return self.message_with_limit % dict(limit=self.limit)
+        elif self.message:
+            return self.message
+        return None
 
 
 class PatronLoanLimitReached(CannotLoan, LimitReached):
-    BASE_DOC = LOAN_LIMIT_REACHED
-    MESSAGE_WITH_LIMIT = SPECIFIC_LOAN_LIMIT_MESSAGE
+    @property
+    def base(self) -> ProblemDetail:
+        return LOAN_LIMIT_REACHED
+
+    @property
+    def message_with_limit(self) -> str:
+        return SPECIFIC_LOAN_LIMIT_MESSAGE
 
 
 class CannotReturn(CirculationException):
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return COULD_NOT_MIRROR_TO_REMOTE
 
 
 class CannotHold(CirculationException):
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return HOLD_FAILED
 
 
 class PatronHoldLimitReached(CannotHold, LimitReached):
-    BASE_DOC = HOLD_LIMIT_REACHED
-    MESSAGE_WITH_LIMIT = SPECIFIC_HOLD_LIMIT_MESSAGE
+    @property
+    def base(self) -> ProblemDetail:
+        return HOLD_LIMIT_REACHED
+
+    @property
+    def message_with_limit(self) -> str:
+        return SPECIFIC_HOLD_LIMIT_MESSAGE
 
 
 class CannotReleaseHold(CirculationException):
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return CANNOT_RELEASE_HOLD
 
 
 class CannotFulfill(CirculationException):
-    status_code = 500
-
-
-class CannotPartiallyFulfill(CannotFulfill):
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return CANNOT_FULFILL
 
 
 class FormatNotAvailable(CannotFulfill):
     """Our format information for this book was outdated, and it's
     no longer available in the requested format."""
 
-    status_code = 502
+    @property
+    def base(self) -> ProblemDetail:
+        return NO_ACCEPTABLE_FORMAT
 
 
 class NotFoundOnRemote(CirculationException):
     """We know about this book but the remote site doesn't seem to."""
 
-    status_code = 404
+    @property
+    def base(self) -> ProblemDetail:
+        return NOT_FOUND_ON_REMOTE
 
 
 class NoLicenses(NotFoundOnRemote):
     """The library no longer has licenses for this book."""
 
-    def as_problem_detail_document(self, debug=False):
-        """Return a suitable problem detail document."""
+    @property
+    def base(self) -> ProblemDetail:
         return NO_LICENSES
 
 
@@ -214,7 +265,9 @@ class CannotRenew(CirculationException):
     Probably because it's not available for renewal.
     """
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return RENEW_FAILED
 
 
 class NoAvailableCopiesWhenReserved(CannotLoan):
@@ -223,9 +276,11 @@ class NoAvailableCopiesWhenReserved(CannotLoan):
     patron.
     """
 
-    def as_problem_detail_document(self, debug=False):
-        """Return a suitable problem detail document."""
-        return NO_COPIES_WHEN_RESERVED
+    @property
+    def base(self) -> ProblemDetail:
+        return CHECKOUT_FAILED.detailed(
+            detail="No copies available to check out, you are still next in line."
+        )
 
 
 class NoAvailableCopies(CannotLoan):
@@ -233,7 +288,9 @@ class NoAvailableCopies(CannotLoan):
     copies are already checked out.
     """
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return CHECKOUT_FAILED.detailed(detail="No copies available to check out.")
 
 
 class AlreadyCheckedOut(CannotLoan):
@@ -241,7 +298,11 @@ class AlreadyCheckedOut(CannotLoan):
     it checked out.
     """
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return CHECKOUT_FAILED.detailed(
+            detail="You already have this book checked out."
+        )
 
 
 class AlreadyOnHold(CannotHold):
@@ -249,7 +310,9 @@ class AlreadyOnHold(CannotHold):
     it on hold.
     """
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return HOLD_FAILED.detailed(detail="You already have this book on hold.")
 
 
 class NotCheckedOut(CannotReturn):
@@ -257,13 +320,11 @@ class NotCheckedOut(CannotReturn):
     have it checked out in the first place.
     """
 
-    status_code = 400
-
-
-class RemoteRefusedReturn(CannotReturn):
-    """The remote refused to count this book as returned."""
-
-    status_code = 500
+    @property
+    def base(self) -> ProblemDetail:
+        return COULD_NOT_MIRROR_TO_REMOTE.detailed(
+            title="Unable to return", detail="You don't have this book checked out."
+        )
 
 
 class NotOnHold(CannotReleaseHold):
@@ -271,13 +332,13 @@ class NotOnHold(CannotReleaseHold):
     have it on hold in the first place.
     """
 
-    status_code = 400
-
 
 class CurrentlyAvailable(CannotHold):
     """The patron can't put this book on hold because it's available now."""
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return HOLD_FAILED.detailed(detail="Cannot place a hold on an available title.")
 
 
 class NoAcceptableFormat(CannotFulfill):
@@ -285,7 +346,9 @@ class NoAcceptableFormat(CannotFulfill):
     in an acceptable format.
     """
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return super().base.detailed("No acceptable format", status_code=400)
 
 
 class FulfilledOnIncompatiblePlatform(CannotFulfill):
@@ -294,7 +357,11 @@ class FulfilledOnIncompatiblePlatform(CannotFulfill):
     exclusive to that platform.
     """
 
-    status_code = 451
+    @property
+    def base(self) -> ProblemDetail:
+        return super().base.detailed(
+            "Fulfilled on an incompatible platform", status_code=451
+        )
 
 
 class NoActiveLoan(CannotFulfill):
@@ -302,8 +369,14 @@ class NoActiveLoan(CannotFulfill):
     active loan.
     """
 
-    status_code = 400
+    @property
+    def base(self) -> ProblemDetail:
+        return NO_ACTIVE_LOAN.detailed(
+            "Can't fulfill loan because you have no active loan for this book.",
+        )
 
 
 class PatronNotFoundOnRemote(NotFoundOnRemote):
-    status_code = 404
+    @property
+    def base(self) -> ProblemDetail:
+        return PATRON_NOT_FOUND_ON_REMOTE

--- a/api/controller/odl_notification.py
+++ b/api/controller/odl_notification.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
-import json
-
 import flask
 from flask import Response
 from flask_babel import lazy_gettext as _
+from pydantic import ValidationError
+from sqlalchemy.orm.exc import StaleDataError
 
 from api.controller.circulation_manager import CirculationManagerController
+from api.lcp.status import LoanStatus
 from api.odl import ODLAPI
 from api.odl2 import ODL2API
-from api.problem_details import INVALID_LOAN_FOR_ODL_NOTIFICATION, NO_ACTIVE_LOAN
-from core.model import Loan, get_one
+from api.problem_details import (
+    INVALID_INPUT,
+    INVALID_LOAN_FOR_ODL_NOTIFICATION,
+    NO_ACTIVE_LOAN,
+)
+from core.model import get_one
+from core.model.credential import Credential
+from core.model.licensing import License
+from core.model.patron import Loan, Patron
+from core.util.datetime_helpers import utc_now
+from core.util.problem_detail import ProblemDetailException
 
 
 class ODLNotificationController(CirculationManagerController):
@@ -18,20 +28,83 @@ class ODLNotificationController(CirculationManagerController):
     status of a loan changes.
     """
 
-    def notify(self, loan_id):
-        library = flask.request.library
-        status_doc = flask.request.data
-        loan = get_one(self._db, Loan, id=loan_id)
+    def _get_loan(
+        self, patron_identifier: str | None, license_identifier: str | None
+    ) -> Loan | None:
+        if patron_identifier is None or license_identifier is None:
+            return None
 
-        if not loan:
-            return NO_ACTIVE_LOAN.detailed(_("No loan was found for this identifier."))
+        patron_identifier = str(patron_identifier)
+        license_identifier = str(license_identifier)
 
-        collection = loan.license_pool.collection
-        if collection.protocol not in (ODLAPI.label(), ODL2API.label()):
-            return INVALID_LOAN_FOR_ODL_NOTIFICATION
-
-        api = self.manager.circulation_apis[library.id].api_for_license_pool(
-            loan.license_pool
+        # When the loan was made the patron's identifier to this remote API was saved to credential.credential. It's now
+        # used to identify the loan for this license.
+        loan = (
+            self._db.query(Loan)
+            .join(License)
+            .join(Patron)
+            .join(Credential)
+            .filter(
+                License.identifier == license_identifier,
+                Credential.credential == patron_identifier,
+                Credential.type == Credential.IDENTIFIER_TO_REMOTE_SERVICE,
+            )
+            .one_or_none()
         )
-        api.update_loan(loan, json.loads(status_doc))
+        return loan
+
+    # TODO: This method is deprecated and should be removed once all the loans
+    #   created using the old endpoint have expired.
+    def notify_deprecated(self, loan_id: int) -> Response:
+        loan = get_one(self._db, Loan, id=loan_id)
+        return self._process_notification(loan)
+
+    def notify(
+        self, patron_identifier: str | None, license_identifier: str | None
+    ) -> Response:
+        loan = self._get_loan(patron_identifier, license_identifier)
+        return self._process_notification(loan)
+
+    def _process_notification(self, loan: Loan | None) -> Response:
+        library = flask.request.library  # type: ignore
+        status_doc_json = flask.request.data
+
+        try:
+            status_doc = LoanStatus.parse_raw(status_doc_json)
+        except ValidationError as e:
+            self.log.exception(f"Unable to parse loan status document. {e}")
+            raise ProblemDetailException(INVALID_INPUT) from e
+
+        # We don't have a record of this loan. This likely means that the loan has been returned
+        # and our local record has been deleted. This is expected, except in the case where the
+        # distributor thinks the loan is still active.
+        if loan is None and status_doc.active:
+            self.log.error(
+                f"No loan found for active OPDS + ODL Notification. Document: {status_doc.to_serializable()}"
+            )
+            raise ProblemDetailException(
+                NO_ACTIVE_LOAN.detailed(_("No loan was found."), status_code=404)
+            )
+
+        if loan:
+            collection = loan.license_pool.collection
+            if collection.protocol not in (ODLAPI.label(), ODL2API.label()):
+                raise ProblemDetailException(INVALID_LOAN_FOR_ODL_NOTIFICATION)
+
+            # We might be out of sync with the distributor. Mark the loan as expired and update the license pool.
+            if not status_doc.active:
+                try:
+                    with self._db.begin_nested():
+                        loan.end = utc_now()
+                    api = self.manager.circulation_apis[
+                        library.id
+                    ].api_for_license_pool(loan.license_pool)
+                    api.update_availability(loan.license_pool)
+                except StaleDataError:
+                    # This can happen if this callback happened while we were returning this
+                    # item. We can fetch the loan, but it's deleted by the time we go to do
+                    # the update. This is not a problem, as we were just marking the loan as
+                    # completed anyway so we just continue.
+                    ...
+
         return Response(_("Success"), 200)

--- a/api/controller/odl_notification.py
+++ b/api/controller/odl_notification.py
@@ -62,6 +62,9 @@ class ODLNotificationController(CirculationManagerController):
     def notify(
         self, patron_identifier: str | None, license_identifier: str | None
     ) -> Response:
+        self.log.info(
+            f"Loan notification received [patron: {patron_identifier}] [license: {license_identifier}]"
+        )
         loan = self._get_loan(patron_identifier, license_identifier)
         return self._process_notification(loan)
 

--- a/api/ekirjasto_authentication.py
+++ b/api/ekirjasto_authentication.py
@@ -324,8 +324,7 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
         if patrondata.permanent_id == None:
             # permanent_id is used to get the local Patron, we cannot proceed
             # if it is missing.
-            message = "Value for permanent_id is missing in remote user info."
-            raise RemotePatronCreationFailedException(message, self.__class__.__name__)
+            raise RemotePatronCreationFailedException()
 
         return patrondata
 
@@ -797,9 +796,7 @@ class EkirjastoAuthenticationAPI(AuthenticationProvider, ABC):
             return patron
         if delegate_patron and patron.id != delegate_patron.id:
             # This situation should never happen.
-            raise PatronNotFoundOnRemote(
-                404, "Remote patron is conflicting with delegate patron."
-            )
+            raise PatronNotFoundOnRemote()
         if patron.cached_neighborhood and not patron.neighborhood:
             # Patron.neighborhood (which is not a model field) was not
             # set, probably because we avoided an expensive metadata

--- a/api/enki.py
+++ b/api/enki.py
@@ -531,7 +531,7 @@ class EnkiAPI(
                 self.log.error(
                     "Unexpected error in patron_activity: %r", response.content
                 )
-                raise CirculationException(response.content)
+                raise CirculationException(response.content)  # type: ignore
         for loan in result["checkedOutItems"]:
             yield self.parse_patron_loans(loan)
         for type, holds in list(result["holds"].items()):

--- a/api/lcp/status.py
+++ b/api/lcp/status.py
@@ -132,7 +132,7 @@ class LoanStatus(BaseModel):
     status: Status
     message: str | None = None
     updated: Updated | None = None
-    links: LinkCollection
+    links: LinkCollection | None = None
     potential_rights: PotentialRights = Field(default_factory=PotentialRights)
     events: list[Event] | None = Field(default_factory=list)
 

--- a/api/odl.py
+++ b/api/odl.py
@@ -349,6 +349,7 @@ class BaseODLAPI(
             self.update_licensepool_and_hold_queue(loan.license_pool)
             return
 
+        assert loan_status.links  # To satisfy mypy
         return_link = loan_status.links.get(
             rel="return", content_type=LoanStatus.content_type()
         )
@@ -486,6 +487,7 @@ class BaseODLAPI(
             )
             raise CannotLoan()
 
+        assert loan_status.links  # To satisfy mypy
         # We save the link to the loan status document in the loan's external_identifier field, so
         # we are able to retrieve it later.
         loan_status_document_link: Link | None = loan_status.links.get(
@@ -639,6 +641,7 @@ class BaseODLAPI(
 
         drm_scheme = delivery_mechanism.delivery_mechanism.drm_scheme
         fulfill_cls: Callable[[str, str | None], UrlFulfillment]
+        assert loan_status.links  # To satisfy mypy
         if drm_scheme == DeliveryMechanism.NO_DRM:
             # If we have no DRM, we can just redirect to the content link and let the patron download the book.
             fulfill_link = loan_status.links.get(

--- a/api/odl.py
+++ b/api/odl.py
@@ -309,6 +309,7 @@ class BaseODLAPI(
 
     def checkin(self, patron: Patron, pin: str, licensepool: LicensePool) -> None:
         """Return a loan early."""
+        self.log.info(f"Checking in a loan in license pool {licensepool}")
         _db = Session.object_session(patron)
 
         loan = (
@@ -387,6 +388,7 @@ class BaseODLAPI(
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:
         """Create a new loan."""
+        self.log.info(f"Checking out a loan in license pool {licensepool}")
         _db = Session.object_session(patron)
 
         loan = (
@@ -612,13 +614,14 @@ class BaseODLAPI(
             raise FormatNotAvailable()
         content_link = resource.representation.public_url
         content_type = resource.representation.media_type
-        return RedirectFulfillment(
-            content_link, content_type
-        )  # Tää pitää kattoo, ei ole circulation.py:ssä
+        return RedirectFulfillment(content_link, content_type)
 
     def _license_fulfill(
         self, loan: Loan, delivery_mechanism: LicensePoolDeliveryMechanism
     ) -> Fulfillment:
+        self.log.info(
+            f"Fulfilling loan of license {loan.license.identifier} in license pool {loan.license_pool}"
+        )
         # We are unable to fulfill a loan that doesn't have its external identifier set,
         # since we use this to get to the checkout link. It shouldn't be possible to get
         # into this state.
@@ -722,6 +725,7 @@ class BaseODLAPI(
         notification_email_address: str | None,
     ) -> HoldInfo:
         """Create a new hold."""
+        self.log.info(f"Placing hold in license pool {licensepool}")
         return self._place_hold(patron, licensepool)
 
     def _place_hold(self, patron: Patron, licensepool: LicensePool) -> HoldInfo:
@@ -759,6 +763,7 @@ class BaseODLAPI(
 
     def release_hold(self, patron: Patron, pin: str, licensepool: LicensePool) -> None:
         """Cancel a hold."""
+        self.log.info(f"Releasing hold in license pool {licensepool}")
         _db = Session.object_session(patron)
 
         hold = get_one(

--- a/api/odl.py
+++ b/api/odl.py
@@ -6,14 +6,15 @@ import json
 import uuid
 from abc import ABC
 from collections.abc import Callable
-from typing import Any, Literal, TypeVar
+from functools import partial
+from typing import Any, TypeVar
 
 import dateutil
 from dependency_injector.wiring import Provide, inject
 from flask import url_for
 from flask_babel import lazy_gettext as _
 from lxml.etree import Element
-from pydantic import AnyHttpUrl, HttpUrl, PositiveInt
+from pydantic import AnyHttpUrl, HttpUrl, PositiveInt, ValidationError
 from requests import Response
 from sqlalchemy.sql.expression import or_
 from uritemplate import URITemplate
@@ -21,13 +22,18 @@ from uritemplate import URITemplate
 from api.circulation import (
     BaseCirculationAPI,
     BaseCirculationEbookLoanSettings,
-    FulfillmentInfo,
+    FetchFulfillment,
+    Fulfillment,
     HoldInfo,
     LoanInfo,
     PatronActivityCirculationAPI,
+    RedirectFulfillment,
+    UrlFulfillment,
 )
 from api.circulation_exceptions import *
 from api.lcp.hash import Hasher, HasherFactory, HashingAlgorithm
+from api.lcp.status import Link, LoanStatus
+from api.odl_api.auth import OpdsWithOdlException
 from core import util
 from core.integration.settings import (
     ConfigurationFormItem,
@@ -48,12 +54,13 @@ from core.model import (
     ExternalIntegration,
     Hold,
     Hyperlink,
-    Library,
+    License,
     LicensePool,
     LicensePoolDeliveryMechanism,
     Loan,
     MediaTypes,
     Representation,
+    Resource,
     RightsStatus,
     Session,
     get_one,
@@ -72,6 +79,7 @@ from core.service.container import Services
 from core.util import base64
 from core.util.datetime_helpers import to_utc, utc_now
 from core.util.http import HTTP, BadResponseException, RemoteIntegrationException
+from core.util.log import LoggerMixin
 
 
 class ODLAPIConstants:
@@ -160,7 +168,9 @@ LibrarySettingsType = TypeVar(
 )
 
 
-class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType], ABC):
+class BaseODLAPI(
+    PatronActivityCirculationAPI[SettingsType, LibrarySettingsType], LoggerMixin, ABC
+):
     """ODL (Open Distribution to Libraries) is a specification that allows
     libraries to manage their own loans and holds. It offers a deeper level
     of control to the library, but it requires the circulation manager to
@@ -172,35 +182,6 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
     """
 
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.FULFILL_STEP
-
-    # Possible status values in the License Status Document:
-
-    # The license is available but the user hasn't fulfilled it yet.
-    READY_STATUS = "ready"
-
-    # The license is available and has been fulfilled on at least one device.
-    ACTIVE_STATUS = "active"
-
-    # The license has been revoked by the distributor.
-    REVOKED_STATUS = "revoked"
-
-    # The license has been returned early by the user.
-    RETURNED_STATUS = "returned"
-
-    # The license was returned early and was never fulfilled.
-    CANCELLED_STATUS = "cancelled"
-
-    # The license has expired.
-    EXPIRED_STATUS = "expired"
-
-    STATUS_VALUES = [
-        READY_STATUS,
-        ACTIVE_STATUS,
-        REVOKED_STATUS,
-        RETURNED_STATUS,
-        CANCELLED_STATUS,
-        EXPIRED_STATUS,
-    ]
 
     @inject
     def __init__(
@@ -255,106 +236,76 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         auth_header = "Basic %s" % base64.b64encode(f"{username}:{password}")
         headers["Authorization"] = auth_header
 
-        return HTTP.get_with_timeout(
-            url, headers=headers, timeout=30
-        )  # Added a bigger timeout for loan checkouts
+        try:
+            response = HTTP.get_with_timeout(
+                url, headers=headers, timeout=30, *args, **kwargs
+            )
+            return response
+        except BadResponseException as e:
+            response = e.response
+            if opds_exception := OpdsWithOdlException.from_response(response):
+                raise opds_exception from e
+            raise
 
     def _url_for(self, *args: Any, **kwargs: Any) -> str:
         """Wrapper around flask's url_for to be overridden for tests."""
         return url_for(*args, **kwargs)
 
-    def get_license_status_document(self, loan: Loan) -> dict[str, Any]:
-        """Get the License Status Document for a loan.
+    @staticmethod
+    def _notification_url(
+        short_name: str | None, patron_id: str, license_id: str
+    ) -> str:
+        """Get the notification URL that should be passed in the ODL checkout link.
 
-        For a new loan, create a local loan with no external identifier and
-        pass it in to this method.
-
-        This will create the remote loan if one doesn't exist yet. The loan's
-        internal database id will be used to receive notifications from the
-        distributor when the loan's status changes.
+        This is broken out into a separate function to make it easier to override
+        in tests.
         """
-        _db = Session.object_session(loan)
+        return url_for(
+            "opds2_with_odl_notification",
+            library_short_name=short_name,
+            patron_identifier=patron_id,
+            license_identifier=license_id,
+            _external=True,
+        )
 
-        if loan.external_identifier:
-            url = loan.external_identifier
-        else:
-            id = loan.license.identifier
-            checkout_id = str(uuid.uuid1())
-            if self.collection is None:
-                raise ValueError(f"Collection not found: {self.collection_id}")
-            default_loan_period = self.collection.default_loan_period(
-                loan.patron.library
-            )
-
-            expires = utc_now() + datetime.timedelta(days=default_loan_period)
-            # The patron UUID is generated randomly on each loan, so the distributor
-            # doesn't know when multiple loans come from the same patron.
-            patron_id = str(uuid.uuid1())
-
-            library_short_name = loan.patron.library.short_name
-
-            db = Session.object_session(loan)
-            patron = loan.patron
-            hasher = self._get_hasher()
-
-            unhashed_pass: LCPUnhashedPassphrase = (
-                self._credential_factory.get_patron_passphrase(db, patron)
-            )
-            hashed_pass: LCPHashedPassphrase = unhashed_pass.hash(hasher)
-            self._credential_factory.set_hashed_passphrase(db, patron, hashed_pass)
-            encoded_pass: str = base64.b64encode(binascii.unhexlify(hashed_pass.hashed))
-
-            notification_url = self._url_for(
-                "odl_notify",
-                library_short_name=library_short_name,
-                loan_id=loan.id,
-                _external=True,
-            )
-
-            checkout_url = str(loan.license.checkout_url)
-            url_template = URITemplate(checkout_url)
-            url = url_template.expand(
-                id=str(id),
-                checkout_id=checkout_id,
-                patron_id=patron_id,
-                expires=expires.isoformat(),
-                notification_url=notification_url,
-                passphrase=encoded_pass,
-                hint=self.settings.passphrase_hint,
-                hint_url=self.settings.passphrase_hint_url,
-            )
-
+    def _request_loan_status(
+        self, url: str, ignored_problem_types: list[str] | None = None
+    ) -> LoanStatus:
+        """Retrieves the Loan Status Document."""
         try:
             response = self._get(url, allowed_response_codes=["2xx"])
+            status_doc = LoanStatus.parse_raw(response.content)
+        except ValidationError as e:
+            self.log.exception(
+                f"Error validating Loan Status Document. '{url}' returned and invalid document. {e}"
+            )
+            raise RemoteIntegrationException(
+                url, "Loan Status Document not valid."
+            ) from e
         except BadResponseException as e:
             response = e.response
-            header_string = ", ".join(
-                {f"{k}: {v}" for k, v in response.headers.items()}
-            )
-            response_string = (
-                response.text
-                if len(response.text) < 100
-                else response.text[:100] + "..."
-            )
-            raise BadResponseException(
-                url,
-                f"Error getting License Status Document for loan ({loan.id}):  Url '{url}' returned "
-                f"status code {response.status_code}. Expected 2XX. Response headers: {header_string}. "
-                f"Response content: {response_string}.",
-                response,
-            )
-
-        try:
-            status_doc = json.loads(response.content)
-        except ValueError as e:
-            raise RemoteIntegrationException(
-                url, "License Status Document was not valid JSON."
-            ) from e
-        if status_doc.get("status") not in self.STATUS_VALUES:
-            raise RemoteIntegrationException(
-                url, "License Status Document had an unknown status value."
-            )
-        return status_doc  # type: ignore[no-any-return]
+            error_message = f"Error requesting Loan Status Document. '{url}' returned status code {response.status_code}."
+            if isinstance(e, OpdsWithOdlException):
+                # It this problem type is explicitly ignored, we just raise the exception instead of proceeding with
+                # logging the information about it. The caller will handle the exception.
+                if ignored_problem_types and e.type in ignored_problem_types:
+                    raise
+                error_message += f" Problem Detail: '{e.type}' - {e.title}"
+                if e.detail:
+                    error_message += f" - {e.detail}"
+            else:
+                header_string = ", ".join(
+                    {f"{k}: {v}" for k, v in response.headers.items()}
+                )
+                response_string = (
+                    response.text
+                    if len(response.text) < 100
+                    else response.text[:100] + "..."
+                )
+                error_message += f" Response headers: {header_string}. Response content: {response_string}."
+            self.log.exception(error_message)
+            raise
+        return status_doc
 
     def checkin(self, patron: Patron, pin: str, licensepool: LicensePool) -> None:
         """Return a loan early."""
@@ -369,55 +320,63 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             raise NotCheckedOut()
         loan_result = loan.one()
 
-        if loan_result.license_pool.open_access:
+        if licensepool.open_access:
             # If this is an open-access book, we don't need to do anything.
             return
 
         self._checkin(loan_result)
 
-    def _checkin(self, loan: Loan) -> bool:
+    def _checkin(self, loan: Loan) -> None:
         _db = Session.object_session(loan)
-        doc = self.get_license_status_document(loan)
-        status = doc.get("status")
-        if status in [
-            self.REVOKED_STATUS,
-            self.RETURNED_STATUS,
-            self.CANCELLED_STATUS,
-            self.EXPIRED_STATUS,
-        ]:
-            # This loan was already returned early or revoked by the distributor, or it expired.
-            self.update_loan(loan, doc)
-            raise NotCheckedOut()
+        if loan.external_identifier is None:
+            # We can't return a loan that doesn't have an external identifier. This should never happen
+            # but if it does, we self.log an error and continue on, so it doesn't stay on the patrons
+            # bookshelf forever.
+            self.log.error(f"Loan {loan.id} has no external identifier.")
+            return
+        if loan.license is None:
+            # We can't return a loan that doesn't have a license. This should never happen but if it does,
+            # we self.log an error and continue on, so it doesn't stay on the patrons bookshelf forever.
+            self.log.error(f"Loan {loan.id} has no license.")  # type: ignore
+            return
 
-        return_url = None
-        links = doc.get("links", [])
-        for link in links:
-            if link.get("rel") == "return":
-                return_url = link.get("href")
-                break
+        loan_status = self._request_loan_status(loan.external_identifier)
+        if not loan_status.active:
+            self.log.warning(
+                f"Loan {loan.id} was {loan_status.status} was already returned early, revoked by the distributor, or it expired."
+            )
+            loan.license.checkin()
+            self.update_licensepool_and_hold_queue(loan.license_pool)
+            return
 
-        if not return_url:
-            # The distributor didn't provide a link to return this loan.
-            # This may be because the book has already been fulfilled and
-            # must be returned through the DRM system. If that's true, the
-            # app will already be doing that on its own, so we'll silently
-            # do nothing.
-            return False
+        return_link = loan_status.links.get(
+            rel="return", content_type=LoanStatus.content_type()
+        )
+        if not return_link:
+            # The distributor didn't provide a link to return this loan. This means that the distributor
+            # does not support early returns, and the patron will have to wait until the loan expires.
+            raise CannotReturn()
 
-        # Hit the distributor's return link.
-        self._get(return_url)
-        # Get the status document again to make sure the return was successful,
-        # and if so update the pool availability and delete the local loan.
-        self.update_loan(loan)
+        # The parameters for this link (if its templated) are defined here:
+        # https://readium.org/lcp-specs/releases/lsd/latest.html#34-returning-a-publication
+        # None of them are required, and often the link is not templated. But in the case
+        # of the open source LCP server, the link is templated, so we need to process the
+        # template before we can make the request.
+        return_url = return_link.href
 
-        # At this point, if the loan still exists, something went wrong.
-        # However, it might be because the loan has already been fulfilled
-        # and must be returned through the DRM system, which the app will
-        # do on its own, so we can ignore the problem.
-        new_loan = get_one(_db, Loan, id=loan.id)
-        if new_loan:
-            return False
-        return True
+        # Hit the distributor's return link, and if it's successful, update the pool
+        # availability.
+        loan_status = self._request_loan_status(return_url)
+        if loan_status.active:
+            # If the distributor says the loan is still active, we didn't return it, and
+            # something went wrong. We self.log an error and don't delete the loan, so the patron
+            # can try again later.
+            self.log.error(
+                f"Loan {loan.id} was {loan_status.status} not returned. The distributor says it's still active. {loan_status}"
+            )
+            raise CannotReturn()
+        loan.license.checkin()
+        self.update_licensepool_and_hold_queue(loan.license_pool)
 
     def checkout(
         self,
@@ -437,37 +396,24 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         if loan.count() > 0:
             raise AlreadyCheckedOut()
 
-        if licensepool.open_access:
-            loan_start = None
-            loan_end = None
-            external_identifier = None
+        if licensepool.open_access or licensepool.unlimited_access:
+            return LoanInfo.from_license_pool(
+                licensepool,
+                end_date=None,
+            )
         else:
             hold = get_one(_db, Hold, patron=patron, license_pool_id=licensepool.id)
-            loan_obj = self._checkout(patron, licensepool, hold)
-            loan_start = loan_obj.start
-            loan_end = loan_obj.end
-            external_identifier = loan_obj.external_identifier
-
-        return LoanInfo.from_license_pool(
-            licensepool,
-            start_date=loan_start,
-            end_date=loan_end,
-            external_identifier=external_identifier,
-        )
+            return self._checkout(patron, licensepool, hold)
 
     def _checkout(
         self, patron: Patron, licensepool: LicensePool, hold: Hold | None = None
-    ) -> Loan:
-        _db = Session.object_session(patron)
+    ) -> LoanInfo:
+        db = Session.object_session(patron)
 
         if not any(l for l in licensepool.licenses if not l.is_inactive):
             raise NoLicenses()
-
         # Make sure pool info is updated.
-        self.update_licensepool(licensepool)
-
-        if hold:
-            self._update_hold_data(hold)
+        self.update_licensepool_and_hold_queue(licensepool)
 
         # If there's a holds queue, the patron must have a non-expired hold
         # with position 0 to check out the book.
@@ -478,74 +424,147 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         ) and licensepool.licenses_available < 1:
             raise NoAvailableCopies()
 
-        # Create a local loan so its database id can be used to
-        # receive notifications from the distributor.
-        license = licensepool.best_available_license()
-        if not license:
-            raise NoAvailableCopies()
-        loan, ignore = license.loan_to(patron)
+        if self.collection is None:
+            raise ValueError(f"Collection not found: {self.collection_id}")
+        default_loan_period = self.collection.default_loan_period(patron.library)
+        requested_expiry = utc_now() + datetime.timedelta(days=default_loan_period)
+        patron_id = patron.identifier_to_remote_service(licensepool.data_source)
+        library_short_name = patron.library.short_name
+        hasher = self._get_hasher()
+        unhashed_pass: LCPUnhashedPassphrase = (
+            self._credential_factory.get_patron_passphrase(db, patron)
+        )
+        hashed_pass: LCPHashedPassphrase = unhashed_pass.hash(hasher)
+        self._credential_factory.set_hashed_passphrase(db, patron, hashed_pass)
+        encoded_pass = base64.b64encode(binascii.unhexlify(hashed_pass.hashed))
 
-        try:
-            doc = self.get_license_status_document(loan)
-        except BadResponseException as e:
-            _db.delete(loan)
-            response = e.response
-            # DeMarque sends "application/api-problem+json", but the ODL spec says we should
-            # expect "application/problem+json", so we need to check for both.
-            if response.headers.get("Content-Type") in [
-                "application/api-problem+json",
-                "application/problem+json",
-            ]:
-                try:
-                    json_response = response.json()
-                except ValueError:
-                    json_response = {}
+        licenses = licensepool.best_available_licenses()
+        self.log.info(
+            f"Available licenses in license pool {licensepool.identifier}: {len(licenses)}"
+        )
 
-                if (
-                    json_response.get("type")
-                    == "http://opds-spec.org/odl/error/checkout/unavailable"
-                ):
-                    raise NoAvailableCopies()
-            raise
-
-        status = doc.get("status")
-
-        if status not in [self.READY_STATUS, self.ACTIVE_STATUS]:
-            # Something went wrong with this loan and we don't actually
-            # have the book checked out. This should never happen.
-            # Remove the loan we created.
-            _db.delete(loan)
-            raise CannotLoan()
-
-        links = doc.get("links", [])
-        external_identifier = None
-        for link in links:
-            if link.get("rel") == "self":
-                external_identifier = link.get("href")
+        license_: License | None = None
+        loan_status: LoanStatus | None = None
+        for license_ in licenses:
+            try:
+                self.log.info(
+                    f"Trying license id {license_.identifier} with {license_.checkouts_available} checkouts..."
+                )
+                loan_status = self._checkout_license(
+                    license_,
+                    library_short_name,
+                    patron_id,
+                    requested_expiry.isoformat(),
+                    encoded_pass,
+                )
                 break
-        if not external_identifier:
-            _db.delete(loan)
+            except NoAvailableCopies:
+                self.log.info(
+                    f"No available checkouts for license: {license_.identifier}. Trying the next one..."
+                )
+                # This license had no available copies, so we try the next one.
+                ...
+
+        # No best available licenses were found in the first place or, for some reason, there's no status.
+        if license_ is None or loan_status is None:
+            # Instantly get updated information from licenses.
+            licensepool.update_availability_from_licenses()
+            # If we have a hold, it means we thought the book was available, but it wasn't.
+            if hold:
+                # The license should be available at most by the default loan period in E-Kirjasto.
+                hold.end = utc_now() + datetime.timedelta(days=default_loan_period)
+                # Update the pool's queue and raise a specific error message.
+                self._recalculate_holds_in_license_pool(licensepool)
+                raise NoAvailableCopiesWhenReserved()
+            raise NoAvailableCopies()
+
+        if not loan_status.active:
+            # Something went wrong with this loan, and we don't actually
+            # have the book checked out. This should never happen.
+            self.log.warning(
+                f"Loan status for license {license_.identifier} was {loan_status.status} instead of active"
+            )
             raise CannotLoan()
 
-        start = utc_now()
-        expires = doc.get("potential_rights", {}).get("end")
-        if expires:
-            expires = dateutil.parser.parse(expires)
+        # We save the link to the loan status document in the loan's external_identifier field, so
+        # we are able to retrieve it later.
+        loan_status_document_link: Link | None = loan_status.links.get(
+            rel="self", content_type="application/vnd.readium.license.status.v1.0+json"
+        )
 
-        # We need to set the start and end dates on our local loan since
-        # the code that calls this only sets them when a new loan is created.
-        loan.start = start
-        loan.end = expires
-        loan.external_identifier = external_identifier
+        if not loan_status_document_link:
+            self.log.warning(
+                f"There was no loan status link for license {license_.identifier}"
+            )
+            raise CannotLoan()
+
+        loan_start = utc_now()
+        loan = LoanInfo.from_license_pool(
+            licensepool,
+            start_date=loan_start,
+            end_date=loan_status.potential_rights.end,
+            external_identifier=loan_status_document_link.href,
+            license_identifier=license_.identifier,
+        )
 
         # We also need to update the remaining checkouts for the license.
-        loan.license.checkout()
+        license_.checkout()
 
-        # We have successfully borrowed this book.
-        if hold:
-            _db.delete(hold)
-        self.update_licensepool(licensepool)
+        # If there was a hold CirculationAPI will take care of deleting it. So we just need to
+        # update the license pool to reflect the loan. Since update_availability_from_licenses
+        # takes into account holds, we need to tell it to ignore the hold about to be deleted.
+        self.update_licensepool_and_hold_queue(
+            licensepool, ignored_holds={hold} if hold else None
+        )
+        self.log.info(f"License {license_.identifier} checked out with LoanInfo {loan}")
         return loan
+
+    def _checkout_license(
+        self,
+        license_: License,
+        library_short_name: str | None,
+        patron_id: str,
+        expiry: str,
+        encoded_pass: str,
+    ) -> LoanStatus:
+        identifier = str(license_.identifier)
+        checkout_id = str(uuid.uuid4())
+        notification_url = self._notification_url(
+            library_short_name,
+            patron_id,
+            identifier,
+        )
+        # We should never be able to get here if the license doesn't have a checkout_url, but
+        # we assert it anyway, to be sure we fail fast if it happens.
+        assert license_.checkout_url is not None
+        url_template = URITemplate(license_.checkout_url)
+        checkout_url = url_template.expand(
+            id=identifier,
+            checkout_id=checkout_id,
+            patron_id=patron_id,
+            expires=expiry,
+            notification_url=notification_url,
+            passphrase=encoded_pass,
+            hint=self.settings.passphrase_hint,
+            hint_url=self.settings.passphrase_hint_url,
+        )
+
+        try:
+            loan_status = self._request_loan_status(
+                checkout_url,
+                ignored_problem_types=[
+                    "http://opds-spec.org/odl/error/checkout/unavailable"
+                ],
+            )
+            return loan_status
+        except OpdsWithOdlException as e:
+            if e.type == "http://opds-spec.org/odl/error/checkout/unavailable":
+                # TODO: This would be a good place to do an async availability update, since we know
+                #   the book is unavailable, when we thought it was available. For now, we know that
+                #   the license has no checkouts_available, so we do that update.
+                license_.checkouts_available = 0
+                raise NoAvailableCopies() from e
+            raise
 
     def fulfill(
         self,
@@ -553,10 +572,9 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         pin: str,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
-    ) -> FulfillmentInfo:
+    ) -> Fulfillment:
         """Get the actual resource file to the patron."""
         _db = Session.object_session(patron)
-
         loan = (
             _db.query(Loan)
             .filter(Loan.patron == patron)
@@ -565,246 +583,133 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         return self._fulfill(loan, delivery_mechanism)
 
     @staticmethod
-    def _find_content_link_and_type(
-        links: list[dict[str, str]],
-        drm_scheme: str | None,
-    ) -> tuple[str | None, str | None]:
-        """Find a content link with the type information corresponding to the selected delivery mechanism.
+    def _get_resource_for_delivery_mechanism(
+        requested_delivery_mechanism: DeliveryMechanism, licensepool: LicensePool
+    ) -> Resource:
+        resource = next(
+            (
+                lpdm.resource
+                for lpdm in licensepool.delivery_mechanisms
+                if lpdm.delivery_mechanism == requested_delivery_mechanism
+                and lpdm.resource is not None
+            ),
+            None,
+        )
+        if resource is None:
+            raise FormatNotAvailable()
+        return resource
 
-        :param links: List of dict-like objects containing information about available links in the LCP license file
-        :param drm_scheme: Selected delivery mechanism DRM scheme
+    def _unlimited_access_fulfill(
+        self, loan: Loan, delivery_mechanism: LicensePoolDeliveryMechanism
+    ) -> Fulfillment:
+        licensepool = loan.license_pool
+        resource = self._get_resource_for_delivery_mechanism(
+            delivery_mechanism.delivery_mechanism, licensepool
+        )
+        if resource.representation is None:
+            raise FormatNotAvailable()
+        content_link = resource.representation.public_url
+        content_type = resource.representation.media_type
+        return RedirectFulfillment(
+            content_link, content_type
+        )  # Tää pitää kattoo, ei ole circulation.py:ssä
 
-        :return: Two-tuple containing a content link and content type
-        """
-        candidates = []
-        for link in links:
-            # Depending on the format being served, the crucial information
-            # may be in 'manifest' or in 'license'.
-            if link.get("rel") not in ("manifest", "license"):
-                continue
-            href = link.get("href")
-            type = link.get("type")
-            candidates.append((href, type))
+    def _license_fulfill(
+        self, loan: Loan, delivery_mechanism: LicensePoolDeliveryMechanism
+    ) -> Fulfillment:
+        # We are unable to fulfill a loan that doesn't have its external identifier set,
+        # since we use this to get to the checkout link. It shouldn't be possible to get
+        # into this state.
+        license_status_url = loan.external_identifier
+        assert license_status_url is not None
 
-        if len(candidates) == 0:
-            # No candidates
-            return None, None
+        loan_status = self._request_loan_status(license_status_url)
 
-        # For DeMarque audiobook content, we need to translate the type property
-        # to reflect what we have stored in our delivery mechanisms.
-        if drm_scheme == DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM:
-            drm_scheme = ODLImporter.FEEDBOOKS_AUDIO
+        if not loan_status.active:
+            # This loan isn't available for some reason. It's possible
+            # the distributor revoked it or the patron already returned it
+            # through the DRM system, and we didn't get a notification
+            # from the distributor yet.
+            db = Session.object_session(loan)
+            db.delete(loan)
+            self.log.warning(
+                f"Loan status was not active but {loan_status.status}, can not fulfill"
+            )
+            raise CannotFulfill()
 
-        return next(filter(lambda x: x[1] == drm_scheme, candidates), (None, None))
+        drm_scheme = delivery_mechanism.delivery_mechanism.drm_scheme
+        fulfill_cls: Callable[[str, str | None], UrlFulfillment]
+        if drm_scheme == DeliveryMechanism.NO_DRM:
+            # If we have no DRM, we can just redirect to the content link and let the patron download the book.
+            fulfill_link = loan_status.links.get(
+                rel="publication",
+                content_type=delivery_mechanism.delivery_mechanism.content_type,  # type: ignore
+            )
+            fulfill_cls = RedirectFulfillment
+        elif drm_scheme == DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM:
+            # For DeMarque audiobook content using "FEEDBOOKS_AUDIOBOOK_DRM", the link
+            # we are looking for is stored in the 'manifest' rel.
+            fulfill_link = loan_status.links.get(
+                rel="manifest", content_type=BaseODLImporter.FEEDBOOKS_AUDIO
+            )
+            fulfill_cls = partial(FetchFulfillment, allowed_response_codes=["2xx"])
+        else:
+            # We are getting content via a license loan_status document, so we need to find the link
+            # that corresponds to the delivery mechanism we are using.
+            fulfill_link = loan_status.links.get(rel="license", content_type=drm_scheme)  # type: ignore
+            fulfill_cls = partial(FetchFulfillment, allowed_response_codes=["2xx"])
+
+        if fulfill_link is None:
+            raise CannotFulfill()
+
+        self.log.info(f"Fulfilling with {drm_scheme}, Link: {fulfill_link.href}")
+        return fulfill_cls(fulfill_link.href, fulfill_link.content_type)
 
     def _fulfill(
         self,
         loan: Loan,
         delivery_mechanism: LicensePoolDeliveryMechanism,
-    ) -> FulfillmentInfo:
-        licensepool = loan.license_pool
-
-        if licensepool.open_access:
-            expires = None
-            requested_mechanism = delivery_mechanism.delivery_mechanism
-            fulfillment = next(
-                (
-                    lpdm
-                    for lpdm in licensepool.delivery_mechanisms
-                    if lpdm.delivery_mechanism == requested_mechanism
-                ),
-                None,
-            )
-            if fulfillment is None:
-                raise FormatNotAvailable()
-            content_link = fulfillment.resource.representation.public_url
-            content_type = fulfillment.resource.representation.media_type
+    ) -> Fulfillment:
+        if loan.license_pool.open_access or loan.license_pool.unlimited_access:
+            return self._unlimited_access_fulfill(loan, delivery_mechanism)
         else:
-            doc = self.get_license_status_document(loan)
-            status = doc.get("status")
+            return self._license_fulfill(loan, delivery_mechanism)
 
-            if status not in [self.READY_STATUS, self.ACTIVE_STATUS]:
-                # This loan isn't available for some reason. It's possible
-                # the distributor revoked it or the patron already returned it
-                # through the DRM system, and we didn't get a notification
-                # from the distributor yet.
-                self.update_loan(loan, doc)
-                raise CannotFulfill()
-
-            expires = doc.get("potential_rights", {}).get("end")
-            expires = dateutil.parser.parse(expires)
-
-            links = doc.get("links", [])
-
-            content_link, content_type = self._find_content_link_and_type(
-                links, delivery_mechanism.delivery_mechanism.drm_scheme
-            )
-
-        return FulfillmentInfo(
-            licensepool.collection,
-            licensepool.data_source.name,
-            licensepool.identifier.type,
-            licensepool.identifier.identifier,
-            content_link,
-            content_type,
-            None,
-            expires,
+    def _recalculate_holds_in_license_pool(self, licensepool: LicensePool) -> None:
+        """Set any holds ready for checkout and update the position for all other holds in the queue."""
+        holds = licensepool.holds_by_start_date()
+        ready_for_checkout = holds[: licensepool.licenses_reserved]
+        waiting = holds[licensepool.licenses_reserved :]
+        self.log.info(
+            f"Holds in License pool [{licensepool.identifier}]: {len(holds)} "
+            f"holds / {len(ready_for_checkout)} ready to checkout / {len(waiting)} in queue"
         )
 
-    def _count_holds_before(self, holdinfo: HoldInfo, pool: LicensePool) -> int:
-        # Count holds on the license pool that started before this hold and
-        # aren't expired.
-        _db = Session.object_session(pool)
-        return (
-            _db.query(Hold)
-            .filter(Hold.license_pool_id == pool.id)
-            .filter(Hold.start < holdinfo.start_date)
-            .filter(
-                or_(
-                    Hold.end == None,
-                    Hold.end > utc_now(),
-                    Hold.position > 0,
-                )
-            )
-            .count()
-        )
-
-    def _update_hold_data(self, hold: Hold) -> None:
-        pool: LicensePool = hold.license_pool
-        holdinfo = HoldInfo.from_license_pool(
-            pool,
-            start_date=hold.start,
-            end_date=hold.end,
-            hold_position=hold.position,
-        )
-        library = hold.patron.library
-        self._update_hold_end_date(holdinfo, pool, library=library)
-        hold.end = holdinfo.end_date
-        hold.position = holdinfo.hold_position
-
-    def _update_hold_end_date(
-        self, holdinfo: HoldInfo, pool: LicensePool, library: Library
-    ) -> None:
-        _db = Session.object_session(pool)
-
-        # First make sure the hold position is up-to-date, since we'll
-        # need it to calculate the end date.
-        original_position = holdinfo.hold_position
-        self._update_hold_position(holdinfo, pool)
-        assert holdinfo.hold_position is not None
-
-        if self.collection is None:
-            raise ValueError(f"Collection not found: {self.collection_id}")
-        default_loan_period = self.collection.default_loan_period(library)
+        assert self.collection is not None
         default_reservation_period = self.collection.default_reservation_period
-
-        # If the hold was already to check out and already has an end date,
-        # it doesn't need an update.
-        if holdinfo.hold_position == 0 and original_position == 0 and holdinfo.end_date:
-            return
-
-        # If the patron is in the queue, we need to estimate when the book
-        # will be available for check out. We can do slightly better than the
-        # default calculation since we know when all current loans will expire,
-        # but we're still calculating the worst case.
-        elif holdinfo.hold_position > 0:
-            # Find the current loans and reserved holds for the licenses.
-            current_loans = (
-                _db.query(Loan)
-                .filter(Loan.license_pool_id == pool.id)
-                .filter(or_(Loan.end == None, Loan.end > utc_now()))
-                .order_by(Loan.start)
-                .all()
-            )
-            current_holds = (
-                _db.query(Hold)
-                .filter(Hold.license_pool_id == pool.id)
-                .filter(
-                    or_(
-                        Hold.end == None,
-                        Hold.end > utc_now(),
-                        Hold.position > 0,
-                    )
-                )
-                .order_by(Hold.start)
-                .all()
-            )
-            assert pool.licenses_owned is not None
-            licenses_reserved = min(
-                pool.licenses_owned - len(current_loans), len(current_holds)
-            )
-            current_reservations = current_holds[:licenses_reserved]
-
-            # The licenses will have to go through some number of cycles
-            # before one of them gets to this hold. This leavs out the first cycle -
-            # it's already started so we'll handle it separately.
-            cycles = (
-                holdinfo.hold_position - licenses_reserved - 1
-            ) // pool.licenses_owned
-
-            # Each of the owned licenses is currently either on loan or reserved.
-            # Figure out which license this hold will eventually get if every
-            # patron keeps their loans and holds for the maximum time.
-            copy_index = (
-                holdinfo.hold_position - licenses_reserved - 1
-            ) % pool.licenses_owned
-
-            # In the worse case, the first cycle ends when a current loan expires, or
-            # after a current reservation is checked out and then expires.
-            if len(current_loans) > copy_index:
-                next_cycle_start = current_loans[copy_index].end
-            else:
-                reservation = current_reservations[copy_index - len(current_loans)]
-                next_cycle_start = reservation.end + datetime.timedelta(
-                    days=default_loan_period
-                )
-
-            # Assume all cycles after the first cycle take the maximum time.
-            cycle_period = default_loan_period + default_reservation_period
-            holdinfo.end_date = next_cycle_start + datetime.timedelta(
-                days=(cycle_period * cycles)
-            )
-
-        # If the end date isn't set yet or the position just became 0, the
-        # hold just became available. The patron's reservation period starts now.
-        else:
-            holdinfo.end_date = utc_now() + datetime.timedelta(
-                days=default_reservation_period
-            )
-
-    def _update_hold_position(self, holdinfo: HoldInfo, pool: LicensePool) -> None:
-        _db = Session.object_session(pool)
-        loans_count = (
-            _db.query(Loan)
-            .filter(
-                Loan.license_pool_id == pool.id,
-            )
-            .filter(or_(Loan.end == None, Loan.end > utc_now()))
-            .count()
-        )
-        holds_count = self._count_holds_before(holdinfo, pool)
-
-        assert pool.licenses_owned is not None
-        remaining_licenses = pool.licenses_owned - loans_count
-
-        if remaining_licenses > holds_count:
-            # The hold is ready to check out.
-            holdinfo.hold_position = 0
-
-        else:
-            # Add 1 since position 0 indicates the hold is ready.
-            holdinfo.hold_position = holds_count + 1
-
-    def update_licensepool(self, licensepool: LicensePool) -> None:
-        # Update the pool and the next holds in the queue when a license is reserved.
-        licensepool.update_availability_from_licenses(
-            as_of=utc_now(),
-        )
-        holds = licensepool.get_active_holds()
-        for hold in holds[: licensepool.licenses_reserved]:
+        # If we had available copies, reserve them for the same amount of holds at the top of the queue.
+        for hold in ready_for_checkout:
             if hold.position != 0:
-                # This hold just got a reserved license.
-                self._update_hold_data(hold)
+                hold.position = 0
+                # And start the reservation period.
+                hold.end = utc_now() + datetime.timedelta(
+                    days=default_reservation_period
+                )
+
+        # Update the rest of the queue.
+        for idx, hold in enumerate(waiting):
+            position = idx + 1
+            if hold.position != position:
+                hold.position = position
+
+    def update_licensepool_and_hold_queue(
+        self, licensepool: LicensePool, ignored_holds: set[Hold] | None = None
+    ) -> None:
+        """Update availability information of the license pool and recaulculate its holds queue."""
+        licensepool.update_availability_from_licenses(
+            as_of=utc_now(), ignored_holds=ignored_holds
+        )
+        self._recalculate_holds_in_license_pool(licensepool)
 
     def place_hold(
         self,
@@ -818,9 +723,8 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
 
     def _place_hold(self, patron: Patron, licensepool: LicensePool) -> HoldInfo:
         _db = Session.object_session(patron)
-
         # Make sure pool info is updated.
-        self.update_licensepool(licensepool)
+        licensepool.update_availability_from_licenses()
 
         if licensepool.licenses_available > 0:
             raise CurrentlyAvailable()
@@ -845,12 +749,9 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         holdinfo = HoldInfo.from_license_pool(
             licensepool,
             start_date=utc_now(),
-            end_date=None,
-            hold_position=0,
+            end_date=utc_now() + datetime.timedelta(days=365),  # E-Kirjasto
+            hold_position=licensepool.patrons_in_hold_queue,
         )
-        library = patron.library
-        self._update_hold_end_date(holdinfo, licensepool, library=library)
-
         return holdinfo
 
     def release_hold(self, patron: Patron, pin: str, licensepool: LicensePool) -> None:
@@ -865,23 +766,12 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         )
         if not hold:
             raise NotOnHold()
-        self._release_hold(hold)
-
-    def _release_hold(self, hold: Hold) -> Literal[True]:
-        # If the book was ready and the patron revoked the hold instead
-        # of checking it out, but no one else had the book on hold, the
-        # book is now available for anyone to check out. If someone else
-        # had a hold, the license is now reserved for the next patron.
-        # If someone else had a hold, the license is now reserved for the
-        # next patron, and we need to update that hold.
-        _db = Session.object_session(hold)
-        licensepool = hold.license_pool
-        _db.delete(hold)
-        self.update_licensepool(licensepool)
-        return True
+        # The hold itself will be deleted by the caller CirculationAPI,
+        # so we just need to update the license pool to reflect the released hold.
+        self.update_licensepool_and_hold_queue(licensepool, ignored_holds={hold})
 
     def patron_activity(self, patron: Patron, pin: str) -> list[LoanInfo | HoldInfo]:
-        """Look up non-expired loans for this collection in the database."""
+        """Look up non-expired loans for this collection in the database and update holds."""
         _db = Session.object_session(patron)
         loans = (
             _db.query(Loan)
@@ -895,7 +785,6 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
                 )
             )
         )
-
         # Get the patron's holds. If there are any expired holds, delete them.
         # Update the end date and position for the remaining holds.
         holds = (
@@ -906,13 +795,15 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         )
         remaining_holds = []
         for hold in holds:
+            licensepool = hold.license_pool
+            # Delete expired holds and update the pool and queue to reflect the change.
             if hold.end and hold.end < utc_now():
                 _db.delete(hold)
-                self.update_licensepool(hold.license_pool)
+                self._recalculate_holds_in_license_pool(licensepool)
             else:
-                self._update_hold_data(hold)
+                # Check to see if the position has changed in the queue or maybe the hold is ready for checkout.
+                self._recalculate_holds_in_license_pool(licensepool)
                 remaining_holds.append(hold)
-
         return [
             LoanInfo.from_license_pool(
                 loan.license_pool,
@@ -931,42 +822,8 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             for hold in remaining_holds
         ]
 
-    def update_loan(self, loan: Loan, status_doc: dict[str, Any] | None = None) -> None:
-        """Check a loan's status, and if it is no longer active, delete the loan
-        and update its pool's availability.
-        """
-        _db = Session.object_session(loan)
-
-        if not status_doc:
-            status_doc = self.get_license_status_document(loan)
-
-        status = status_doc.get("status")
-        # We already check that the status is valid in get_license_status_document,
-        # but if the document came from a notification it hasn't been checked yet.
-        if status not in self.STATUS_VALUES:
-            raise BadResponseException(
-                str(loan.license.checkout_url),
-                "The License Status Document had an unknown status value.",
-            )
-
-        if status in [
-            self.REVOKED_STATUS,
-            self.RETURNED_STATUS,
-            self.CANCELLED_STATUS,
-            self.EXPIRED_STATUS,
-        ]:
-            # This loan is no longer active. Update the pool's availability
-            # and delete the loan.
-
-            # Update the license
-            loan.license.checkin()
-
-            # If there are holds, the license is reserved for the next patron.
-            _db.delete(loan)
-            self.update_licensepool(loan.license_pool)
-
     def update_availability(self, licensepool: LicensePool) -> None:
-        pass
+        licensepool.update_availability_from_licenses()
 
 
 class ODLAPI(
@@ -1109,6 +966,10 @@ class BaseODLImporter(BaseOPDSImporter[SettingsType], ABC):
             elif isinstance(document_format, list):
                 content_types = document_format
 
+        cls.logger().info(
+            f"License identifier {identifier} / status {status} / concurrency {concurrency} / expires {expires} / checkouts left {left} / available / {available} / content types {content_types}"
+        )
+
         return LicenseData(
             identifier=identifier,
             checkout_url=checkout_link,
@@ -1135,7 +996,7 @@ class BaseODLImporter(BaseOPDSImporter[SettingsType], ABC):
 
         if not license_info_document:
             return None
-
+        cls.logger().info(f"Parsing License Info Document {license_info_link}")
         parsed_license = cls.parse_license_info(
             license_info_document, license_info_link, checkout_link
         )
@@ -1367,7 +1228,7 @@ class ODLHoldReaper(CollectionMonitor):
             total_deleted_holds += 1
 
         for pool in changed_pools:
-            self.api.update_licensepool(pool)
+            self.api.update_licensepool_and_hold_queue(pool)
 
         message = "Holds deleted: %d. License pools updated: %d" % (
             total_deleted_holds,

--- a/api/odl.py
+++ b/api/odl.py
@@ -694,10 +694,10 @@ class BaseODLAPI(
         for hold in ready_for_checkout:
             if hold.position != 0:
                 hold.position = 0
-                # And start the reservation period.
-                hold.end = utc_now() + datetime.timedelta(
-                    days=default_reservation_period
-                )
+                # And start the reservation period which ends end of day.
+                hold.end = (
+                    utc_now() + datetime.timedelta(days=default_reservation_period)
+                ).replace(hour=23, minute=59, second=59, microsecond=999999)
 
         # Update the rest of the queue.
         for idx, hold in enumerate(waiting):

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from webpub_manifest_parser.odl import ODLFeedParserFactory
 from webpub_manifest_parser.opds2.registry import OPDS2LinkRelationsRegistry
 
+from api.circulation import LoanInfo
 from api.circulation_exceptions import PatronHoldLimitReached, PatronLoanLimitReached
 from api.odl import BaseODLAPI, BaseODLImporter, ODLLibrarySettings, ODLSettings
 from core.integration.settings import (
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
 
     from api.circulation import HoldInfo
     from core.model import Collection, LicensePool
-    from core.model.patron import Hold, Loan, Patron
+    from core.model.patron import Hold, Patron
 
 
 class ODL2Settings(ODLSettings, OPDS2ImporterSettings):
@@ -103,7 +104,7 @@ class ODL2API(BaseODLAPI[ODL2Settings, ODLLibrarySettings]):
 
     def _checkout(
         self, patron: Patron, licensepool: LicensePool, hold: Hold | None = None
-    ) -> Loan:
+    ) -> LoanInfo:
         # If the loan limit is not None or 0
         if self.loan_limit:
             loans = list(

--- a/api/odl_api/auth.py
+++ b/api/odl_api/auth.py
@@ -1,0 +1,64 @@
+from requests import Response
+from typing_extensions import Self
+
+from core.util.http import BadResponseException
+from core.util.problem_detail import ProblemDetail
+
+
+class OpdsWithOdlException(BadResponseException):
+    """
+    ODL and Readium LCP specify that all errors should be returned as Problem
+    Detail documents. This isn't always the case, but we try to use this information
+    when we can.
+    """
+
+    def __init__(
+        self,
+        type: str,
+        title: str,
+        status: int,
+        detail: str | None,
+        response: Response,
+    ) -> None:
+        super().__init__(url_or_service=response.url, message=title, response=response)
+        self.type = type
+        self.title = title
+        self.status = status
+        self.detail = detail
+
+    @property
+    def problem_detail(self) -> ProblemDetail:
+        return ProblemDetail(
+            uri=self.type,
+            status_code=self.status,
+            title=self.title,
+            detail=self.detail,
+        )
+
+    @classmethod
+    def from_response(cls, response: Response) -> Self | None:
+        # Wrap the response in a OpdsWithOdlException if it is a problem detail document.
+        #
+        # DeMarque sends "application/api-problem+json", but the ODL spec says we should
+        # expect "application/problem+json", so we need to check for both.
+        if response.headers.get("Content-Type") not in [
+            "application/api-problem+json",
+            "application/problem+json",
+        ]:
+            print(f"auth.py: {response.headers}")
+            return None
+
+        try:
+            json_response = response.json()
+        except ValueError:
+            json_response = {}
+
+        type = json_response.get("type")
+        title = json_response.get("title")
+        status = json_response.get("status") or response.status_code
+        detail = json_response.get("detail")
+
+        if type is None or title is None:
+            return None
+
+        return cls(type, title, status, detail, response)

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -56,14 +56,6 @@ NO_AVAILABLE_LICENSE = pd(
     _("All licenses for this book are loaned out."),
 )
 
-# E-kirjasto
-NO_COPIES_WHEN_RESERVED = pd(
-    "http://librarysimplified.org/terms/problem/cannot-issue-loan",
-    502,
-    _("No available license."),
-    _("All copies of this book are loaned out after all. You are still next in line."),
-)
-
 NO_ACCEPTABLE_FORMAT = pd(
     "http://librarysimplified.org/terms/problem/no-acceptable-format",
     400,
@@ -300,6 +292,22 @@ INVALID_EKIRJASTO_TOKEN = pd(
 )
 
 # Finland
+MISSING_USER_INFO = pd(
+    "http://librarysimplified.org/terms/problem/credentials-invalid",
+    status_code=500,
+    title=_("Missing permanent id"),
+    detail="Value for permanent_id is missing in remote user info.",
+)
+
+# Finland
+PATRON_NOT_FOUND_ON_REMOTE = pd(
+    "",
+    status_code=404,
+    title=("Patron not found"),
+    detail=("Remote patron is conflicting with delegate patron."),
+)
+
+# Finland
 EKIRJASTO_REMOTE_AUTHENTICATION_FAILED = pd(
     "http://librarysimplified.org/terms/problem/credentials-invalid",
     status_code=400,
@@ -433,5 +441,14 @@ PATRON_AUTH_ACCESS_TOKEN_NOT_POSSIBLE = pd(
     title=_("Access token not possible"),
     detail=_(
         "The patron authentication access token is not possible for this type of authentication."
+    ),
+)
+
+COULD_NOT_MIRROR_TO_REMOTE = pd(
+    "http://librarysimplified.org/terms/problem/cannot-mirror-to-remote",
+    503,
+    _("Loan deleted locally but remote failed."),
+    _(
+        "Could not convince a third party to accept the change you made. It's likely to show up again soon."
     ),
 )

--- a/api/routes.py
+++ b/api/routes.py
@@ -10,7 +10,7 @@ from flask_pydantic_spec import Response as SpecResponse
 from api.app import api_spec, app
 from api.model.patron_auth import PatronAuthAccessToken
 from api.model.time_tracking import PlaytimeEntriesPost, PlaytimeEntriesPostResponse
-from core.app_server import compressible, returns_problem_detail
+from core.app_server import compressible, raises_problem_detail, returns_problem_detail
 from core.model import HasSessionCache
 from core.util.problem_detail import ProblemDetail
 
@@ -486,7 +486,6 @@ def borrow(identifier_type, identifier, mechanism_id=None):
 
 @library_route("/works/<license_pool_id>/fulfill")
 @library_route("/works/<license_pool_id>/fulfill/<mechanism_id>")
-@library_route("/works/<license_pool_id>/fulfill/<mechanism_id>")
 @has_library
 @allows_patron_web
 @returns_problem_detail
@@ -691,12 +690,28 @@ def client_libraries(library_uuid):
     return app.manager.catalog_descriptions.get_catalogs(library_uuid)
 
 
-# Loan notifications for ODL distributors, eg. Feedbooks
+# TODO: This is a deprecated route that will be removed in a future release of the code,
+#       its left here for now to provide a dummy endpoint for existing ODL loans. All
+#       new loans will use the new endpoint.
 @library_route("/odl_notify/<loan_id>", methods=["GET", "POST"])
 @has_library
-@returns_problem_detail
-def odl_notify(loan_id):
-    return app.manager.odl_notification_controller.notify(loan_id)
+@raises_problem_detail
+def odl_notify(loan_id) -> Response:
+    return app.manager.odl_notification_controller.notify_deprecated(loan_id)
+
+
+# Loan notifications for OPDS + ODL distributors
+@library_route(
+    "/odl/notify/<patron_identifier>/<license_identifier>", methods=["GET", "POST"]
+)
+@has_library
+@raises_problem_detail
+def opds2_with_odl_notification(
+    patron_identifier: str, license_identifier: str
+) -> Response:
+    return app.manager.odl_notification_controller.notify(
+        patron_identifier, license_identifier
+    )
 
 
 # Controllers used for operations purposes

--- a/core/app_server.py
+++ b/core/app_server.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 import gzip
 import sys
 import traceback
+from collections.abc import Callable
 from functools import wraps
 from io import BytesIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 import flask
 from flask import Response, make_response, url_for
@@ -23,7 +24,7 @@ from core.problem_details import *
 from core.service.logging.configuration import LogLevel
 from core.util.log import LoggerMixin
 from core.util.opds_writer import OPDSMessage
-from core.util.problem_detail import ProblemDetail
+from core.util.problem_detail import BaseProblemDetailException, ProblemDetail
 
 if TYPE_CHECKING:
     from api.util.flask import PalaceFlask
@@ -107,6 +108,21 @@ def returns_problem_detail(f):
         if isinstance(v, ProblemDetail):
             return v.response
         return v
+
+    return decorated
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def raises_problem_detail(f: Callable[P, T]) -> Callable[P, T | Response]:
+    @wraps(f)
+    def decorated(*args: P.args, **kwargs: P.kwargs) -> T | Response:
+        try:
+            return f(*args, **kwargs)
+        except BaseProblemDetailException as e:
+            return make_response(e.problem_detail.response)
 
     return decorated
 

--- a/core/feed/acquisition.py
+++ b/core/feed/acquisition.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from dependency_injector.wiring import Provide, inject
 from sqlalchemy.orm import Query, Session
 
+from api.circulation import Fulfillment, FulfillmentInfo
 from api.problem_details import NOT_FOUND_ON_REMOTE
 from core.entrypoint import EntryPoint
 from core.external_search import ExternalSearchIndex, QueryParseException
@@ -558,7 +559,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         circulation: Any,
         item: LicensePool | Loan,
         annotator: LibraryAnnotator | None = None,
-        fulfillment: FulfillmentInfo | None = None,
+        fulfillment: FulfillmentInfo | Fulfillment | None = None,
         selected_book: SelectedBook | None = None,
         **response_kwargs: Any,
     ) -> OPDSEntryResponse | ProblemDetail | None:

--- a/core/feed/serializer/opds2.py
+++ b/core/feed/serializer/opds2.py
@@ -33,6 +33,8 @@ MARC_CODE_TO_ROLES = {
 
 
 class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
+    CONTENT_TYPE = "application/opds+json"
+
     def __init__(self) -> None:
         pass
 
@@ -210,7 +212,7 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
         return result
 
     def content_type(self) -> str:
-        return "application/opds+json"
+        return self.CONTENT_TYPE
 
     @classmethod
     def to_string(cls, data: dict[str, Any]) -> str:

--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -211,7 +211,7 @@ class License(Base, LicenseFunctions):
             logging.warning(f"Checking in expired license # {self.identifier}.")
 
     def __repr__(self):
-        return f"License id: {self.identifier}, checkouts left: {self.checkouts_left}, available: {self.checkouts_available} active: {self.is_inactive} to borrow: {self.is_available_for_borrowing}"
+        return f"License id: {self.identifier}, checkouts left: {self.checkouts_left}, available: {self.checkouts_available}, is inactive: {self.is_inactive}, can be borrowed: {self.is_available_for_borrowing}"
 
 
 class LicensePool(Base):

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -246,6 +246,10 @@ class Patron(Base):
             refresh,
             allow_persistent_token=True,
         )
+        # Any way that we create a credential should result in a result that does not
+        # have credential.credential set to None. Mypy doesn't know that, so we assert
+        # it here.
+        assert credential.credential is not None
         return credential.credential
 
     def works_on_loan(self):
@@ -635,6 +639,9 @@ class Loan(Base, LoanAndHoldMixin):
         start = self.start or utc_now()
         return start + default_loan_period
 
+    def __repr__(self):
+        return f"Loan id: {self.id}, ext id: {self.external_identifier} loan period: {self.start} - {self.end}"
+
 
 # Finland
 class LoanCheckout(Base, LoanAndHoldMixin):
@@ -679,6 +686,11 @@ class Hold(Base, LoanAndHoldMixin):
 
     def __lt__(self, other):
         return self.id < other.id
+
+    def __repr__(self):
+        return (
+            f"Hold id={self.id} start={self.start}->{self.end} position={self.position}"
+        )
 
     @classmethod
     def _calculate_until(

--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -35,7 +35,7 @@ from webpub_manifest_parser.opds2.registry import (
 )
 from webpub_manifest_parser.utils import encode, first_or_default
 
-from api.circulation import FulfillmentInfo
+from api.circulation import Fulfillment, FulfillmentInfo
 from api.circulation_exceptions import CannotFulfill
 from core.coverage import CoverageFailure
 from core.integration.settings import (
@@ -312,11 +312,11 @@ class OPDS2API(BaseOPDSAPI):
         pin: str,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
-    ) -> FulfillmentInfo:
+    ) -> Fulfillment | FulfillmentInfo:
         fufillment_info = super().fulfill(patron, pin, licensepool, delivery_mechanism)
         if self.token_auth_configuration:
             fufillment_info = self.fulfill_token_auth(
-                patron, licensepool, fufillment_info
+                patron, licensepool, fufillment_info  # type: ignore
             )
         return fufillment_info
 

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm.session import Session
 from api.circulation import (
     BaseCirculationAPI,
     BaseCirculationApiSettings,
+    Fulfillment,
     FulfillmentInfo,
     HoldInfo,
     LoanInfo,
@@ -284,7 +285,7 @@ class BaseOPDSAPI(
         pin: str,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
-    ) -> FulfillmentInfo:
+    ) -> FulfillmentInfo | Fulfillment:
         requested_mechanism = delivery_mechanism.delivery_mechanism
         fulfillment = None
         for lpdm in licensepool.delivery_mechanisms:
@@ -332,9 +333,9 @@ class BaseOPDSAPI(
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
         return LoanInfo.from_license_pool(licensepool, end_date=None)
 

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2745,7 +2745,7 @@ class LoanNotificationsScript(Script):
     are expiring"""
 
     # Days before on which to send out a notification
-    LOAN_EXPIRATION_DAYS = [5, 1]
+    LOAN_EXPIRATION_DAYS = [3, 1]
     BATCH_SIZE = 100
 
     def do_run(self):

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -116,8 +116,8 @@ class PushNotifications(LoggerMixin):
         edition = loan.license_pool.presentation_edition
         identifier = loan.license_pool.identifier
         library_short_name = loan.library.short_name
-        title = f"Only {days_to_expiry} {'days' if days_to_expiry != 1 else 'day'} left on your loan!"
-        body = f"Your loan on {edition.title} is expiring soon"
+        title = f'"{edition.title}" laina-aika on päättymässä!'
+        body = f'"{edition.title}" laina-aika päättyy {days_to_expiry} päivän päästä.'
         data = dict(
             title=title,
             body=body,
@@ -196,8 +196,9 @@ class PushNotifications(LoggerMixin):
             loans_api = f"{url}/{hold.patron.library.short_name}/loans"
             work: Work = hold.work
             identifier: Identifier = hold.license_pool.identifier
-            title = "Your hold is available!"
-            body = f'Your hold on "{work.title}" is available!'
+            title = f'Varauksesi "{work.title}" on lainattavissa!'
+            body = f"Varaus on lainattava viimeistään {hold.end.strftime('%-d.%-m.%Y') if hold.end else '3 päivän päästä'}."
+            print(body)
             data = dict(
                 title=title,
                 body=body,

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -18,26 +18,26 @@ RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends -o Dpkg::Options::="--force-confold" && \
     /bd_build/cleanup.sh
 
-ARG POETRY_VERSION=1.7.1
+ARG POETRY_VERSION=1.8.5
 
 # Install required packages including python, pip, compiliers and libraries needed
 # to build the python wheels we need and poetry.
 RUN install_clean \
-      nginx \
-      python3 \
-      python3-dev \
-      python3-venv \
-      python3-pip \
-      gcc \
-      # needed for uwsgi
-      libpcre3-dev \
-      # needed for psycopg2
-      libpq-dev \
-      # needed for xmlsec
-      libxmlsec1-dev \
-      libxmlsec1-openssl \
-      tzdata \
-      pkg-config && \
+    nginx \
+    python3 \
+    python3-dev \
+    python3-venv \
+    python3-pip \
+    gcc \
+    # needed for uwsgi
+    libpcre3-dev \
+    # needed for psycopg2
+    libpq-dev \
+    # needed for xmlsec
+    libxmlsec1-dev \
+    libxmlsec1-openssl \
+    tzdata \
+    pkg-config && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version $POETRY_VERSION && \
     ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry && \
     rm -rf /etc/logrotate.d/dpkg && \

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -1,7 +1,6 @@
 import datetime
 from collections.abc import Generator
-from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import feedparser
 import pytest
@@ -9,16 +8,20 @@ from flask import Response as FlaskResponse
 from flask import url_for
 from werkzeug import Response as wkResponse
 
-from api.axis import Axis360API, Axis360FulfillmentInfo
 from api.circulation import (
     BaseCirculationAPI,
     CirculationAPI,
-    FulfillmentInfo,
+    DirectFulfillment,
+    FetchFulfillment,
+    Fulfillment,
     HoldInfo,
     LoanInfo,
+    RedirectFulfillment,
 )
 from api.circulation_exceptions import (
     AlreadyOnHold,
+    CannotReleaseHold,
+    CannotReturn,
     NoAvailableCopies,
     NoAvailableCopiesWhenReserved,
     NoLicenses,
@@ -27,12 +30,15 @@ from api.circulation_exceptions import (
 )
 from api.problem_details import (
     BAD_DELIVERY_MECHANISM,
+    CANNOT_RELEASE_HOLD,
+    CHECKOUT_FAILED,
+    COULD_NOT_MIRROR_TO_REMOTE,
     HOLD_LIMIT_REACHED,
     NO_ACTIVE_LOAN,
-    NO_COPIES_WHEN_RESERVED,
+    NO_LICENSES,
     NOT_FOUND_ON_REMOTE,
-    OUTSTANDING_FINES,
 )
+from core.feed.serializer.opds2 import OPDS2Serializer
 from core.model import (
     Collection,
     DataSource,
@@ -44,6 +50,7 @@ from core.model import (
     LicensePoolDeliveryMechanism,
     Loan,
     MediaTypes,
+    Patron,
     Representation,
     RightsStatus,
     Work,
@@ -52,14 +59,13 @@ from core.model import (
 )
 from core.problem_details import INTEGRATION_ERROR, INVALID_INPUT
 from core.util.datetime_helpers import utc_now
-from core.util.flask_util import Response
+from core.util.flask_util import OPDSEntryResponse, Response
 from core.util.http import RemoteIntegrationException
-from core.util.opds_writer import OPDSFeed
+from core.util.opds_writer import AtomFeed, OPDSFeed
 from core.util.problem_detail import ProblemDetail
-from tests.core.mock import DummyHTTPClient
+from tests.api.mockapi.mock import MockHTTPClient
 from tests.fixtures.api_controller import CirculationControllerFixture
 from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.library import LibraryFixture
 
 
 class LoanFixture(CirculationControllerFixture):
@@ -72,6 +78,8 @@ class LoanFixture(CirculationControllerFixture):
     def __init__(self, db: DatabaseTransactionFixture):
         super().__init__(db)
         self.pool = self.english_1.license_pools[0]
+        assert self.pool.id is not None
+        self.pool_id = self.pool.id
         [self.mech1] = self.pool.delivery_mechanisms
         self.mech2 = self.pool.set_delivery_mechanism(
             Representation.PDF_MEDIA_TYPE,
@@ -83,12 +91,58 @@ class LoanFixture(CirculationControllerFixture):
         self.data_source = self.edition.data_source
         self.identifier = self.edition.primary_identifier
 
+        assert self.identifier is not None
+        assert self.identifier.identifier is not None
+        assert self.identifier.type is not None
+
+        self.identifier_identifier = self.identifier.identifier
+        self.identifier_type = self.identifier.type
+
 
 @pytest.fixture(scope="function")
 def loan_fixture(db: DatabaseTransactionFixture) -> Generator[LoanFixture, None, None]:
     fixture = LoanFixture(db)
     with fixture.wired_container():
         yield fixture
+
+
+class OPDSSerializationTestHelper:
+    PARAMETRIZED_SINGLE_ENTRY_ACCEPT_HEADERS = (
+        "accept_header,expected_content_type",
+        [
+            (None, OPDSFeed.ENTRY_TYPE),
+            ("default-foo-bar", OPDSFeed.ENTRY_TYPE),
+            (AtomFeed.ATOM_TYPE, OPDSFeed.ENTRY_TYPE),
+            (OPDS2Serializer.CONTENT_TYPE, OPDS2Serializer.CONTENT_TYPE),
+        ],
+    )
+
+    def __init__(
+        self,
+        accept_header: str | None = None,
+        expected_content_type: str | None = None,
+    ):
+        self.accept_header = accept_header
+        self.expected_content_type = expected_content_type
+
+    def merge_accept_header(self, headers):
+        return headers | ({"Accept": self.accept_header} if self.accept_header else {})
+
+    def verify_and_get_single_entry_feed_links(self, response):
+        assert response.content_type == self.expected_content_type
+        if self.expected_content_type == OPDSFeed.ENTRY_TYPE:
+            feed = feedparser.parse(response.get_data())
+            [entry] = feed["entries"]
+        elif self.expected_content_type == OPDS2Serializer.CONTENT_TYPE:
+            entry = response.get_json()
+        else:
+            assert (
+                False
+            ), f"Unexpected content type prefix: {self.expected_content_type}"
+
+        # Ensure that the response content parsed correctly.
+        assert "links" in entry
+        return entry["links"]
 
 
 class TestLoanController:
@@ -104,7 +158,7 @@ class TestLoanController:
         patron = object()
         pool = object()
         lpdm = object()
-        assert False == m(loan_fixture.db.default_library(), patron, pool, lpdm)
+        assert False == m(library=loan_fixture.db.default_library(), patron=patron, pool=pool, lpdm=lpdm)  # type: ignore
 
         # If the library does not authenticate patrons, then this
         # _may_ be possible, but
@@ -127,7 +181,7 @@ class TestLoanController:
             loan_fixture.manager.loans.circulation.can_fulfill_without_loan = (
                 mock_can_fulfill_without_loan
             )
-            assert True == m(loan_fixture.db.default_library(), patron, pool, lpdm)
+            assert True == m(library=loan_fixture.db.default_library(), patron=patron, pool=pool, lpdm=lpdm)  # type: ignore
             assert (patron, pool, lpdm) == self.called_with
 
     def test_patron_circulation_retrieval(self, loan_fixture: LoanFixture):
@@ -183,19 +237,13 @@ class TestLoanController:
             assert (hold, other_pool) == result
 
     @pytest.mark.parametrize(
-        "accept_header,expected_content_type_prefix",
-        [
-            (None, "application/atom+xml"),
-            ("default-foo-bar", "application/atom+xml"),
-            ("application/atom+xml", "application/atom+xml"),
-            ("application/opds+json", "application/opds+json"),
-        ],
+        *OPDSSerializationTestHelper.PARAMETRIZED_SINGLE_ENTRY_ACCEPT_HEADERS
     )
     def test_borrow_success(
         self,
         loan_fixture: LoanFixture,
         accept_header: str | None,
-        expected_content_type_prefix,
+        expected_content_type: str,
     ):
         # Create a loanable LicensePool.
         work = loan_fixture.db.work(
@@ -211,23 +259,29 @@ class TestLoanController:
             ),
         )
 
-        # Setup headers for the request.
-        headers = {"Authorization": loan_fixture.valid_auth} | (
-            {"Accept": accept_header} if accept_header else {}
+        serialization_helper = OPDSSerializationTestHelper(
+            accept_header, expected_content_type
+        )
+        headers = serialization_helper.merge_accept_header(
+            {"Authorization": loan_fixture.valid_auth}
         )
 
         # Create a new loan.
         with loan_fixture.request_context_with_library("/", headers=headers):
-            loan_fixture.manager.loans.authenticated_patron_from_request()
-            response = loan_fixture.manager.loans.borrow(
-                loan_fixture.identifier.type, loan_fixture.identifier.identifier
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            borrow_response = loan_fixture.manager.loans.borrow(
+                loan_fixture.identifier_type, loan_fixture.identifier_identifier
             )
             loan = get_one(
                 loan_fixture.db.session, Loan, license_pool=loan_fixture.pool
             )
 
             # A new loan should return a 201 status.
-            assert 201 == response.status_code
+            assert isinstance(borrow_response, FlaskResponse)
+            assert 201 == borrow_response.status_code
+
+            # And queue up a task to sync the patron's activity.
+            assert isinstance(patron, Patron)
 
             # A loan has been created for this license pool.
             assert loan is not None
@@ -236,13 +290,13 @@ class TestLoanController:
 
             # We've been given an OPDS feed with one entry, which tells us how
             # to fulfill the license.
-            new_feed_content = response.get_data()
+            new_feed_content = borrow_response.get_data()
 
         # Borrow again with an existing loan.
         with loan_fixture.request_context_with_library("/", headers=headers):
             loan_fixture.manager.loans.authenticated_patron_from_request()
-            response = loan_fixture.manager.loans.borrow(
-                loan_fixture.identifier.type, loan_fixture.identifier.identifier
+            borrow_response = loan_fixture.manager.loans.borrow(
+                loan_fixture.identifier_type, loan_fixture.identifier_identifier
             )
 
             # A loan has been created for this license pool.
@@ -250,7 +304,8 @@ class TestLoanController:
                 loan_fixture.db.session, Loan, license_pool=loan_fixture.pool
             )
             # An existing loan should return a 200 status.
-            assert 200 == response.status_code
+            assert isinstance(borrow_response, OPDSEntryResponse)
+            assert 200 == borrow_response.status_code
 
             # There is still a loan that has not yet been fulfilled.
             assert loan is not None
@@ -258,23 +313,17 @@ class TestLoanController:
 
             # We've been given an OPDS feed with one entry, which tells us how
             # to fulfill the license.
-            existing_feed_content = response.get_data()
+            existing_feed_content = borrow_response.get_data()
 
             # The new loan feed should look the same as the existing loan feed.
             assert new_feed_content == existing_feed_content
 
-            if expected_content_type_prefix == "application/atom+xml":
-                assert response.content_type.startswith("application/atom+xml")
-                feed = feedparser.parse(response.get_data())
-                [entry] = feed["entries"]
-            elif expected_content_type_prefix == "application/opds+json":
-                assert "application/opds+json" == response.content_type
-                entry = response.get_json()
+            feed_links = serialization_helper.verify_and_get_single_entry_feed_links(
+                borrow_response
+            )
 
             fulfillment_links = [
-                x["href"]
-                for x in entry["links"]
-                if x["rel"] == OPDSFeed.ACQUISITION_REL
+                x["href"] for x in feed_links if x["rel"] == OPDSFeed.ACQUISITION_REL
             ]
 
             assert loan_fixture.mech1.resource is not None
@@ -304,32 +353,25 @@ class TestLoanController:
             assert loan_fixture.mech1.resource.representation.url is not None
 
             # Now let's try to fulfill the loan using the first delivery mechanism.
-            fulfillment = FulfillmentInfo(
-                loan_fixture.pool.collection,
-                loan_fixture.pool.data_source,
-                loan_fixture.pool.identifier.type,
-                loan_fixture.pool.identifier.identifier,
+            redirect = RedirectFulfillment(
                 content_link=fulfillable_mechanism.resource.representation.public_url,
                 content_type=fulfillable_mechanism.resource.representation.media_type,
-                content=None,
-                content_expires=None,
             )
             loan_fixture.manager.d_circulation.queue_fulfill(
-                loan_fixture.pool, fulfillment
+                loan_fixture.pool, redirect
             )
 
-            assert isinstance(loan_fixture.pool.id, int)
-            response = loan_fixture.manager.loans.fulfill(
-                loan_fixture.pool.id,
+            fulfill_response = loan_fixture.manager.loans.fulfill(
+                loan_fixture.pool_id,
                 fulfillable_mechanism.delivery_mechanism.id,
             )
-            if isinstance(response, ProblemDetail):
-                j, status, headers = response.response
+            if isinstance(fulfill_response, ProblemDetail):
+                j, status, headers = fulfill_response.response
                 raise Exception(repr(j))
-            assert 302 == response.status_code
+            assert 302 == fulfill_response.status_code
             assert (
                 fulfillable_mechanism.resource.representation.public_url
-                == response.headers.get("Location")
+                == fulfill_response.headers.get("Location")
             )
 
             # The mechanism we used has been registered with the loan.
@@ -339,58 +381,54 @@ class TestLoanController:
             # external request to obtain the book.
             loan_fixture.pool.open_access = False
 
-            http = DummyHTTPClient()
+            http = MockHTTPClient()
 
-            fulfillment = FulfillmentInfo(
-                loan_fixture.pool.collection,
-                loan_fixture.pool.data_source,
-                loan_fixture.pool.identifier.type,
-                loan_fixture.pool.identifier.identifier,
+            assert fulfillable_mechanism.resource.url is not None
+            fetch = FetchFulfillment(
                 content_link=fulfillable_mechanism.resource.url,
                 content_type=fulfillable_mechanism.resource.representation.media_type,
-                content=None,
-                content_expires=None,
             )
 
             # Now that we've set a mechanism, we can fulfill the loan
             # again without specifying a mechanism.
-            loan_fixture.manager.d_circulation.queue_fulfill(
-                loan_fixture.pool, fulfillment
-            )
+            loan_fixture.manager.d_circulation.queue_fulfill(loan_fixture.pool, fetch)
             http.queue_response(200, content="I am an ACSM file")
 
-            response = loan_fixture.manager.loans.fulfill(
-                loan_fixture.pool.id, do_get=http.do_get
-            )
-            assert 200 == response.status_code
-            assert "I am an ACSM file" == response.get_data(as_text=True)
+            with http.patch():
+                fulfill_response = loan_fixture.manager.loans.fulfill(
+                    loan_fixture.pool_id
+                )
+            assert isinstance(fulfill_response, wkResponse)
+            assert 200 == fulfill_response.status_code
+            assert "I am an ACSM file" == fulfill_response.get_data(as_text=True)
             assert http.requests == [fulfillable_mechanism.resource.url]
 
             # But we can't use some other mechanism -- we're stuck with
             # the first one we chose.
-            response = loan_fixture.manager.loans.fulfill(
-                loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
+            fulfill_response = loan_fixture.manager.loans.fulfill(
+                loan_fixture.pool_id, loan_fixture.mech2.delivery_mechanism.id
             )
-
-            assert 409 == response.status_code
+            assert isinstance(fulfill_response, ProblemDetail)
+            assert 409 == fulfill_response.status_code
+            assert fulfill_response.detail is not None
             assert (
                 "You already fulfilled this loan as application/epub+zip (DRM Scheme 1), you can't also do it as application/pdf (DRM Scheme 2)"
-                in response.detail
+                in fulfill_response.detail
             )
 
             # If the remote server fails, we get a problem detail.
-            def doomed_get(url, headers, **kwargs):
-                raise RemoteIntegrationException("fulfill service", "Error!")
+            doomed_fulfillment = create_autospec(Fulfillment)
+            doomed_fulfillment.response.side_effect = RemoteIntegrationException(
+                "fulfill service", "Error!"
+            )
 
             loan_fixture.manager.d_circulation.queue_fulfill(
-                loan_fixture.pool, fulfillment
+                loan_fixture.pool, doomed_fulfillment
             )
 
-            response = loan_fixture.manager.loans.fulfill(
-                loan_fixture.pool.id, do_get=doomed_get
-            )
-            assert isinstance(response, ProblemDetail)
-            assert 502 == response.status_code
+            fulfill_response = loan_fixture.manager.loans.fulfill(loan_fixture.pool_id)
+            assert isinstance(fulfill_response, ProblemDetail)
+            assert 502 == fulfill_response.status_code
 
     def test_borrow_and_fulfill_with_streaming_delivery_mechanism(
         self, loan_fixture: LoanFixture
@@ -422,9 +460,10 @@ class TestLoanController:
                     end_date=utc_now() + datetime.timedelta(seconds=3600),
                 ),
             )
-            response = loan_fixture.manager.loans.borrow(
+            borrow_response = loan_fixture.manager.loans.borrow(
                 identifier.type, identifier.identifier
             )
+            assert isinstance(borrow_response, Response)
 
             # A loan has been created for this license pool.
             loan = get_one(loan_fixture.db.session, Loan, license_pool=pool)
@@ -434,8 +473,8 @@ class TestLoanController:
 
             # We've been given an OPDS feed with two delivery mechanisms, which tell us how
             # to fulfill the license.
-            assert 201 == response.status_code
-            feed = feedparser.parse(response.get_data())
+            assert 201 == borrow_response.status_code
+            feed = feedparser.parse(borrow_response.get_data())
             [entry] = feed["entries"]
             fulfillment_links = [
                 x["href"]
@@ -464,25 +503,20 @@ class TestLoanController:
             # Now let's try to fulfill the loan using the streaming mechanism.
             loan_fixture.manager.d_circulation.queue_fulfill(
                 pool,
-                FulfillmentInfo(
-                    pool.collection,
-                    pool.data_source.name,
-                    pool.identifier.type,
-                    pool.identifier.identifier,
+                RedirectFulfillment(
                     "http://streaming-content-link",
                     Representation.TEXT_HTML_MEDIA_TYPE
                     + DeliveryMechanism.STREAMING_PROFILE,
-                    None,
-                    None,
                 ),
             )
-            response = loan_fixture.manager.loans.fulfill(
+            fulfill_response = loan_fixture.manager.loans.fulfill(
                 pool.id, streaming_mechanism.delivery_mechanism.id
             )
+            assert isinstance(fulfill_response, Response)
 
             # We get an OPDS entry.
-            assert 200 == response.status_code
-            opds_entries = feedparser.parse(response.response[0])["entries"]
+            assert 200 == fulfill_response.status_code
+            opds_entries = feedparser.parse(fulfill_response.get_data())["entries"]
             assert 1 == len(opds_entries)
             links = opds_entries[0]["links"]
 
@@ -506,26 +540,22 @@ class TestLoanController:
             assert None == loan.fulfillment
 
             # We can still use the other mechanism too.
-            http = DummyHTTPClient()
+            http = MockHTTPClient()
             http.queue_response(200, content="I am an ACSM file")
 
             loan_fixture.manager.d_circulation.queue_fulfill(
                 pool,
-                FulfillmentInfo(
-                    pool.collection,
-                    pool.data_source.name,
-                    pool.identifier.type,
-                    pool.identifier.identifier,
+                FetchFulfillment(
                     "http://other-content-link",
                     Representation.TEXT_HTML_MEDIA_TYPE,
-                    None,
-                    None,
                 ),
             )
-            response = loan_fixture.manager.loans.fulfill(
-                pool.id, mech1.delivery_mechanism.id, do_get=http.do_get
-            )
-            assert 200 == response.status_code
+            with http.patch():
+                fulfill_response = loan_fixture.manager.loans.fulfill(
+                    pool.id, mech1.delivery_mechanism.id
+                )
+            assert isinstance(fulfill_response, wkResponse)
+            assert 200 == fulfill_response.status_code
 
             # Now the fulfillment has been set to the other mechanism.
             assert mech1 == loan.fulfillment
@@ -533,24 +563,19 @@ class TestLoanController:
             # But we can still fulfill the streaming mechanism again.
             loan_fixture.manager.d_circulation.queue_fulfill(
                 pool,
-                FulfillmentInfo(
-                    pool.collection,
-                    pool.data_source.name,
-                    pool.identifier.type,
-                    pool.identifier.identifier,
+                RedirectFulfillment(
                     "http://streaming-content-link",
                     Representation.TEXT_HTML_MEDIA_TYPE
                     + DeliveryMechanism.STREAMING_PROFILE,
-                    None,
-                    None,
                 ),
             )
 
-            response = loan_fixture.manager.loans.fulfill(
+            fulfill_response = loan_fixture.manager.loans.fulfill(
                 pool.id, streaming_mechanism.delivery_mechanism.id
             )
-            assert 200 == response.status_code
-            opds_entries = feedparser.parse(response.response[0])["entries"]
+            assert isinstance(fulfill_response, Response)
+            assert 200 == fulfill_response.status_code
+            opds_entries = feedparser.parse(fulfill_response.get_data())["entries"]
             assert 1 == len(opds_entries)
             links = opds_entries[0]["links"]
 
@@ -573,9 +598,7 @@ class TestLoanController:
             "/", headers=dict(Authorization=loan_fixture.valid_auth)
         ):
             loan_fixture.manager.loans.authenticated_patron_from_request()
-            response = loan_fixture.manager.loans.borrow(
-                loan_fixture.identifier.type, loan_fixture.identifier.identifier, -100
-            )
+            response = loan_fixture.manager.loans.borrow(loan_fixture.identifier.type, loan_fixture.identifier.identifier, -100)  # type: ignore
             assert BAD_DELIVERY_MECHANISM == response
 
     def test_borrow_creates_hold_when_no_available_copies(
@@ -610,7 +633,7 @@ class TestLoanController:
             response = loan_fixture.manager.loans.borrow(
                 pool.identifier.type, pool.identifier.identifier
             )
-            assert 201 == response.status_code
+            assert 201 == response.status_code  # type: ignore
 
             # A hold has been created for this license pool.
             hold = get_one(loan_fixture.db.session, Hold, license_pool=pool)
@@ -633,8 +656,8 @@ class TestLoanController:
             response = loan_fixture.manager.loans.borrow(
                 pool.identifier.type, pool.identifier.identifier
             )
-            assert 404 == response.status_code
-            assert NOT_FOUND_ON_REMOTE == response
+            assert 404 == response.status_code  # type: ignore
+            assert NO_LICENSES == response
 
     def test_borrow_creates_local_hold_if_remote_hold_exists(
         self, loan_fixture: LoanFixture
@@ -671,7 +694,7 @@ class TestLoanController:
             response = loan_fixture.manager.loans.borrow(
                 pool.identifier.type, pool.identifier.identifier
             )
-            assert 201 == response.status_code
+            assert 201 == response.status_code  # type: ignore
 
             # A hold has been created for this license pool.
             hold = get_one(loan_fixture.db.session, Hold, license_pool=pool)
@@ -700,10 +723,10 @@ class TestLoanController:
             response = loan_fixture.manager.loans.borrow(
                 pool.identifier.type, pool.identifier.identifier
             )
-            assert 404 == response.status_code
+            assert 404 == response.status_code  # type: ignore
             assert (
                 "http://librarysimplified.org/terms/problem/not-found-on-remote"
-                == response.uri
+                == response.uri  # type: ignore
             )
 
     def test_borrow_succeeds_when_work_already_checked_out(
@@ -730,9 +753,7 @@ class TestLoanController:
 
             mock_remote = circulation.api_for_license_pool(loan.license_pool)
             assert 1 == len(mock_remote.responses["checkout"])
-            response = loan_fixture.manager.loans.borrow(
-                loan_fixture.identifier.type, loan_fixture.identifier.identifier
-            )
+            response = loan_fixture.manager.loans.borrow(loan_fixture.identifier.type, loan_fixture.identifier.identifier)  # type: ignore
 
             # No checkout request was actually made to the remote.
             assert 1 == len(mock_remote.responses["checkout"])
@@ -740,8 +761,8 @@ class TestLoanController:
             # We got an OPDS entry that includes at least one
             # fulfillment link, which is what we expect when we ask
             # about an active loan.
-            assert 200 == response.status_code
-            [entry] = feedparser.parse(response.response[0])["entries"]
+            assert 200 == response.status_code  # type: ignore[union-attr]
+            [entry] = feedparser.parse(response.response[0])["entries"]  # type: ignore
             assert any(
                 [
                     x
@@ -762,12 +783,12 @@ class TestLoanController:
             "/", headers=dict(Authorization=loan_fixture.valid_auth)
         ):
             authenticated = controller.authenticated_patron_from_request()
+            assert isinstance(authenticated, Patron)
             loan, ignore = loan_fixture.pool.loan_to(authenticated)
 
             # Try to fulfill the loan.
-            assert isinstance(loan_fixture.pool.id, int)
             controller.fulfill(
-                loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
+                loan_fixture.pool_id, loan_fixture.mech2.delivery_mechanism.id
             )
 
             # Verify that the right arguments were passed into
@@ -780,37 +801,31 @@ class TestLoanController:
             )
 
     @pytest.mark.parametrize(
-        "as_response_value",
+        "response_value",
         [
             Response(status=200, response="Here's your response"),
             Response(status=401, response="Error"),
             Response(status=500, response="Fault"),
         ],
     )
-    def test_fulfill_returns_fulfillment_info_implementing_as_response(
-        self, as_response_value, loan_fixture: LoanFixture
+    def test_fulfill_returns_fulfillment(
+        self, response_value: Response, loan_fixture: LoanFixture
     ):
-        # If CirculationAPI.fulfill returns a FulfillmentInfo that
-        # defines as_response, the result of as_response is returned
-        # directly and the normal process of converting a FulfillmentInfo
-        # to a Flask response is skipped.
-        class MockFulfillmentInfo(FulfillmentInfo):
-            @property
-            def as_response(self):
-                return as_response_value
+        # When CirculationAPI.fulfill returns a Fulfillment, we
+        # simply return the result of Fulfillment.response()
+        class MockFulfillment(Fulfillment):
+            def __init__(self):
+                self.response_called = False
+
+            def response(self) -> Response:
+                self.response_called = True
+                return response_value
+
+        fulfillment = MockFulfillment()
 
         class MockCirculationAPI:
             def fulfill(self, *args, **kwargs):
-                return MockFulfillmentInfo(
-                    loan_fixture.db.default_collection(),
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                )
+                return fulfillment
 
         controller = loan_fixture.manager.loans
         mock = MockCirculationAPI()
@@ -820,17 +835,17 @@ class TestLoanController:
             "/", headers=dict(Authorization=loan_fixture.valid_auth)
         ):
             authenticated = controller.authenticated_patron_from_request()
+            assert isinstance(authenticated, Patron)
             loan, ignore = loan_fixture.pool.loan_to(authenticated)
 
             # Fulfill the loan.
-            assert isinstance(loan_fixture.pool.id, int)
             result = controller.fulfill(
-                loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
+                loan_fixture.pool_id, loan_fixture.mech2.delivery_mechanism.id
             )
 
-            # The result of MockFulfillmentInfo.as_response was
+            # The result of MockFulfillment.response was
             # returned directly.
-            assert as_response_value == result
+            assert response_value == result
 
     def test_fulfill_without_active_loan(self, loan_fixture: LoanFixture):
         controller = loan_fixture.manager.loans
@@ -842,9 +857,8 @@ class TestLoanController:
             "/", headers=dict(Authorization=loan_fixture.valid_auth)
         ):
             controller.authenticated_patron_from_request()
-            assert isinstance(loan_fixture.pool.id, int)
             response = controller.fulfill(
-                loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
+                loan_fixture.pool_id, loan_fixture.mech2.delivery_mechanism.id
             )
             assert isinstance(response, ProblemDetail)
             assert NO_ACTIVE_LOAN.uri == response.uri
@@ -852,7 +866,7 @@ class TestLoanController:
         # ...or it might be because there is no authenticated patron.
         with loan_fixture.request_context_with_library("/"):
             response = controller.fulfill(
-                loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
+                loan_fixture.pool_id, loan_fixture.mech2.delivery_mechanism.id
             )
             assert isinstance(response, FlaskResponse)
             assert 401 == response.status_code
@@ -867,14 +881,14 @@ class TestLoanController:
         controller.authenticated_patron_from_request = mock_authenticated_patron
         with loan_fixture.request_context_with_library("/"):
             problem = controller.fulfill(
-                loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
+                loan_fixture.pool_id, loan_fixture.mech2.delivery_mechanism.id
             )
             assert INTEGRATION_ERROR == problem
         controller.authenticated_patron_from_request = old_authenticated_patron
 
         # However, if can_fulfill_without_loan returns True, then
         # fulfill() will be called. If fulfill() returns a
-        # FulfillmentInfo, then the title is fulfilled, with no loan
+        # Fulfillment, then the title is fulfilled, with no loan
         # having been created.
         #
         # To that end, we'll mock can_fulfill_without_loan and fulfill.
@@ -882,15 +896,9 @@ class TestLoanController:
             return True
 
         def mock_fulfill(*args, **kwargs):
-            return FulfillmentInfo(
-                loan_fixture.collection,
-                loan_fixture.pool.data_source.name,
-                loan_fixture.pool.identifier.type,
-                loan_fixture.pool.identifier.identifier,
-                None,
-                "text/html",
-                "here's your book",
-                utc_now(),
+            return DirectFulfillment(
+                content_type="text/html",
+                content="here's your book",
             )
 
         # Now we're able to fulfill the book even without
@@ -899,7 +907,7 @@ class TestLoanController:
             controller.can_fulfill_without_loan = mock_can_fulfill_without_loan
             controller.circulation.fulfill = mock_fulfill
             response = controller.fulfill(
-                loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
+                loan_fixture.pool_id, loan_fixture.mech2.delivery_mechanism.id
             )
 
             assert isinstance(response, wkResponse)
@@ -914,13 +922,15 @@ class TestLoanController:
         ):
             circulation = controller.circulation
             authenticated = controller.authenticated_patron_from_request()
+            assert isinstance(authenticated, Patron)
             loan_fixture.pool.loan_to(authenticated)
-            with patch(
-                "api.controller.opds_feed.OPDSAcquisitionFeed.single_entry_loans_feed"
-            ) as feed, patch.object(circulation, "fulfill") as fulfill:
-                # Complex setup
-                # The fulfillmentInfo should not be have response type
-                fulfill.return_value.as_response = None
+            with (
+                patch(
+                    "api.controller.opds_feed.OPDSAcquisitionFeed.single_entry_loans_feed"
+                ) as feed,
+                patch.object(circulation, "fulfill") as fulfill,
+            ):
+                fulfill.return_value = MagicMock(spec=RedirectFulfillment)
                 # The single_item_feed must return this error
                 feed.return_value = NOT_FOUND_ON_REMOTE
                 # The content type needs to be streaming
@@ -928,9 +938,8 @@ class TestLoanController:
                     DeliveryMechanism.STREAMING_TEXT_CONTENT_TYPE
                 )
 
-                assert isinstance(loan_fixture.pool.id, int)
                 response = controller.fulfill(
-                    loan_fixture.pool.id, loan_fixture.mech1.delivery_mechanism.id
+                    loan_fixture.pool_id, loan_fixture.mech1.delivery_mechanism.id
                 )
                 assert response == NOT_FOUND_ON_REMOTE
 
@@ -960,16 +969,9 @@ class TestLoanController:
 
         # Mock out the flow
         api = MagicMock(spec=BaseCirculationAPI)
-        api.fulfill.return_value = FulfillmentInfo(
-            loan_fixture.db.default_collection(),
-            DataSource.OVERDRIVE,
-            "overdrive",
-            pool.identifier.identifier,
+        api.fulfill.return_value = RedirectFulfillment(
             "https://example.org/redirect_to_epub",
             MediaTypes.EPUB_MEDIA_TYPE,
-            "",
-            None,
-            content_link_redirect=True,
         )
         controller.can_fulfill_without_loan = MagicMock(return_value=False)
         controller.authenticated_patron_from_request = MagicMock(return_value=patron)
@@ -979,14 +981,7 @@ class TestLoanController:
             library=loan_fixture.db.default_library(),
             headers=dict(Authorization=loan_fixture.valid_auth),
         ):
-            loan_fixture.manager.circulation_apis[
-                loan_fixture.db.default_library().id
-            ] = CirculationAPI(
-                loan_fixture.db.session, loan_fixture.db.default_library()
-            )
-            controller.circulation.api_for_collection[
-                loan_fixture.db.default_collection().id
-            ] = api
+            controller.circulation.api_for_license_pool = MagicMock(return_value=api)
             assert isinstance(pool.id, int)
             response = controller.fulfill(pool.id, lpdm.delivery_mechanism.id)
 
@@ -994,64 +989,121 @@ class TestLoanController:
         assert response.status_code == 302
         assert response.location == "https://example.org/redirect_to_epub"
 
-        # Axis360 variant
-        api = MagicMock(spec=Axis360API)
-        api.collection = loan_fixture.db.default_collection()
-        api._db = loan_fixture.db.session
-        axis360_ff = Axis360FulfillmentInfo(
-            api, DataSource.AXIS_360, "Axis 360 ID", "xxxxxx", "xxxxxx"
+    @pytest.mark.parametrize(
+        *OPDSSerializationTestHelper.PARAMETRIZED_SINGLE_ENTRY_ACCEPT_HEADERS
+    )
+    def test_revoke_loan(
+        self,
+        loan_fixture: LoanFixture,
+        accept_header: str | None,
+        expected_content_type: str,
+    ):
+        serialization_helper = OPDSSerializationTestHelper(
+            accept_header, expected_content_type
         )
-        api.get_fulfillment_info.return_value = MagicMock(
-            content={
-                "ExpirationDate": "2020-01-01 00:00:00",
-                "Status": dict(Code=1, Message="Worked."),
-                "ISBN": "ISBN ID",
-                "BookVaultUUID": "Vault ID",
-            }
+        headers = serialization_helper.merge_accept_header(
+            {"Authorization": loan_fixture.valid_auth}
         )
-        api.fulfill.return_value = axis360_ff
-        assert isinstance(pool.id, int)
-        with loan_fixture.request_context_with_library(
-            "/",
-            library=loan_fixture.db.default_library(),
-            headers=dict(Authorization=loan_fixture.valid_auth),
-        ):
-            controller.circulation.api_for_collection[
-                loan_fixture.db.default_collection().id
-            ] = api
-            response = controller.fulfill(pool.id, lpdm.delivery_mechanism.id)
 
-        assert isinstance(response, wkResponse)
-        assert response.status_code == 200
-        assert response.json == {"book_vault_uuid": "Vault ID", "isbn": "ISBN ID"}
-
-    def test_revoke_loan(self, loan_fixture: LoanFixture):
-        with loan_fixture.request_context_with_library(
-            "/", headers=dict(Authorization=loan_fixture.valid_auth)
-        ):
+        # Create a loan and revoke it
+        with loan_fixture.request_context_with_library("/", headers=headers):
             patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
             loan, newly_created = loan_fixture.pool.loan_to(patron)
 
             loan_fixture.manager.d_circulation.queue_checkin(loan_fixture.pool, True)
 
-            response = loan_fixture.manager.loans.revoke(loan_fixture.pool.id)
+            response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
 
-            assert 200 == response.status_code
+        assert 200 == response.status_code
+        serialization_helper.verify_and_get_single_entry_feed_links(response)
 
-    def test_revoke_hold(self, loan_fixture: LoanFixture):
+    def test_revoke_loan_exception(
+        self,
+        loan_fixture: LoanFixture,
+    ):
+        # Revoke loan where an exception is raised from the circulation api
+        with loan_fixture.request_context_with_library(
+            "/", headers=dict(Authorization=loan_fixture.valid_auth)
+        ):
+            loan_fixture.manager.d_circulation.revoke_loan = MagicMock(
+                side_effect=CannotReturn()
+            )
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
+            loan_fixture.pool.loan_to(patron)
+            response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
+
+        assert isinstance(response, ProblemDetail)
+        assert response == COULD_NOT_MIRROR_TO_REMOTE
+        assert response.status_code == 503
+
+    def test_revoke_loan_licensepool_no_work(
+        self,
+        loan_fixture: LoanFixture,
+    ):
+        # Revoke loan where the license pool has no work
         with loan_fixture.request_context_with_library(
             "/", headers=dict(Authorization=loan_fixture.valid_auth)
         ):
             patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            loan_fixture.manager.d_circulation.queue_checkin(loan_fixture.pool, True)
+            assert isinstance(patron, Patron)
+            loan_fixture.pool.loan_to(patron)
+            loan_fixture.pool.work = None
+            response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
+
+        assert isinstance(response, ProblemDetail)
+        assert response == NOT_FOUND_ON_REMOTE
+
+    @pytest.mark.parametrize(
+        *OPDSSerializationTestHelper.PARAMETRIZED_SINGLE_ENTRY_ACCEPT_HEADERS
+    )
+    def test_revoke_hold(
+        self,
+        loan_fixture: LoanFixture,
+        accept_header: str | None,
+        expected_content_type: str,
+    ):
+        serialization_helper = OPDSSerializationTestHelper(
+            accept_header, expected_content_type
+        )
+        headers = serialization_helper.merge_accept_header(
+            {"Authorization": loan_fixture.valid_auth}
+        )
+
+        with loan_fixture.request_context_with_library("/", headers=headers):
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
             hold, newly_created = loan_fixture.pool.on_hold_to(patron, position=0)
 
             loan_fixture.manager.d_circulation.queue_release_hold(
                 loan_fixture.pool, True
             )
 
-            response = loan_fixture.manager.loans.revoke(loan_fixture.pool.id)
+            response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
 
-            assert 200 == response.status_code
+        assert 200 == response.status_code
+        _ = serialization_helper.verify_and_get_single_entry_feed_links(response)
+
+    def test_revoke_hold_exception(
+        self,
+        loan_fixture: LoanFixture,
+    ):
+        # Revoke hold where an exception is raised from the circulation api
+        with loan_fixture.request_context_with_library(
+            "/", headers=dict(Authorization=loan_fixture.valid_auth)
+        ):
+            loan_fixture.manager.d_circulation.release_hold = MagicMock(
+                side_effect=CannotReleaseHold()
+            )
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
+            loan_fixture.pool.on_hold_to(patron, position=0)
+            response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
+
+        assert isinstance(response, ProblemDetail)
+        assert response == CANNOT_RELEASE_HOLD
 
     def test_revoke_hold_nonexistent_licensepool(self, loan_fixture: LoanFixture):
         with loan_fixture.request_context_with_library(
@@ -1079,9 +1131,11 @@ class TestLoanController:
             assert isinstance(response, ProblemDetail)
             assert HOLD_LIMIT_REACHED.uri == response.uri
 
-    def test_loan_fails_when_patron_is_at_hold_limit_and_hold_position_zero(
+    def test_borrow_fails_when_no_available_copies_and_existing_hold(
         self, loan_fixture: LoanFixture
     ):
+        """Patron has a hold that they're trying to check out but the remote says there's no
+        available copies."""
         edition, pool = loan_fixture.db.edition(with_license_pool=True)
         pool.open_access = False
         with loan_fixture.request_context_with_library(
@@ -1096,61 +1150,8 @@ class TestLoanController:
                 pool.identifier.type, pool.identifier.identifier
             )
             assert isinstance(response, ProblemDetail)
-            assert NO_COPIES_WHEN_RESERVED.uri == response.uri
+            assert CHECKOUT_FAILED.uri == response.uri
             assert 502 == response.status_code
-
-    def test_borrow_fails_with_outstanding_fines(
-        self, loan_fixture: LoanFixture, library_fixture: LibraryFixture
-    ):
-        threem_edition, pool = loan_fixture.db.edition(
-            with_open_access_download=False,
-            data_source_name=DataSource.THREEM,
-            identifier_type=Identifier.THREEM_ID,
-            with_license_pool=True,
-        )
-        threem_book = loan_fixture.db.work(
-            presentation_edition=threem_edition,
-        )
-        pool.open_access = False
-
-        library = loan_fixture.db.default_library()
-        settings = library_fixture.settings(library)
-
-        settings.max_outstanding_fines = 0.50
-        with loan_fixture.request_context_with_library(
-            "/", headers=dict(Authorization=loan_fixture.valid_auth)
-        ):
-            # The patron's credentials are valid, but they have a lot
-            # of fines.
-            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
-            patron.fines = Decimal("12345678.90")
-            response = loan_fixture.manager.loans.borrow(
-                pool.identifier.type, pool.identifier.identifier
-            )
-
-            assert 403 == response.status_code
-            assert OUTSTANDING_FINES.uri == response.uri
-            assert "$12345678.90 outstanding" in response.detail
-
-        # Reduce the patron's fines, and there's no problem.
-        with loan_fixture.request_context_with_library(
-            "/", headers=dict(Authorization=loan_fixture.valid_auth)
-        ):
-            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
-            patron.fines = Decimal("0.49")
-            loan_fixture.manager.d_circulation.queue_checkout(
-                pool,
-                LoanInfo.from_license_pool(
-                    pool,
-                    start_date=utc_now(),
-                    end_date=utc_now() + datetime.timedelta(seconds=3600),
-                ),
-            )
-            response = loan_fixture.manager.loans.borrow(
-                pool.identifier.type, pool.identifier.identifier
-            )
-
-            assert 201 == response.status_code
 
     def test_active_loans(self, loan_fixture: LoanFixture):
         # First, verify that this controller supports conditional HTTP

--- a/tests/api/controller/test_odl_notify.py
+++ b/tests/api/controller/test_odl_notify.py
@@ -1,15 +1,23 @@
-import json
 import types
 
 import flask
 import pytest
+from flask import Response
+from freezegun import freeze_time
 
 from api.odl import ODLAPI
 from api.odl2 import ODL2API
-from api.problem_details import INVALID_LOAN_FOR_ODL_NOTIFICATION, NO_ACTIVE_LOAN
-from core.model import Collection
+from api.problem_details import (
+    INVALID_INPUT,
+    INVALID_LOAN_FOR_ODL_NOTIFICATION,
+    NO_ACTIVE_LOAN,
+)
+from core.model import Collection, License, Loan, Patron
+from core.util.datetime_helpers import utc_now
 from tests.fixtures.api_controller import ControllerFixture
 from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.odl import OPDS2WithODLApiFixture
+from tests.fixtures.problem_detail import raises_problem_detail
 
 
 class ODLFixture:
@@ -30,6 +38,8 @@ class ODLFixture:
         }
         self.collection.libraries.append(self.library)
         self.work = self.db.work(with_license_pool=True, collection=self.collection)
+        self.license = self.create_license()
+        self.patron, self.patron_identifier = self.create_patron()
 
         def setup(self, available, concurrency, left=None, expires=None):
             self.checkouts_available = available
@@ -48,10 +58,47 @@ class ODLFixture:
         types.MethodType(setup, self.license)
         self.pool.update_availability_from_licenses()
         self.patron = self.db.patron()
+        self.loan_status_document = OPDS2WithODLApiFixture.loan_status_document
 
     @staticmethod
     def integration_protocol():
         return ODLAPI.label()
+
+    def create_license(self, collection: Collection | None = None) -> License:
+        collection = collection or self.collection
+        if not collection.data_source:
+            collection.data_source = "testing"  # type: ignore
+        assert collection.data_source is not None
+        pool = self.db.licensepool(
+            None, collection=collection, data_source_name=collection.data_source.name
+        )
+        license = self.db.license(
+            pool,
+            checkout_url="https://provider.net/loan",
+            checkouts_available=1,
+            terms_concurrency=1,
+        )
+        pool.update_availability_from_licenses()
+        return license
+
+    def create_patron(self) -> tuple[Patron, str]:
+        patron = self.db.patron()
+        data_source = self.collection.data_source
+        assert data_source is not None
+        patron_identifier = patron.identifier_to_remote_service(data_source)
+        return patron, patron_identifier
+
+    def create_loan(
+        self, license: License | None = None, patron: Patron | None = None
+    ) -> Loan:
+        if license is None:
+            license = self.license
+        if patron is None:
+            patron = self.patron
+        license.checkout()
+        loan, _ = license.loan_to(patron)
+        loan.external_identifier = self.db.fresh_str()
+        return loan
 
 
 @pytest.fixture(scope="function")
@@ -59,6 +106,7 @@ def odl_fixture(db: DatabaseTransactionFixture) -> ODLFixture:
     return ODLFixture(db)
 
 
+@freeze_time()
 class TestODLNotificationController:
     """Test that an ODL distributor can notify the circulation manager
     when a loan's status changes."""
@@ -70,6 +118,91 @@ class TestODLNotificationController:
             pytest.param(ODL2API.label(), id="ODL 2.x collection"),
         ],
     )
+    def test__get_loan(
+        self, protocol, controller_fixture: ControllerFixture, odl_fixture: ODLFixture
+    ) -> None:
+        db = controller_fixture.db
+
+        odl_fixture.collection.integration_configuration.protocol = protocol
+
+        patron1, patron_id_1 = odl_fixture.create_patron()
+        patron2, patron_id_2 = odl_fixture.create_patron()
+        patron3, patron_id_3 = odl_fixture.create_patron()
+
+        license1 = odl_fixture.create_license()
+        license2 = odl_fixture.create_license()
+        license3 = odl_fixture.create_license()
+
+        loan1 = odl_fixture.create_loan(license=license1, patron=patron1)
+        loan2 = odl_fixture.create_loan(license=license2, patron=patron1)
+        loan3 = odl_fixture.create_loan(license=license3, patron=patron2)
+
+        # We get the correct loan for each patron and license.
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                patron_id_1, license1.identifier
+            )
+            == loan1
+        )
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                patron_id_1, license2.identifier
+            )
+            == loan2
+        )
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                patron_id_2, license3.identifier
+            )
+            == loan3
+        )
+
+        # We get None if the patron doesn't have a loan for the license.
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                patron_id_1, license3.identifier
+            )
+            is None
+        )
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                patron_id_2, license1.identifier
+            )
+            is None
+        )
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                patron_id_3, license1.identifier
+            )
+            is None
+        )
+
+        # We get None if the patron or license identifiers are None.
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                None, license1.identifier
+            )
+            is None
+        )
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(
+                patron_id_1, None
+            )
+            is None
+        )
+        assert (
+            controller_fixture.manager.odl_notification_controller._get_loan(None, None)
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "protocol",
+        [
+            pytest.param(ODLAPI.label(), id="ODL 1.x collection"),
+            pytest.param(ODL2API.label(), id="ODL 2.x collection"),
+        ],
+    )
+    @freeze_time()
     def test_notify_success(
         self,
         protocol,
@@ -79,49 +212,98 @@ class TestODLNotificationController:
         db = controller_fixture.db
 
         odl_fixture.collection.integration_configuration.protocol = protocol
-        odl_fixture.pool.licenses_owned = 10
-        odl_fixture.pool.licenses_available = 5
-        loan, ignore = odl_fixture.pool.loan_to(odl_fixture.patron)
-        loan.external_identifier = db.fresh_str()
+        patron, patron_identifier = odl_fixture.create_patron()
+        license = odl_fixture.create_license()
+        loan = odl_fixture.create_loan(license=license, patron=patron)
 
+        license.checkouts_available = 0
+
+        status_doc = odl_fixture.loan_status_document("active")
         with controller_fixture.request_context_with_library("/", method="POST"):
-            text = json.dumps(
-                {
-                    "id": loan.external_identifier,
-                    "status": "revoked",
-                }
-            )
-            data = bytes(text, "utf-8")
-            flask.request.data = data
+            flask.request.data = status_doc.json()  # type: ignore[assignment]
             response = controller_fixture.manager.odl_notification_controller.notify(
-                loan.id
+                patron_identifier, license.identifier
             )
+            assert odl_fixture.license.identifier is not None
             assert 200 == response.status_code
 
-            # The pool's availability has been updated.
-            api = controller_fixture.manager.circulation_apis[
-                db.default_library().id
-            ].api_for_license_pool(loan.license_pool)
-            assert [loan.license_pool] == api.availability_updated_for
+        assert loan.end != utc_now()
 
-    def test_notify_errors(self, controller_fixture: ControllerFixture):
+        status_doc = odl_fixture.loan_status_document("revoked")
+        with controller_fixture.request_context_with_library("/", method="POST"):
+            flask.request.data = status_doc.json()  # type: ignore[assignment]
+            response = controller_fixture.manager.odl_notification_controller.notify(
+                patron_identifier, license.identifier
+            )
+            assert odl_fixture.license.identifier is not None
+            assert 200 == response.status_code
+
+        # Since we had a loan and it's not active, we're out of sync with the remote. We've set the loan to end now.
+        assert loan.end == utc_now()
+
+        # The pool's availability has been updated.
+        api = controller_fixture.manager.circulation_apis[
+            db.default_library().id
+        ].api_for_license_pool(loan.license_pool)
+        assert [loan.license_pool] == api.availability_updated_for
+
+    def test_notify_errors(
+        self, controller_fixture: ControllerFixture, odl_fixture: ODLFixture
+    ):
         db = controller_fixture.db
 
-        # No loan.
-        with controller_fixture.request_context_with_library("/", method="POST"):
-            response = controller_fixture.manager.odl_notification_controller.notify(
-                db.fresh_str()
+        non_odl_collection = db.collection()
+        patron, patron_identifier = odl_fixture.create_patron()
+        license = odl_fixture.create_license(collection=non_odl_collection)
+        odl_fixture.create_loan(patron=patron, license=license)
+
+        # Bad JSON, no data.
+        with (
+            controller_fixture.request_context_with_library("/", method="POST"),
+            raises_problem_detail(pd=INVALID_INPUT),
+        ):
+            assert odl_fixture.license.identifier is not None
+            controller_fixture.manager.odl_notification_controller.notify(
+                patron_identifier, license.identifier
             )
-            assert NO_ACTIVE_LOAN.uri == response.uri
 
         # Loan from a non-ODL collection.
-        patron = db.patron()
-        pool = db.licensepool(None)
-        loan, ignore = pool.loan_to(patron)
-        loan.external_identifier = db.fresh_str()
-
-        with controller_fixture.request_context_with_library("/", method="POST"):
-            response = controller_fixture.manager.odl_notification_controller.notify(
-                loan.id
+        with (
+            controller_fixture.request_context_with_library("/", method="POST"),
+            raises_problem_detail(pd=INVALID_LOAN_FOR_ODL_NOTIFICATION),
+        ):
+            flask.request.data = odl_fixture.loan_status_document("active").json()  # type: ignore[assignment]
+            assert license.identifier is not None
+            controller_fixture.manager.odl_notification_controller.notify(
+                patron_identifier, license.identifier
             )
-            assert INVALID_LOAN_FOR_ODL_NOTIFICATION == response
+
+        # No loan, but distributor thinks it isn't active
+        NON_EXISTENT_LICENSE_IDENTIFIER = "Foo"
+        with controller_fixture.request_context_with_library(
+            "/",
+            method="POST",
+            library=odl_fixture.library,
+        ):
+            flask.request.data = odl_fixture.loan_status_document("returned").json()  # type: ignore[assignment]
+            response = controller_fixture.manager.odl_notification_controller.notify(
+                odl_fixture.patron_identifier, NON_EXISTENT_LICENSE_IDENTIFIER
+            )
+        assert isinstance(response, Response)
+        assert response.status_code == 200
+
+        # No loan, but distributor thinks it is active
+        with (
+            controller_fixture.request_context_with_library(
+                "/",
+                method="POST",
+                library=odl_fixture.library,
+            ),
+            raises_problem_detail(
+                pd=NO_ACTIVE_LOAN.detailed("No loan was found.", 404)
+            ),
+        ):
+            flask.request.data = odl_fixture.loan_status_document("active").json()  # type: ignore[assignment]
+            controller_fixture.manager.odl_notification_controller.notify(
+                odl_fixture.patron_identifier, NON_EXISTENT_LICENSE_IDENTIFIER
+            )

--- a/tests/api/mockapi/mock.py
+++ b/tests/api/mockapi/mock.py
@@ -1,7 +1,71 @@
 import json
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
+from unittest.mock import patch
 
 from requests import Request, Response
+from typing_extensions import Unpack
+
+from core.util.http import HTTP, GetRequestKwargs, RequestKwargs
+
+
+class MockHTTPClient:
+    def __init__(self) -> None:
+        self.responses: list[Response] = []
+        self.requests: list[str] = []
+        self.requests_args: list[RequestKwargs] = []
+        self.requests_methods: list[str] = []
+
+    def reset_mock(self) -> None:
+        self.responses = []
+        self.requests = []
+        self.requests_args = []
+        self.requests_methods = []
+
+    def queue_response(
+        self,
+        response_code: int,
+        media_type: str | None = None,
+        other_headers: dict[str, str] | None = None,
+        content: str | bytes | dict[str, Any] = "",
+    ):
+        """Queue a response of the type produced by HTTP.get_with_timeout."""
+        headers = dict(other_headers or {})
+        if media_type:
+            headers["Content-Type"] = media_type
+
+        self.responses.append(MockRequestsResponse(response_code, headers, content))
+
+    def _request(self, *args: Any, **kwargs: Any) -> Response:
+        return self.responses.pop(0)
+
+    def do_request(
+        self, http_method: str, url: str, **kwargs: Unpack[RequestKwargs]
+    ) -> Response:
+        self.requests.append(url)
+        self.requests_methods.append(http_method)
+        self.requests_args.append(kwargs)
+        return HTTP._request_with_timeout(http_method, url, self._request, **kwargs)
+
+    def do_get(self, url: str, **kwargs: Unpack[GetRequestKwargs]) -> Response:
+        return self.do_request("GET", url, **kwargs)
+
+    @contextmanager
+    def patch(self) -> Generator[None, None, None]:
+        with patch.object(HTTP, "request_with_timeout", self.do_request):
+            yield
+
+
+class MockRequestsRequest:
+    """A mock object that simulates an HTTP request from the
+    `requests` library.
+    """
+
+    def __init__(self, url, method="GET", headers=None):
+        self.url = url
+        self.method = method
+        self.headers = headers or dict()
 
 
 class MockRequestsResponse(Response):

--- a/tests/api/test_circulation_exceptions.py
+++ b/tests/api/test_circulation_exceptions.py
@@ -1,32 +1,66 @@
+import pytest
 from flask_babel import lazy_gettext as _
 
 from api.circulation_exceptions import *
 from api.problem_details import *
 from core.util.problem_detail import ProblemDetail
-from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class TestCirculationExceptions:
-    def test_as_problem_detail_document(self):
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            PatronAuthorizationFailedException,
+            LibraryAuthorizationFailedException,
+            InvalidInputException,
+            LibraryInvalidInputException,
+            DeliveryMechanismError,
+            DeliveryMechanismMissing,
+            DeliveryMechanismConflict,
+            CannotLoan,
+            AuthorizationExpired,
+            AuthorizationBlocked,
+            CannotReturn,
+            CannotHold,
+            CannotReleaseHold,
+            CannotFulfill,
+            FormatNotAvailable,
+            NotFoundOnRemote,
+            NoLicenses,
+            CannotRenew,
+            NoAvailableCopies,
+            AlreadyCheckedOut,
+            AlreadyOnHold,
+            NotCheckedOut,
+            NotOnHold,
+            CurrentlyAvailable,
+            NoAcceptableFormat,
+            FulfilledOnIncompatiblePlatform,
+            NoActiveLoan,
+            OutstandingFines,
+            PatronLoanLimitReached,
+            PatronHoldLimitReached,
+        ],
+    )
+    def test_problem_detail(self, exception: type[CirculationException]) -> None:
         """Verify that circulation exceptions can be turned into ProblemDetail
         documents.
         """
+        e = exception()
+        expected_pd = e.base
 
-        e = RemoteInitiatedServerError("message", "some service")
-        doc = e.as_problem_detail_document()
-        assert "Integration error communicating with some service" == doc.detail
+        assert e.problem_detail == expected_pd
 
-        e = AuthorizationExpired()
-        assert EXPIRED_CREDENTIALS == e.as_problem_detail_document()
+        e_with_detail = exception("A message")
+        assert e_with_detail.problem_detail == expected_pd.detailed("A message")
 
-        e = AuthorizationBlocked()
-        assert BLOCKED_CREDENTIALS == e.as_problem_detail_document()
+        e_with_debug = exception(debug_info="A debug message")
+        assert e_with_debug.problem_detail == expected_pd.with_debug("A debug message")
 
-        e = PatronHoldLimitReached()
-        assert HOLD_LIMIT_REACHED == e.as_problem_detail_document()
-
-        e = NoLicenses()
-        assert NO_LICENSES == e.as_problem_detail_document()
+        e_with_detail_and_debug = exception("A message", "A debug message")
+        assert e_with_detail_and_debug.problem_detail == expected_pd.detailed(
+            "A message"
+        ).with_debug("A debug message")
 
 
 class TestLimitReached:
@@ -34,24 +68,59 @@ class TestLimitReached:
     library ConfigurationSetting.
     """
 
-    def test_as_problem_detail_document(self, db: DatabaseTransactionFixture):
+    def test_limit_reached(self) -> None:
         generic_message = _(
             "You exceeded the limit, but I don't know what the limit was."
         )
         pd = ProblemDetail("http://uri/", 403, _("Limit exceeded."), generic_message)
 
         class Mock(LimitReached):
-            BASE_DOC = pd
-            MESSAGE_WITH_LIMIT = _("The limit was %(limit)d.")
+            @property
+            def message_with_limit(self) -> str:
+                return _("The limit was %(limit)d.")
+
+            @property
+            def base(self) -> ProblemDetail:
+                return pd
 
         # No limit -> generic message.
         ex = Mock()
-        pd = ex.as_problem_detail_document()
+        pd = ex.problem_detail
         assert ex.limit is None
         assert generic_message == pd.detail
 
         # Limit -> specific message.
         ex = Mock(limit=14)
         assert 14 == ex.limit
-        pd = ex.as_problem_detail_document()
+        pd = ex.problem_detail
         assert "The limit was 14." == pd.detail
+
+    @pytest.mark.parametrize(
+        "exception,pd,limit_type",
+        [
+            (PatronHoldLimitReached, HOLD_LIMIT_REACHED, "hold"),
+            (PatronLoanLimitReached, LOAN_LIMIT_REACHED, "loan"),
+        ],
+    )
+    def test_patron_limit_reached(
+        self, exception: type[LimitReached], pd: ProblemDetail, limit_type: str
+    ) -> None:
+        e = exception()
+        assert e.problem_detail == pd
+
+        limit = 10
+        e = exception(limit=limit)
+        assert e.problem_detail.detail is not None
+        assert e.problem_detail.detail.startswith(
+            f"You have reached your {limit_type} limit of {limit}."
+        )
+
+    def test_internal_server_error(self) -> None:
+        e = InternalServerError("message", "debug")
+        assert e.problem_detail == INTERNAL_SERVER_ERROR
+
+    def test_remote_initiated_server_error(self) -> None:
+        e = RemoteInitiatedServerError("debug message", "some service")
+        assert e.problem_detail == INTEGRATION_ERROR.detailed(
+            "Integration error communicating with some service"
+        ).with_debug("debug message")

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -1137,9 +1137,10 @@ class TestODLAPI:
 
         # And the first hold changed.
         assert 0 == hold.position
-        assert hold.end - utc_now() - datetime.timedelta(days=3) < datetime.timedelta(
-            hours=1
-        )
+        # assert hold.end - utc_now() - datetime.timedelta(days=3) < datetime.timedelta(
+        #     hours=1
+        # )
+        assert hold.end.hour == 23 and hold.end.minute == 59
 
         # The later hold also moved one position.
         assert 1 == later_hold.position
@@ -1158,9 +1159,10 @@ class TestODLAPI:
         assert 2 == opds2_with_odl_api_fixture.pool.licenses_reserved
         assert 2 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
         assert 0 == later_hold.position
-        assert later_hold.end - utc_now() - datetime.timedelta(
-            days=3
-        ) < datetime.timedelta(hours=1)
+        # assert later_hold.end - utc_now() - datetime.timedelta(
+        #     days=3
+        # ) < datetime.timedelta(hours=1)
+        assert later_hold.end.hour == 23 and later_hold.end.minute == 59
 
         # Now there are no more holds. If we add another license,
         # it ends up being available.
@@ -1217,12 +1219,8 @@ class TestODLAPI:
         assert 0 == holds[0].position
         assert 0 == holds[1].position
         assert 1 == holds[2].position
-        assert holds[0].end - utc_now() - datetime.timedelta(
-            days=3
-        ) < datetime.timedelta(hours=1)
-        assert holds[1].end - utc_now() - datetime.timedelta(
-            days=3
-        ) < datetime.timedelta(hours=1)
+        assert holds[0].end.hour == 23 and holds[0].end.minute == 59
+        assert holds[1].end.hour == 23 and holds[1].end.minute == 59
 
         # If there are more licenses that change than holds, some of them become available.
         with opds2_with_odl_api_fixture.mock_http.patch():

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -3,27 +3,31 @@ from __future__ import annotations
 import datetime
 import json
 import urllib.parse
-from functools import partial
-from typing import TYPE_CHECKING, Any
+import uuid
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
 
 import dateutil
 import pytest
 from freezegun import freeze_time
+from sqlalchemy import delete
 
-from api.circulation import HoldInfo
+from api.circulation import FetchFulfillment, HoldInfo, RedirectFulfillment
 from api.circulation_exceptions import (
-    AlreadyCheckedOut,
     AlreadyOnHold,
     CannotFulfill,
     CannotLoan,
+    CannotReturn,
     CurrentlyAvailable,
     NoAvailableCopies,
+    NoAvailableCopiesWhenReserved,
     NoLicenses,
     NotCheckedOut,
     NotOnHold,
 )
-from api.odl import ODLHoldReaper, ODLImporter, ODLSettings
+from api.lcp.status import LoanStatus
+from api.odl import ODLAPI, BaseODLImporter, ODLHoldReaper, ODLImporter
 from core.model import (
     Collection,
     DataSource,
@@ -32,7 +36,6 @@ from core.model import (
     Hold,
     LicensePoolDeliveryMechanism,
     Loan,
-    MediaTypes,
     Representation,
     RightsStatus,
 )
@@ -46,47 +49,346 @@ from tests.fixtures.api_odl import (
     OdlImportTemplatedFixture,
 )
 from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.odl import ODLAPITestFixture, ODLTestFixture
+from tests.fixtures.odl import ODLTestFixture, OPDS2WithODLApiFixture
 
 if TYPE_CHECKING:
     from core.model import LicensePool
 
 
 class TestODLAPI:
-    def test_get_license_status_document_success(
-        self, odl_api_test_fixture: ODLAPITestFixture
+    @pytest.mark.parametrize(
+        "status_code",
+        [pytest.param(200, id="existing loan"), pytest.param(200, id="new loan")],
+    )
+    def test__request_loan_status_success(
+        self, opds2_with_odl_api_fixture: OPDS2WithODLApiFixture, status_code: int
     ) -> None:
-        # With a new loan.
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        odl_api_test_fixture.api.queue_response(
-            200, content=json.dumps(dict(status="ready"))
-        )
-        odl_api_test_fixture.api.get_license_status_document(loan)
-        requested_url = odl_api_test_fixture.api.requests[0][0]
+        expected_document = opds2_with_odl_api_fixture.loan_status_document("active")
 
-        parsed = urllib.parse.urlparse(requested_url)
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            status_code, content=expected_document.to_serializable()
+        )
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            requested_document = opds2_with_odl_api_fixture.api._request_loan_status(
+                "http://loan"
+            )
+
+        assert "http://loan" == opds2_with_odl_api_fixture.mock_http.requests.pop()
+        assert requested_document == expected_document
+
+    @pytest.mark.parametrize(
+        "status, headers, content, exception, expected_log_message",
+        [
+            pytest.param(
+                200,
+                {},
+                "not json",
+                RemoteIntegrationException,
+                "Error validating Loan Status Document. 'http://loan' returned and invalid document.",
+                id="invalid json",
+            ),
+            pytest.param(
+                200,
+                {},
+                json.dumps(dict(status="unknown")),
+                RemoteIntegrationException,
+                "Error validating Loan Status Document. 'http://loan' returned and invalid document.",
+                id="invalid document",
+            ),
+            pytest.param(
+                403,
+                {"header": "value"},
+                "server error",
+                RemoteIntegrationException,
+                "Error requesting Loan Status Document. 'http://loan' returned status code 403. "
+                "Response headers: header: value. Response content: server error.",
+                id="bad status code",
+            ),
+            pytest.param(
+                403,
+                {"Content-Type": "application/api-problem+json"},
+                json.dumps(
+                    dict(
+                        type="http://problem-detail-uri",
+                        title="server error",
+                        detail="broken",
+                    )
+                ),
+                RemoteIntegrationException,
+                "Error requesting Loan Status Document. 'http://loan' returned status code 403. "
+                "Problem Detail: 'http://problem-detail-uri' - server error - broken",
+                id="problem detail response",
+            ),
+        ],
+    )
+    def test__request_loan_status_errors(
+        self,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+        caplog: pytest.LogCaptureFixture,
+        status: int,
+        headers: dict[str, str],
+        content: str,
+        exception: type[Exception],
+        expected_log_message: str,
+    ) -> None:
+        # The response can't be parsed as JSON.
+        print(content)
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            status, other_headers=headers, content=content
+        )
+        with pytest.raises(exception):
+            with opds2_with_odl_api_fixture.mock_http.patch():
+                opds2_with_odl_api_fixture.api._request_loan_status("http://loan")
+        assert expected_log_message in caplog.text
+
+    def test_checkin_success(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        # A patron has a copy of this book checked out.
+        opds2_with_odl_api_fixture.setup_license(concurrency=7, available=6)
+
+        loan, _ = opds2_with_odl_api_fixture.license.loan_to(
+            opds2_with_odl_api_fixture.patron
+        )
+        loan.external_identifier = "http://loan/" + db.fresh_str()
+        loan.end = utc_now() + datetime.timedelta(days=3)
+
+        # The patron returns the book successfully.
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.checkin()
+        assert 2 == len(opds2_with_odl_api_fixture.mock_http.requests)
+        assert "http://loan" in opds2_with_odl_api_fixture.mock_http.requests[0]
+        assert "http://return" == opds2_with_odl_api_fixture.mock_http.requests[1]
+
+        # The pool's availability has increased
+        assert 7 == opds2_with_odl_api_fixture.pool.licenses_available
+
+        # The license on the pool has also been updated
+        assert 7 == opds2_with_odl_api_fixture.license.checkouts_available
+
+    def test_checkin_success_with_holds_queue(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        # A patron has the only copy of this book checked out.
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=0)
+        loan, _ = opds2_with_odl_api_fixture.license.loan_to(
+            opds2_with_odl_api_fixture.patron
+        )
+        loan.external_identifier = "http://loan/" + db.fresh_str()
+        loan.end = utc_now() + datetime.timedelta(days=3)
+
+        # Another patron has the book on hold.
+        patron_with_hold = db.patron()
+        opds2_with_odl_api_fixture.pool.patrons_in_hold_queue = 1
+        hold, ignore = opds2_with_odl_api_fixture.pool.on_hold_to(
+            patron_with_hold, start=utc_now(), end=None, position=1
+        )
+
+        # The first patron returns the book successfully.
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.checkin()
+        assert 2 == len(opds2_with_odl_api_fixture.mock_http.requests)
+        assert "http://loan" in opds2_with_odl_api_fixture.mock_http.requests[0]
+        assert "http://return" == opds2_with_odl_api_fixture.mock_http.requests[1]
+
+        # Now the license is reserved for the next patron.
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 1 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 1 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+
+    def test_checkin_not_checked_out(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        # Not checked out locally.
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            pytest.raises(
+                NotCheckedOut,
+                opds2_with_odl_api_fixture.api.checkin,
+                opds2_with_odl_api_fixture.patron,
+                "pin",
+                opds2_with_odl_api_fixture.pool,
+            )
+
+        # Not checked out according to the distributor.
+        loan, _ = opds2_with_odl_api_fixture.license.loan_to(
+            opds2_with_odl_api_fixture.patron
+        )
+        loan.external_identifier = db.fresh_str()
+        loan.end = utc_now() + datetime.timedelta(days=3)
+
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            200,
+            content=opds2_with_odl_api_fixture.loan_status_document(
+                "revoked"
+            ).to_serializable(),
+        )
+        # Checking in silently does nothing.
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.api.checkin(
+                opds2_with_odl_api_fixture.patron,
+                "pin",
+                opds2_with_odl_api_fixture.pool,
+            )
+
+    def test_checkin_cannot_return(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        # Not fulfilled yet, but no return link from the distributor.
+        loan, ignore = opds2_with_odl_api_fixture.license.loan_to(
+            opds2_with_odl_api_fixture.patron
+        )
+        loan.external_identifier = db.fresh_str()
+        loan.end = utc_now() + datetime.timedelta(days=3)
+
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            200,
+            content=opds2_with_odl_api_fixture.loan_status_document(
+                "ready", return_link=False
+            ).to_serializable(),
+        )
+        # Checking in raises the CannotReturn exception, since the distributor
+        # does not support returning the book.
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(CannotReturn):
+                opds2_with_odl_api_fixture.api.checkin(
+                    opds2_with_odl_api_fixture.patron,
+                    "pin",
+                    opds2_with_odl_api_fixture.pool,
+                )
+
+        # If the return link doesn't change the status, we raise the same exception.
+        lsd = opds2_with_odl_api_fixture.loan_status_document(
+            "ready", return_link="http://return"
+        ).to_serializable()
+
+        opds2_with_odl_api_fixture.mock_http.queue_response(200, content=lsd)
+        opds2_with_odl_api_fixture.mock_http.queue_response(200, content=lsd)
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(CannotReturn):
+                opds2_with_odl_api_fixture.api.checkin(
+                    opds2_with_odl_api_fixture.patron,
+                    "pin",
+                    opds2_with_odl_api_fixture.pool,
+                )
+
+    def test_checkin_open_access(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        # Checking in an open-access book doesn't need to call out to the distributor API.
+        oa_work = db.work(
+            with_open_access_download=True,
+            collection=opds2_with_odl_api_fixture.collection,
+        )
+        pool = oa_work.license_pools[0]
+        loan, ignore = pool.loan_to(opds2_with_odl_api_fixture.patron)
+
+        # make sure that _checkin isn't called since it is not needed for an open access work
+        opds2_with_odl_api_fixture.api._checkin = MagicMock(
+            side_effect=Exception("Should not be called")
+        )
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.api.checkin(
+                opds2_with_odl_api_fixture.patron, "pin", pool
+            )
+
+    def test__notification_url(self):
+        short_name = "short_name"
+        patron_id = str(uuid.uuid4())
+        license_id = str(uuid.uuid4())
+
+        def get_path(path: str) -> str:
+            return urlparse(path).path
+
+        # Import the app so we can setup a request context to verify that we can correctly generate
+        # notification url via url_for.
+        from api.app import app
+
+        # Test that we generated the expected URL
+        with app.test_request_context():
+            notification_url = ODLAPI._notification_url(
+                short_name, patron_id, license_id
+            )
+
+        assert (
+            get_path(notification_url)
+            == f"/{short_name}/odl/notify/{patron_id}/{license_id}"
+        )
+
+        # Test that our mock generates the same URL
+        with app.test_request_context():
+            assert get_path(
+                ODLAPI._notification_url(short_name, patron_id, license_id)
+            ) == get_path(ODLAPI._notification_url(short_name, patron_id, license_id))
+
+    def test_checkout_success(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        # This book is available to check out.
+        opds2_with_odl_api_fixture.setup_license(concurrency=6, available=6, left=30)
+
+        # A patron checks out the book successfully.
+        loan_url = db.fresh_str()
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            loan = opds2_with_odl_api_fixture.checkout(loan_url=loan_url)
+
+        assert opds2_with_odl_api_fixture.collection == loan.collection(db.session)
+        assert opds2_with_odl_api_fixture.pool.identifier.type == loan.identifier_type
+        assert opds2_with_odl_api_fixture.pool.identifier.identifier == loan.identifier
+        assert datetime_utc(3017, 10, 21, 11, 12, 13) == loan.end_date
+        assert loan_url == loan.external_identifier
+
+        # The pool's availability and the license's remaining checkouts have decreased.
+        assert 5 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 29 == opds2_with_odl_api_fixture.license.checkouts_left
+
+        # The parameters that we templated into the checkout URL are correct.
+        requested_url = opds2_with_odl_api_fixture.mock_http.requests.pop()
+
+        parsed = urlparse(requested_url)
         assert "https" == parsed.scheme
         assert "loan.feedbooks.net" == parsed.netloc
-        params = urllib.parse.parse_qs(parsed.query)
+        params = parse_qs(parsed.query)
 
-        schema = ODLSettings.schema()["properties"]
-        assert schema["passphrase_hint"]["default"] == params.get("hint")[0]  # type: ignore
         assert (
-            schema["passphrase_hint_url"]["default"] == params.get("hint_url")[0]  # type: ignore
+            opds2_with_odl_api_fixture.api.settings.passphrase_hint == params["hint"][0]
+        )
+        assert (
+            opds2_with_odl_api_fixture.api.settings.passphrase_hint_url
+            == params["hint_url"][0]
         )
 
-        assert odl_api_test_fixture.license.identifier == params.get("id")[0]  # type: ignore
+        assert opds2_with_odl_api_fixture.license.identifier == params["id"][0]
 
-        # The checkout id and patron id are random UUIDs.
-        checkout_id = params.get("checkout_id")[0]  # type: ignore
-        assert len(checkout_id) > 0
-        patron_id = params.get("patron_id")[0]  # type: ignore
-        assert len(patron_id) > 0
+        # The checkout id is a random UUID.
+        checkout_id = params["checkout_id"][0]
+        assert uuid.UUID(checkout_id)
+
+        # The patron id is the UUID of the patron, for this distributor.
+        expected_patron_id = (
+            opds2_with_odl_api_fixture.patron.identifier_to_remote_service(
+                opds2_with_odl_api_fixture.pool.data_source
+            )
+        )
+        patron_id = params["patron_id"][0]
+        assert uuid.UUID(patron_id)
+        assert patron_id == expected_patron_id
 
         # Loans expire in 21 days by default.
         now = utc_now()
         after_expiration = now + datetime.timedelta(days=23)
-        expires = urllib.parse.unquote(params.get("expires")[0])  # type: ignore
+        expires = urllib.parse.unquote(params["expires"][0])
 
         # The expiration time passed to the server is associated with
         # the UTC time zone.
@@ -98,271 +400,29 @@ class TestODLAPI:
         assert expires_t > now
         assert expires_t < after_expiration
 
-        notification_url = urllib.parse.unquote_plus(params.get("notification_url")[0])  # type: ignore
-        assert (
-            "http://odl_notify?library_short_name=%s&loan_id=%s"
-            % (odl_api_test_fixture.library.short_name, loan.id)
-            == notification_url
+        notification_url = urllib.parse.unquote_plus(params["notification_url"][0])
+        expected_notification_url = opds2_with_odl_api_fixture.api._notification_url(
+            opds2_with_odl_api_fixture.library.short_name,
+            patron_id,
+            opds2_with_odl_api_fixture.license.identifier,
         )
-
-        # With an existing loan.
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        loan.external_identifier = odl_api_test_fixture.db.fresh_str()
-
-        odl_api_test_fixture.api.queue_response(
-            200, content=json.dumps(dict(status="active"))
-        )
-        odl_api_test_fixture.api.get_license_status_document(loan)
-        requested_url = odl_api_test_fixture.api.requests[1][0]
-        assert loan.external_identifier == requested_url
-
-    def test_get_license_status_document_errors(
-        self, odl_api_test_fixture: ODLAPITestFixture, caplog
-    ) -> None:
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-
-        # The first request is ok but the content isn't json.
-        odl_api_test_fixture.api.queue_response(200, content="not json")
-        pytest.raises(
-            RemoteIntegrationException,
-            odl_api_test_fixture.api.get_license_status_document,
-            loan,
-        )
-
-        # The second request is ok but the json status-field contains an unkown status value
-        odl_api_test_fixture.api.queue_response(
-            200, content=json.dumps(dict(status="unknown"))
-        )
-        pytest.raises(
-            RemoteIntegrationException,
-            odl_api_test_fixture.api.get_license_status_document,
-            loan,
-        )
-
-        # The last request gets a 400 status code and some json response
-        odl_api_test_fixture.api.queue_response(
-            400, content=json.dumps(dict(content="some content"))
-        )
-
-        with pytest.raises(BadResponseException) as excinfo:
-            odl_api_test_fixture.api.get_license_status_document(loan)
-
-        # Check the exception message
-        assert "returned status code 400. Expected 2XX." in str(excinfo.value)
-
-    def test_checkin_success(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        # A patron has a copy of this book checked out.
-        odl_api_test_fixture.license.setup(concurrency=7, available=6)  # type: ignore[attr-defined]
-
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        loan.external_identifier = "http://loan/" + db.fresh_str()
-        loan.end = utc_now() + datetime.timedelta(days=3)
-
-        # The patron returns the book successfully.
-        odl_api_test_fixture.checkin()
-        assert 3 == len(odl_api_test_fixture.api.requests)
-        assert "http://loan" in odl_api_test_fixture.api.requests[0][0]
-        assert "http://return" == odl_api_test_fixture.api.requests[1][0]
-        assert "http://loan" in odl_api_test_fixture.api.requests[2][0]
-
-        # The pool's availability has increased, and the local loan has
-        # been deleted.
-        assert 7 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == db.session.query(Loan).count()
-
-        # The license on the pool has also been updated
-        assert 7 == odl_api_test_fixture.license.checkouts_available
-
-    def test_checkin_success_with_holds_queue(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        # A patron has the only copy of this book checked out.
-        odl_api_test_fixture.license.setup(concurrency=1, available=0)  # type: ignore[attr-defined]
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        loan.external_identifier = "http://loan/" + db.fresh_str()
-        loan.end = utc_now() + datetime.timedelta(days=3)
-
-        # Another patron has the book on hold.
-        patron_with_hold = db.patron()
-        odl_api_test_fixture.pool.patrons_in_hold_queue = 1
-        hold, ignore = odl_api_test_fixture.pool.on_hold_to(
-            patron_with_hold, start=utc_now(), end=None, position=1
-        )
-
-        # The first patron returns the book successfully.
-        odl_api_test_fixture.checkin()
-        assert 3 == len(odl_api_test_fixture.api.requests)
-        assert "http://loan" in odl_api_test_fixture.api.requests[0][0]
-        assert "http://return" == odl_api_test_fixture.api.requests[1][0]
-        assert "http://loan" in odl_api_test_fixture.api.requests[2][0]
-
-        # Now the license is reserved for the next patron.
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 1 == odl_api_test_fixture.pool.licenses_reserved
-        assert 1 == odl_api_test_fixture.pool.patrons_in_hold_queue
-        assert 0 == db.session.query(Loan).count()
-        assert 0 == hold.position
-
-    def test_checkin_already_fulfilled(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        # The loan is already fulfilled.
-        odl_api_test_fixture.license.setup(concurrency=7, available=6)  # type: ignore[attr-defined]
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        loan.external_identifier = db.fresh_str()
-        loan.end = utc_now() + datetime.timedelta(days=3)
-
-        lsd = json.dumps(
-            {
-                "status": "active",
-            }
-        )
-
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        # Checking in the book silently does nothing.
-        odl_api_test_fixture.api.checkin(
-            odl_api_test_fixture.patron, "pinn", odl_api_test_fixture.pool
-        )
-        assert 1 == len(odl_api_test_fixture.api.requests)
-        assert 6 == odl_api_test_fixture.pool.licenses_available
-        assert 1 == db.session.query(Loan).count()
-
-    def test_checkin_not_checked_out(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        # Not checked out locally.
-        pytest.raises(
-            NotCheckedOut,
-            odl_api_test_fixture.api.checkin,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-        )
-
-        # Not checked out according to the distributor.
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        loan.external_identifier = db.fresh_str()
-        loan.end = utc_now() + datetime.timedelta(days=3)
-
-        lsd = json.dumps(
-            {
-                "status": "revoked",
-            }
-        )
-
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        pytest.raises(
-            NotCheckedOut,
-            odl_api_test_fixture.api.checkin,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-        )
-
-    def test_checkin_cannot_return(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        # Not fulfilled yet, but no return link from the distributor.
-        loan, ignore = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        loan.external_identifier = db.fresh_str()
-        loan.end = utc_now() + datetime.timedelta(days=3)
-
-        lsd = json.dumps(
-            {
-                "status": "ready",
-            }
-        )
-
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        # Checking in silently does nothing.
-        odl_api_test_fixture.api.checkin(
-            odl_api_test_fixture.patron, "pin", odl_api_test_fixture.pool
-        )
-
-        # If the return link doesn't change the status, it still
-        # silently ignores the problem.
-        lsd = json.dumps(
-            {
-                "status": "ready",
-                "links": [
-                    {
-                        "rel": "return",
-                        "href": "http://return",
-                    }
-                ],
-            }
-        )
-
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        odl_api_test_fixture.api.queue_response(200, content="Deleted")
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        odl_api_test_fixture.api.checkin(
-            odl_api_test_fixture.patron, "pin", odl_api_test_fixture.pool
-        )
-
-    def test_checkin_open_access(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        # Checking in an open-access book doesn't need to call out to the distributor API.
-        oa_work = db.work(
-            with_open_access_download=True, collection=odl_api_test_fixture.collection
-        )
-        pool = oa_work.license_pools[0]
-        loan, ignore = pool.loan_to(odl_api_test_fixture.patron)
-
-        # make sure that _checkin isn't called since it is not needed for an open access work
-        odl_api_test_fixture.api._checkin = MagicMock(
-            side_effect=Exception("Should not be called")
-        )
-
-        odl_api_test_fixture.api.checkin(odl_api_test_fixture.patron, "pin", pool)
-
-    def test_checkout_success(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        # This book is available to check out.
-        odl_api_test_fixture.license.setup(concurrency=6, available=6, left=30)  # type: ignore[attr-defined]
-
-        # A patron checks out the book successfully.
-        loan_url = db.fresh_str()
-        loan, _ = odl_api_test_fixture.checkout(loan_url=loan_url)
-
-        assert odl_api_test_fixture.collection == loan.collection(db.session)
-        assert odl_api_test_fixture.pool.identifier.type == loan.identifier_type
-        assert odl_api_test_fixture.pool.identifier.identifier == loan.identifier
-        assert loan.start_date is not None
-        assert loan.start_date > utc_now() - datetime.timedelta(minutes=1)
-        assert loan.start_date < utc_now() + datetime.timedelta(minutes=1)
-        assert datetime_utc(3017, 10, 21, 11, 12, 13) == loan.end_date
-        assert loan_url == loan.external_identifier
-        assert 1 == db.session.query(Loan).count()
-
-        # Now the patron has a loan in the database that matches the LoanInfo
-        # returned by the API.
-        db_loan = db.session.query(Loan).one()
-        assert odl_api_test_fixture.pool == db_loan.license_pool
-        assert odl_api_test_fixture.license == db_loan.license
-        assert loan.start_date == db_loan.start
-        assert loan.end_date == db_loan.end
-
-        # The pool's availability and the license's remaining checkouts have decreased.
-        assert 5 == odl_api_test_fixture.pool.licenses_available
-        assert 29 == odl_api_test_fixture.license.checkouts_left
+        assert notification_url == expected_notification_url
 
     def test_checkout_open_access(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
         # This book is available to check out.
         oa_work = db.work(
-            with_open_access_download=True, collection=odl_api_test_fixture.collection
+            with_open_access_download=True,
+            collection=opds2_with_odl_api_fixture.collection,
         )
-        loan = odl_api_test_fixture.api.checkout(
-            odl_api_test_fixture.patron, "pin", oa_work.license_pools[0], None
+        loan = opds2_with_odl_api_fixture.api_checkout(
+            licensepool=oa_work.license_pools[0],
         )
 
-        assert loan.collection(db.session) == odl_api_test_fixture.collection
+        assert loan.collection(db.session) == opds2_with_odl_api_fixture.collection
         assert loan.identifier == oa_work.license_pools[0].identifier.identifier
         assert loan.identifier_type == oa_work.license_pools[0].identifier.type
         assert loan.start_date is None
@@ -370,96 +430,75 @@ class TestODLAPI:
         assert loan.external_identifier is None
 
     def test_checkout_success_with_hold(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
         # A patron has this book on hold, and the book just became available to check out.
-        odl_api_test_fixture.pool.on_hold_to(
-            odl_api_test_fixture.patron,
+        opds2_with_odl_api_fixture.pool.on_hold_to(
+            opds2_with_odl_api_fixture.patron,
             start=utc_now() - datetime.timedelta(days=1),
+            end=utc_now() + datetime.timedelta(days=1),
             position=0,
         )
-        odl_api_test_fixture.license.setup(concurrency=1, available=1, left=5)  # type: ignore[attr-defined]
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=1, left=5)
 
-        assert odl_api_test_fixture.pool.licenses_available == 0
-        assert odl_api_test_fixture.pool.licenses_reserved == 1
-        assert odl_api_test_fixture.pool.patrons_in_hold_queue == 1
+        assert opds2_with_odl_api_fixture.pool.licenses_available == 0
+        assert opds2_with_odl_api_fixture.pool.licenses_reserved == 1
+        assert opds2_with_odl_api_fixture.pool.patrons_in_hold_queue == 1
 
         # The patron checks out the book.
         loan_url = db.fresh_str()
-        loan, _ = odl_api_test_fixture.checkout(loan_url=loan_url)
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            loan = opds2_with_odl_api_fixture.checkout(loan_url=loan_url)
 
         # The patron gets a loan successfully.
-        assert odl_api_test_fixture.collection == loan.collection(db.session)
-        assert odl_api_test_fixture.pool.identifier.type == loan.identifier_type
-        assert odl_api_test_fixture.pool.identifier.identifier == loan.identifier
-        assert loan.start_date is not None
-        assert loan.start_date > utc_now() - datetime.timedelta(minutes=1)
-        assert loan.start_date < utc_now() + datetime.timedelta(minutes=1)
+        assert opds2_with_odl_api_fixture.collection == loan.collection(db.session)
+        assert opds2_with_odl_api_fixture.pool.identifier.type == loan.identifier_type
+        assert opds2_with_odl_api_fixture.pool.identifier.identifier == loan.identifier
         assert datetime_utc(3017, 10, 21, 11, 12, 13) == loan.end_date
         assert loan_url == loan.external_identifier
-        assert 1 == db.session.query(Loan).count()
 
-        db_loan = db.session.query(Loan).one()
-        assert odl_api_test_fixture.pool == db_loan.license_pool
-        assert odl_api_test_fixture.license == db_loan.license
-        assert 4 == odl_api_test_fixture.license.checkouts_left
-
-        # The book is no longer reserved for the patron, and the hold has been deleted.
-        assert 0 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == odl_api_test_fixture.pool.patrons_in_hold_queue
-        assert 0 == db.session.query(Hold).count()
-
-    def test_checkout_already_checked_out(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        odl_api_test_fixture.license.setup(concurrency=2, available=1)  # type: ignore[attr-defined]
-
-        # Checkout succeeds the first time
-        odl_api_test_fixture.checkout()
-
-        # But raises an exception the second time
-        pytest.raises(AlreadyCheckedOut, odl_api_test_fixture.checkout)
-
-        assert 1 == db.session.query(Loan).count()
+        # The book is no longer reserved for the patron.
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert (
+            0 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+        )  # CirculationAPI removes the hold.
 
     def test_checkout_expired_hold(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
         # The patron was at the beginning of the hold queue, but the hold already expired.
         yesterday = utc_now() - datetime.timedelta(days=1)
-        hold, _ = odl_api_test_fixture.pool.on_hold_to(
-            odl_api_test_fixture.patron, start=yesterday, end=yesterday, position=0
+        hold, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
+            opds2_with_odl_api_fixture.patron,
+            start=yesterday,
+            end=yesterday,
+            position=0,
         )
-        other_hold, _ = odl_api_test_fixture.pool.on_hold_to(
+        other_hold, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
             db.patron(), start=utc_now()
         )
-        odl_api_test_fixture.license.setup(concurrency=2, available=1)  # type: ignore[attr-defined]
+        opds2_with_odl_api_fixture.setup_license(concurrency=2, available=1)
 
-        pytest.raises(
-            NoAvailableCopies,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(NoAvailableCopies):
+                opds2_with_odl_api_fixture.api_checkout()
 
     def test_checkout_no_available_copies(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
         # A different patron has the only copy checked out.
-        odl_api_test_fixture.license.setup(concurrency=1, available=0)  # type: ignore[attr-defined]
-        existing_loan, _ = odl_api_test_fixture.license.loan_to(db.patron())
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=0)
+        existing_loan, _ = opds2_with_odl_api_fixture.license.loan_to(db.patron())
 
-        pytest.raises(
-            NoAvailableCopies,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with pytest.raises(NoAvailableCopies):
+            opds2_with_odl_api_fixture.api_checkout()
 
         assert 1 == db.session.query(Loan).count()
 
@@ -470,52 +509,34 @@ class TestODLAPI:
         last_week = now - datetime.timedelta(weeks=1)
 
         # A different patron has the only copy reserved.
-        other_patron_hold, _ = odl_api_test_fixture.pool.on_hold_to(
+        other_patron_hold, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
             db.patron(), position=0, start=last_week
         )
-        odl_api_test_fixture.pool.update_availability_from_licenses()
+        opds2_with_odl_api_fixture.pool.update_availability_from_licenses()
 
-        pytest.raises(
-            NoAvailableCopies,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with pytest.raises(NoAvailableCopies):
+            opds2_with_odl_api_fixture.api_checkout()
 
         assert 0 == db.session.query(Loan).count()
 
         # The patron has a hold, but another patron is ahead in the holds queue.
-        hold, _ = odl_api_test_fixture.pool.on_hold_to(
+        hold, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
             db.patron(), position=1, start=yesterday
         )
-        odl_api_test_fixture.pool.update_availability_from_licenses()
+        opds2_with_odl_api_fixture.pool.update_availability_from_licenses()
 
-        pytest.raises(
-            NoAvailableCopies,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with pytest.raises(NoAvailableCopies):
+            opds2_with_odl_api_fixture.api_checkout()
 
         assert 0 == db.session.query(Loan).count()
 
         # The patron has the first hold, but it's expired.
         hold.start = last_week - datetime.timedelta(days=1)
         hold.end = yesterday
-        odl_api_test_fixture.pool.update_availability_from_licenses()
+        opds2_with_odl_api_fixture.pool.update_availability_from_licenses()
 
-        pytest.raises(
-            NoAvailableCopies,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with pytest.raises(NoAvailableCopies):
+            opds2_with_odl_api_fixture.api_checkout()
 
         assert 0 == db.session.query(Loan).count()
 
@@ -526,154 +547,281 @@ class TestODLAPI:
     def test_checkout_no_available_copies_unknown_to_us(
         self,
         db: DatabaseTransactionFixture,
-        odl_api_test_fixture: ODLAPITestFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
         response_type: str,
     ) -> None:
         """
         The title has no available copies, but we are out of sync with the distributor, so we think there
         are copies available.
         """
-        checkout = partial(
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            MagicMock(),
-        )
-
         # We think there are copies available.
-        odl_api_test_fixture.license.setup(  # type: ignore[attr-defined]
-            concurrency=1,
-            available=1,
-        )
+        pool = opds2_with_odl_api_fixture.pool
+        pool.licenses = []
+        license_1 = db.license(pool, terms_concurrency=1, checkouts_available=1)
+        license_2 = db.license(pool, checkouts_available=1)
+        pool.update_availability_from_licenses()
 
         # But the distributor says there are no available copies.
-        odl_api_test_fixture.api.queue_response(
+        opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            headers={"Content-Type": response_type},
-            content=odl_api_test_fixture.files.sample_text("unavailable.json"),
+            response_type,
+            content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
+        )
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            400,
+            response_type,
+            content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
         )
 
-        with pytest.raises(NoAvailableCopies):
-            checkout()
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(NoAvailableCopies):
+                opds2_with_odl_api_fixture.api_checkout()
 
         assert db.session.query(Loan).count() == 0
+        assert opds2_with_odl_api_fixture.pool.licenses_available == 0
+        assert license_1.checkouts_available == 0
+        assert license_2.checkouts_available == 0
+
+    def test_checkout_many_licenses(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        """
+        The title has 5 different licenses. Several of them seem to have copies available. But
+        we are out of sync, so it turns out that not all of them do.
+        """
+        # We think there are copies available.
+        pool = opds2_with_odl_api_fixture.pool
+        pool.licenses = []
+        license_unavailable_1 = db.license(
+            pool, checkouts_available=2, expires=utc_now() + datetime.timedelta(weeks=4)
+        )
+        license_unavailable_2 = db.license(
+            pool, terms_concurrency=1, checkouts_available=1
+        )
+        license_untouched = db.license(pool, checkouts_left=1, checkouts_available=1)
+        license_lent = db.license(
+            pool,
+            checkouts_left=4,
+            checkouts_available=4,
+            expires=utc_now() + datetime.timedelta(weeks=1),
+        )
+        license_expired = db.license(
+            pool,
+            terms_concurrency=10,
+            checkouts_available=10,
+            expires=utc_now() - datetime.timedelta(weeks=1),
+        )
+        pool.update_availability_from_licenses()
+        assert pool.licenses_available == 8
+
+        assert opds2_with_odl_api_fixture.pool.best_available_licenses() == [
+            license_unavailable_1,
+            license_unavailable_2,
+            license_lent,
+            license_untouched,
+        ]
+
+        # But the distributor says there are no available copies for license_unavailable_1
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            400,
+            "application/api-problem+json",
+            content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
+        )
+        # And for license_unavailable_2
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            400,
+            "application/api-problem+json",
+            content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
+        )
+        # But license_lent is still available, and we successfully check it out
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            201,
+            content=opds2_with_odl_api_fixture.loan_status_document().to_serializable(),
+        )
+
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            loan_info = opds2_with_odl_api_fixture.api_checkout()
+
+        assert opds2_with_odl_api_fixture.pool.licenses_available == 4
+        assert license_unavailable_2.checkouts_available == 0
+        assert license_unavailable_1.checkouts_available == 0
+        assert license_lent.checkouts_available == 3
+        assert license_untouched.checkouts_available == 1
+
+        assert loan_info.license_identifier == license_lent.identifier
+
+    @freeze_time()
+    def test_checkout_ready_hold_no_available_copies(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        """
+        We think there is a hold ready for us, but we are out of sync with the distributor,
+        so there actually isn't a copy ready for our hold.
+        """
+        now = utc_now()
+        # We think there is a copy available for this hold.
+        hold, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
+            opds2_with_odl_api_fixture.patron,
+            start=utc_now() - datetime.timedelta(days=1),
+            end=utc_now() + datetime.timedelta(days=1),
+            position=0,
+        )
+        # Set the reservation period and loan period.
+        library = hold.patron.library
+        config = (
+            opds2_with_odl_api_fixture.collection.integration_configuration.for_library(
+                library.id
+            )
+        )
+        assert config is not None
+        DatabaseTransactionFixture.set_settings(
+            config,
+            **{
+                Collection.DEFAULT_RESERVATION_PERIOD_KEY: 3,
+                Collection.EBOOK_LOAN_DURATION_KEY: 6,
+            },
+        )
+        opds2_with_odl_api_fixture.db.session.commit()
+        loan_period = now + datetime.timedelta(
+            days=opds2_with_odl_api_fixture.collection.default_loan_period(library)
+        )
+
+        print(opds2_with_odl_api_fixture.pool)
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=1)
+
+        assert opds2_with_odl_api_fixture.pool.licenses_available == 0
+        assert opds2_with_odl_api_fixture.pool.licenses_reserved == 1
+        assert opds2_with_odl_api_fixture.pool.patrons_in_hold_queue == 1
+
+        # We have another hold in the queue.
+        hold2, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
+            db.patron(),
+            start=now - datetime.timedelta(days=1),
+            end=now + datetime.timedelta(days=365),
+            position=1,
+        )
+
+        # The patron tries to checkout but the distributor says there are no available copies after all.
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            400,
+            "application/api-problem+json",
+            content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
+        )
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(NoAvailableCopiesWhenReserved):
+                opds2_with_odl_api_fixture.api_checkout()
+        assert db.session.query(Hold).count() == 2
+
+        # The availability has been updated.
+        assert opds2_with_odl_api_fixture.pool.licenses_available == 0
+        assert opds2_with_odl_api_fixture.pool.licenses_reserved == 0
+        assert opds2_with_odl_api_fixture.pool.patrons_in_hold_queue == 2
+
+        # The first hold gets back to position 1 with a new end date.
+        assert hold.position == 1
+        assert hold.end == loan_period
+        # And the second hold position moves a position down but the end date remains.
+        assert hold2.position == 2
+        assert hold2.end == now + datetime.timedelta(days=365)
+
+    def test_checkout_failures(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        # We think there are copies available.
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=1)
 
         # Test the case where we get bad JSON back from the distributor.
-        odl_api_test_fixture.api.queue_response(
+        opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            headers={"Content-Type": response_type},
+            "application/api-problem+json",
             content="hot garbage",
         )
 
         with pytest.raises(BadResponseException):
-            checkout()
+            opds2_with_odl_api_fixture.api_checkout()
 
         # Test the case where we just get an unknown bad response.
-        odl_api_test_fixture.api.queue_response(
-            500, headers={"Content-Type": "text/plain"}, content="halt and catch fire 🔥"
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            500, "text/plain", content="halt and catch fire 🔥"
         )
         with pytest.raises(BadResponseException):
-            checkout()
+            opds2_with_odl_api_fixture.api_checkout()
 
     def test_checkout_no_licenses(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
-        odl_api_test_fixture.license.setup(concurrency=1, available=1, left=0)  # type: ignore[attr-defined]
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=1, left=0)
 
-        pytest.raises(
-            NoLicenses,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with pytest.raises(NoLicenses):
+            opds2_with_odl_api_fixture.api_checkout()
 
         assert 0 == db.session.query(Loan).count()
 
     def test_checkout_when_all_licenses_expired(
-        self, odl_api_test_fixture: ODLAPITestFixture
+        self, opds2_with_odl_api_fixture: OPDS2WithODLApiFixture
     ) -> None:
         # license expired by expiration date
-        odl_api_test_fixture.license.setup(  # type: ignore[attr-defined]
+        opds2_with_odl_api_fixture.setup_license(
             concurrency=1,
             available=2,
             left=1,
             expires=utc_now() - datetime.timedelta(weeks=1),
         )
 
-        pytest.raises(
-            NoLicenses,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with pytest.raises(NoLicenses):
+            opds2_with_odl_api_fixture.api_checkout()
 
         # license expired by no remaining checkouts
-        odl_api_test_fixture.license.setup(  # type: ignore[attr-defined]
+        opds2_with_odl_api_fixture.setup_license(
             concurrency=1,
             available=2,
             left=0,
             expires=utc_now() + datetime.timedelta(weeks=1),
         )
 
-        pytest.raises(
-            NoLicenses,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
+        with pytest.raises(NoLicenses):
+            opds2_with_odl_api_fixture.api_checkout()
 
     def test_checkout_cannot_loan(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
-        lsd = json.dumps(
-            {
-                "status": "revoked",
-            }
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            200,
+            content=opds2_with_odl_api_fixture.loan_status_document(
+                "revoked"
+            ).to_serializable(),
         )
-
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        pytest.raises(
-            CannotLoan,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
-
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(CannotLoan):
+                opds2_with_odl_api_fixture.api_checkout()
         assert 0 == db.session.query(Loan).count()
 
         # No external identifier.
-        lsd = json.dumps(
-            {
-                "status": "ready",
-                "potential_rights": {"end": "2017-10-21T11:12:13Z"},
-            }
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            200,
+            content=opds2_with_odl_api_fixture.loan_status_document(
+                self_link=False, license_link=False
+            ).to_serializable(),
         )
-
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        pytest.raises(
-            CannotLoan,
-            odl_api_test_fixture.api.checkout,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
-        )
-
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(CannotLoan):
+                opds2_with_odl_api_fixture.api_checkout()
         assert 0 == db.session.query(Loan).count()
 
     @pytest.mark.parametrize(
-        "delivery_mechanism, correct_type, correct_link, links",
+        "drm_scheme, correct_type, correct_link, links",
         [
-            (
+            pytest.param(
                 DeliveryMechanism.ADOBE_DRM,
                 DeliveryMechanism.ADOBE_DRM,
                 "http://acsm",
@@ -684,22 +832,37 @@ class TestODLAPI:
                         "type": DeliveryMechanism.ADOBE_DRM,
                     }
                 ],
+                id="adobe drm",
             ),
-            (
-                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-                "http://manifest",
+            pytest.param(
+                DeliveryMechanism.LCP_DRM,
+                DeliveryMechanism.LCP_DRM,
+                "http://lcp",
                 [
                     {
-                        "rel": "manifest",
-                        "href": "http://manifest",
-                        "type": MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
+                        "rel": "license",
+                        "href": "http://lcp",
+                        "type": DeliveryMechanism.LCP_DRM,
                     }
                 ],
+                id="lcp drm",
             ),
-            (
+            pytest.param(
+                DeliveryMechanism.NO_DRM,
+                "application/epub+zip",
+                "http://publication",
+                [
+                    {
+                        "rel": "publication",
+                        "href": "http://publication",
+                        "type": "application/epub+zip",
+                    }
+                ],
+                id="no drm",
+            ),
+            pytest.param(
                 DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
-                ODLImporter.FEEDBOOKS_AUDIO,
+                BaseODLImporter.FEEDBOOKS_AUDIO,
                 "http://correct",
                 [
                     {
@@ -710,116 +873,212 @@ class TestODLAPI:
                     {
                         "rel": "manifest",
                         "href": "http://correct",
-                        "type": ODLImporter.FEEDBOOKS_AUDIO,
+                        "type": BaseODLImporter.FEEDBOOKS_AUDIO,
                     },
                 ],
+                id="feedbooks audio",
             ),
         ],
     )
     def test_fulfill_success(
         self,
-        odl_api_test_fixture: ODLAPITestFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
         db: DatabaseTransactionFixture,
-        delivery_mechanism: str,
+        drm_scheme: str,
         correct_type: str,
         correct_link: str,
-        links: dict[str, Any],
+        links: list[dict[str, str]],
     ) -> None:
         # Fulfill a loan in a way that gives access to a license file.
-        odl_api_test_fixture.license.setup(concurrency=1, available=1)  # type: ignore[attr-defined]
-        odl_api_test_fixture.checkout()
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=1)
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.checkout(create_loan=True)
 
         lpdm = MagicMock(spec=LicensePoolDeliveryMechanism)
         lpdm.delivery_mechanism = MagicMock(spec=DeliveryMechanism)
-        lpdm.delivery_mechanism.content_type = "ignored/format"
-        lpdm.delivery_mechanism.drm_scheme = delivery_mechanism
-
-        lsd = json.dumps(
-            {
-                "status": "ready",
-                "potential_rights": {"end": "2017-10-21T11:12:13Z"},
-                "links": links,
-            }
+        lpdm.delivery_mechanism.content_type = (
+            "ignored/format" if drm_scheme != DeliveryMechanism.NO_DRM else correct_type
         )
+        lpdm.delivery_mechanism.drm_scheme = drm_scheme
 
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
-        fulfillment = odl_api_test_fixture.api.fulfill(
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            lpdm,
+        lsd = opds2_with_odl_api_fixture.loan_status_document("active", links=links)
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            200, content=lsd.to_serializable()
         )
-
-        assert odl_api_test_fixture.collection == fulfillment.collection(db.session)
-        assert odl_api_test_fixture.pool.identifier.type == fulfillment.identifier_type
-        assert odl_api_test_fixture.pool.identifier.identifier == fulfillment.identifier
-        assert datetime_utc(2017, 10, 21, 11, 12, 13) == fulfillment.content_expires
-        assert correct_link == fulfillment.content_link
-        assert correct_type == fulfillment.content_type
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            fulfillment = opds2_with_odl_api_fixture.api.fulfill(
+                opds2_with_odl_api_fixture.patron,
+                "pin",
+                opds2_with_odl_api_fixture.pool,
+                lpdm,
+            )
+        assert (
+            isinstance(fulfillment, FetchFulfillment)
+            if drm_scheme != DeliveryMechanism.NO_DRM
+            else isinstance(fulfillment, RedirectFulfillment)
+        )
+        assert correct_link == fulfillment.content_link  # type: ignore[attr-defined]
+        assert correct_type == fulfillment.content_type  # type: ignore[attr-defined]
+        if isinstance(fulfillment, FetchFulfillment):
+            assert fulfillment.allowed_response_codes == ["2xx"]
 
     def test_fulfill_open_access(
         self,
-        odl_api_test_fixture: ODLAPITestFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
         db: DatabaseTransactionFixture,
     ) -> None:
         oa_work = db.work(
-            with_open_access_download=True, collection=odl_api_test_fixture.collection
+            with_open_access_download=True,
+            collection=opds2_with_odl_api_fixture.collection,
         )
         pool = oa_work.license_pools[0]
-        loan, ignore = pool.loan_to(odl_api_test_fixture.patron)
+        loan, ignore = pool.loan_to(opds2_with_odl_api_fixture.patron)
 
         # If we can't find a delivery mechanism, we can't fulfill the loan.
-        pytest.raises(
-            CannotFulfill,
-            odl_api_test_fixture.api.fulfill,
-            odl_api_test_fixture.patron,
-            "pin",
-            pool,
-            MagicMock(spec=LicensePoolDeliveryMechanism),
+        mock_lpdm = MagicMock(
+            spec=LicensePoolDeliveryMechanism,
+            delivery_mechanism=MagicMock(drm_scheme=None),
         )
+        with pytest.raises(CannotFulfill):
+            opds2_with_odl_api_fixture.api.fulfill(
+                opds2_with_odl_api_fixture.patron, "pin", pool, mock_lpdm
+            )
 
         lpdm = pool.delivery_mechanisms[0]
-        fulfillment = odl_api_test_fixture.api.fulfill(
-            odl_api_test_fixture.patron, "pin", pool, lpdm
+        fulfillment = opds2_with_odl_api_fixture.api.fulfill(
+            opds2_with_odl_api_fixture.patron, "pin", pool, lpdm
         )
 
-        assert odl_api_test_fixture.collection == fulfillment.collection(db.session)
-        assert fulfillment.identifier_type == pool.identifier.type
-        assert fulfillment.identifier == pool.identifier.identifier
-        assert fulfillment.content_expires is None
+        assert isinstance(fulfillment, RedirectFulfillment)
         assert fulfillment.content_link == pool.open_access_download_url
         assert fulfillment.content_type == lpdm.delivery_mechanism.content_type
 
+    @pytest.mark.parametrize(
+        "status_document",
+        [
+            pytest.param(
+                OPDS2WithODLApiFixture.loan_status_document("revoked"),
+                id="revoked",
+            ),
+            pytest.param(
+                OPDS2WithODLApiFixture.loan_status_document("cancelled"),
+                id="cancelled",
+            ),
+            pytest.param(
+                OPDS2WithODLApiFixture.loan_status_document("active"),
+                id="missing link",
+            ),
+        ],
+    )
     def test_fulfill_cannot_fulfill(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+        status_document: LoanStatus,
     ) -> None:
-        odl_api_test_fixture.license.setup(concurrency=7, available=7)  # type: ignore[attr-defined]
-        odl_api_test_fixture.checkout()
+        opds2_with_odl_api_fixture.setup_license(concurrency=7, available=7)
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.checkout(create_loan=True)
 
         assert 1 == db.session.query(Loan).count()
-        assert 6 == odl_api_test_fixture.pool.licenses_available
+        assert 6 == opds2_with_odl_api_fixture.pool.licenses_available
 
-        lsd = json.dumps(
-            {
-                "status": "revoked",
-            }
+        opds2_with_odl_api_fixture.mock_http.queue_response(
+            200, content=status_document.to_serializable()
         )
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(CannotFulfill):
+                opds2_with_odl_api_fixture.api.fulfill(
+                    opds2_with_odl_api_fixture.patron,
+                    "pin",
+                    opds2_with_odl_api_fixture.pool,
+                    MagicMock(),
+                )
 
-        odl_api_test_fixture.api.queue_response(200, content=lsd)
+    @freeze_time()
+    def test_place_hold_success(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            loan = opds2_with_odl_api_fixture.checkout(
+                patron=db.patron(), create_loan=True
+            )
+            hold = opds2_with_odl_api_fixture.place_hold()
+
+        assert 1 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+        assert opds2_with_odl_api_fixture.collection == hold.collection(db.session)
+        assert opds2_with_odl_api_fixture.pool.identifier.type == hold.identifier_type
+        assert opds2_with_odl_api_fixture.pool.identifier.identifier == hold.identifier
+        assert hold.start_date is not None
+        assert hold.start_date == utc_now()
+        assert 1 == hold.hold_position
+
+    def test_place_hold_already_on_hold(
+        self, opds2_with_odl_api_fixture: OPDS2WithODLApiFixture
+    ) -> None:
+        opds2_with_odl_api_fixture.setup_license(concurrency=1, available=0)
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.place_hold(create_hold=True)
+            with pytest.raises(AlreadyOnHold):
+                opds2_with_odl_api_fixture.place_hold()
+
+    def test_place_hold_currently_available(
+        self, opds2_with_odl_api_fixture: OPDS2WithODLApiFixture
+    ) -> None:
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            with pytest.raises(CurrentlyAvailable):
+                opds2_with_odl_api_fixture.place_hold()
+
+    def test_release_hold_success(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        loan_patron = db.patron()
+        hold1_patron = db.patron()
+        hold2_patron = db.patron()
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.checkout(patron=loan_patron, create_loan=True)
+            opds2_with_odl_api_fixture.place_hold(patron=hold1_patron, create_hold=True)
+            opds2_with_odl_api_fixture.place_hold(patron=hold2_patron, create_hold=True)
+
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 2 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.api.release_hold(
+                hold1_patron, "pin", opds2_with_odl_api_fixture.pool
+            )
+        db.session.execute(delete(Hold).where(Hold.patron == hold1_patron))
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 1 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.checkin(patron=loan_patron)
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 1 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 1 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.api.release_hold(
+                hold2_patron, "pin", opds2_with_odl_api_fixture.pool
+            )
+        assert 1 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 0 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+
+    def test_release_hold_not_on_hold(
+        self, opds2_with_odl_api_fixture: OPDS2WithODLApiFixture
+    ) -> None:
         pytest.raises(
-            CannotFulfill,
-            odl_api_test_fixture.api.fulfill,
-            odl_api_test_fixture.patron,
+            NotOnHold,
+            opds2_with_odl_api_fixture.api.release_hold,
+            opds2_with_odl_api_fixture.patron,
             "pin",
-            odl_api_test_fixture.pool,
-            Representation.EPUB_MEDIA_TYPE,
+            opds2_with_odl_api_fixture.pool,
         )
-
-        # The pool's availability has been updated and the local
-        # loan has been deleted, since we found out the loan is
-        # no longer active.
-        assert 7 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == db.session.query(Loan).count()
 
     def _holdinfo_from_hold(self, hold: Hold) -> HoldInfo:
         pool: LicensePool = hold.license_pool
@@ -830,352 +1089,51 @@ class TestODLAPI:
             hold_position=hold.position,
         )
 
-    def test_count_holds_before(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+    def test_update_licensepool_and_hold_queue(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
-        now = utc_now()
-        yesterday = now - datetime.timedelta(days=1)
-        tomorrow = now + datetime.timedelta(days=1)
-        last_week = now - datetime.timedelta(weeks=1)
-
-        hold, ignore = odl_api_test_fixture.pool.on_hold_to(
-            odl_api_test_fixture.patron, start=now
-        )
-
-        info = self._holdinfo_from_hold(hold)
-        assert 0 == odl_api_test_fixture.api._count_holds_before(
-            info, hold.license_pool
-        )
-
-        # A previous hold.
-        odl_api_test_fixture.pool.on_hold_to(db.patron(), start=yesterday)
-        assert 1 == odl_api_test_fixture.api._count_holds_before(
-            info, hold.license_pool
-        )
-
-        # Expired holds don't count.
-        odl_api_test_fixture.pool.on_hold_to(
-            db.patron(), start=last_week, end=yesterday, position=0
-        )
-        assert 1 == odl_api_test_fixture.api._count_holds_before(
-            info, hold.license_pool
-        )
-
-        # Later holds don't count.
-        odl_api_test_fixture.pool.on_hold_to(db.patron(), start=tomorrow)
-        assert 1 == odl_api_test_fixture.api._count_holds_before(
-            info, hold.license_pool
-        )
-
-        # Holds on another pool don't count.
-        other_pool = db.licensepool(None)
-        other_pool.on_hold_to(odl_api_test_fixture.patron, start=yesterday)
-        assert 1 == odl_api_test_fixture.api._count_holds_before(
-            info, hold.license_pool
-        )
-
-        for i in range(3):
-            odl_api_test_fixture.pool.on_hold_to(
-                db.patron(), start=yesterday, end=tomorrow, position=1
-            )
-        assert 4 == odl_api_test_fixture.api._count_holds_before(
-            info, hold.license_pool
-        )
-
-    def test_update_hold_end_date(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        now = utc_now()
-        tomorrow = now + datetime.timedelta(days=1)
-        yesterday = now - datetime.timedelta(days=1)
-        next_week = now + datetime.timedelta(days=7)
-        last_week = now - datetime.timedelta(days=7)
-
-        odl_api_test_fixture.pool.licenses_owned = 1
-        odl_api_test_fixture.pool.licenses_reserved = 1
-
-        hold, ignore = odl_api_test_fixture.pool.on_hold_to(
-            odl_api_test_fixture.patron, start=now, position=0
-        )
-        info = self._holdinfo_from_hold(hold)
-        library = hold.patron.library
-
-        # Set the reservation period and loan period.
-        config = odl_api_test_fixture.collection.integration_configuration.for_library(
-            library.id
-        )
-        assert config is not None
-        DatabaseTransactionFixture.set_settings(
-            config,
-            **{
-                Collection.DEFAULT_RESERVATION_PERIOD_KEY: 3,
-                Collection.EBOOK_LOAN_DURATION_KEY: 6,
-            },
-        )
-        odl_api_test_fixture.db.session.commit()
-
-        # A hold that's already reserved and has an end date doesn't change.
-        info.end_date = tomorrow
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert tomorrow == info.end_date
-        info.end_date = yesterday
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert yesterday == info.end_date
-
-        # Updating a hold that's reserved but doesn't have an end date starts the
-        # reservation period.
-        info.end_date = None
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert info.end_date is not None
-        assert info.end_date < next_week  # type: ignore[unreachable]
-        assert info.end_date > now
-
-        # Updating a hold that has an end date but just became reserved starts
-        # the reservation period.
-        info.end_date = yesterday
-        info.hold_position = 1
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert info.end_date < next_week
-        assert info.end_date > now
-
-        # When there's a holds queue, the end date is the maximum time it could take for
-        # a license to become available.
-
-        # One copy, one loan, hold position 1.
-        # The hold will be available as soon as the loan expires.
-        odl_api_test_fixture.pool.licenses_available = 0
-        odl_api_test_fixture.pool.licenses_reserved = 0
-        odl_api_test_fixture.pool.licenses_owned = 1
-        loan, ignore = odl_api_test_fixture.license.loan_to(db.patron(), end=tomorrow)
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert tomorrow == info.end_date
-
-        # One copy, one loan, hold position 2.
-        # The hold will be available after the loan expires + 1 cycle.
-        first_hold, ignore = odl_api_test_fixture.pool.on_hold_to(
-            db.patron(), start=last_week
-        )
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert tomorrow + datetime.timedelta(days=9) == info.end_date
-
-        # Two copies, one loan, one reserved hold, hold position 2.
-        # The hold will be available after the loan expires.
-        odl_api_test_fixture.pool.licenses_reserved = 1
-        odl_api_test_fixture.pool.licenses_owned = 2
-        odl_api_test_fixture.license.checkouts_available = 2
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert tomorrow == info.end_date
-
-        # Two copies, one loan, one reserved hold, hold position 3.
-        # The hold will be available after the reserved hold is checked out
-        # at the latest possible time and that loan expires.
-        second_hold, ignore = odl_api_test_fixture.pool.on_hold_to(
-            db.patron(), start=yesterday
-        )
-        first_hold.end = next_week
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert next_week + datetime.timedelta(days=6) == info.end_date
-
-        # One copy, no loans, one reserved hold, hold position 3.
-        # The hold will be available after the reserved hold is checked out
-        # at the latest possible time and that loan expires + 1 cycle.
-        db.session.delete(loan)
-        odl_api_test_fixture.pool.licenses_owned = 1
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert next_week + datetime.timedelta(days=15) == info.end_date
-
-        # One copy, no loans, one reserved hold, hold position 2.
-        # The hold will be available after the reserved hold is checked out
-        # at the latest possible time and that loan expires.
-        db.session.delete(second_hold)
-        odl_api_test_fixture.pool.licenses_owned = 1
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert next_week + datetime.timedelta(days=6) == info.end_date
-
-        db.session.delete(first_hold)
-
-        # Ten copies, seven loans, three reserved holds, hold position 9.
-        # The hold will be available after the sixth loan expires.
-        odl_api_test_fixture.pool.licenses_owned = 10
-        for i in range(5):
-            odl_api_test_fixture.pool.loan_to(db.patron(), end=next_week)
-        odl_api_test_fixture.pool.loan_to(
-            db.patron(), end=next_week + datetime.timedelta(days=1)
-        )
-        odl_api_test_fixture.pool.loan_to(
-            db.patron(), end=next_week + datetime.timedelta(days=2)
-        )
-        odl_api_test_fixture.pool.licenses_reserved = 3
-        for i in range(3):
-            odl_api_test_fixture.pool.on_hold_to(
-                db.patron(),
-                start=last_week + datetime.timedelta(days=i),
-                end=next_week + datetime.timedelta(days=i),
-                position=0,
-            )
-        for i in range(5):
-            odl_api_test_fixture.pool.on_hold_to(db.patron(), start=yesterday)
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert next_week + datetime.timedelta(days=1) == info.end_date
-
-        # Ten copies, seven loans, three reserved holds, hold position 12.
-        # The hold will be available after the second reserved hold is checked
-        # out and that loan expires.
-        for i in range(3):
-            odl_api_test_fixture.pool.on_hold_to(db.patron(), start=yesterday)
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert next_week + datetime.timedelta(days=7) == info.end_date
-
-        # Ten copies, seven loans, three reserved holds, hold position 29.
-        # The hold will be available after the sixth loan expires + 2 cycles.
-        for i in range(17):
-            odl_api_test_fixture.pool.on_hold_to(db.patron(), start=yesterday)
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert next_week + datetime.timedelta(days=19) == info.end_date
-
-        # Ten copies, seven loans, three reserved holds, hold position 32.
-        # The hold will be available after the second reserved hold is checked
-        # out and that loan expires + 2 cycles.
-        for i in range(3):
-            odl_api_test_fixture.pool.on_hold_to(db.patron(), start=yesterday)
-        odl_api_test_fixture.api._update_hold_end_date(
-            info, hold.license_pool, library=library
-        )
-        assert next_week + datetime.timedelta(days=25) == info.end_date
-
-    def test_update_hold_position(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        now = utc_now()
-        yesterday = now - datetime.timedelta(days=1)
-        tomorrow = now + datetime.timedelta(days=1)
-
-        hold, ignore = odl_api_test_fixture.pool.on_hold_to(
-            odl_api_test_fixture.patron, start=now
-        )
-        info = self._holdinfo_from_hold(hold)
-
-        odl_api_test_fixture.pool.licenses_owned = 1
-
-        # When there are no other holds and no licenses reserved, hold position is 1.
-        loan, _ = odl_api_test_fixture.license.loan_to(db.patron())
-        odl_api_test_fixture.api._update_hold_position(info, hold.license_pool)
-        assert 1 == info.hold_position
-
-        # When a license is reserved, position is 0.
-        db.session.delete(loan)
-        odl_api_test_fixture.api._update_hold_position(info, hold.license_pool)
-        assert 0 == info.hold_position
-
-        # If another hold has the reserved licenses, position is 2.
-        odl_api_test_fixture.pool.on_hold_to(db.patron(), start=yesterday)
-        odl_api_test_fixture.api._update_hold_position(info, hold.license_pool)
-        assert 2 == info.hold_position
-
-        # If another license is reserved, position goes back to 0.
-        odl_api_test_fixture.pool.licenses_owned = 2
-        odl_api_test_fixture.license.checkouts_available = 2
-        odl_api_test_fixture.api._update_hold_position(info, hold.license_pool)
-        assert 0 == info.hold_position
-
-        # If there's an earlier hold but it expired, it doesn't
-        # affect the position.
-        odl_api_test_fixture.pool.on_hold_to(
-            db.patron(), start=yesterday, end=yesterday, position=0
-        )
-        odl_api_test_fixture.api._update_hold_position(info, hold.license_pool)
-        assert 0 == info.hold_position
-
-        # Hold position is after all earlier non-expired holds...
-        for i in range(3):
-            odl_api_test_fixture.pool.on_hold_to(db.patron(), start=yesterday)
-        odl_api_test_fixture.api._update_hold_position(info, hold.license_pool)
-        assert 5 == info.hold_position
-
-        # and before any later holds.
-        for i in range(2):
-            odl_api_test_fixture.pool.on_hold_to(db.patron(), start=tomorrow)
-        odl_api_test_fixture.api._update_hold_position(info, hold.license_pool)
-        assert 5 == info.hold_position
-
-    def test_update_hold_data(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        hold, is_new = odl_api_test_fixture.pool.on_hold_to(
-            odl_api_test_fixture.patron,
-            utc_now(),
-            utc_now() + datetime.timedelta(days=100),
-            9,
-        )
-        odl_api_test_fixture.api._update_hold_data(hold)
-        assert hold.position == 0
-        assert hold.end.date() == (hold.start + datetime.timedelta(days=3)).date()
-
-    def test_update_hold_queue(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        licenses = [odl_api_test_fixture.license]
+        licenses = [opds2_with_odl_api_fixture.license]
 
         DatabaseTransactionFixture.set_settings(
-            odl_api_test_fixture.collection.integration_configuration,
+            opds2_with_odl_api_fixture.collection.integration_configuration,
             **{Collection.DEFAULT_RESERVATION_PERIOD_KEY: 3},
         )
 
         # If there's no holds queue when we try to update the queue, it
         # will remove a reserved license and make it available instead.
-        odl_api_test_fixture.pool.licenses_owned = 1
-        odl_api_test_fixture.pool.licenses_available = 0
-        odl_api_test_fixture.pool.licenses_reserved = 1
-        odl_api_test_fixture.pool.patrons_in_hold_queue = 0
+        opds2_with_odl_api_fixture.pool.licenses_owned = 1
+        opds2_with_odl_api_fixture.pool.licenses_available = 0
+        opds2_with_odl_api_fixture.pool.licenses_reserved = 1
+        opds2_with_odl_api_fixture.pool.patrons_in_hold_queue = 0
         last_update = utc_now() - datetime.timedelta(minutes=5)
-        odl_api_test_fixture.work.last_update_time = last_update
-        odl_api_test_fixture.api.update_licensepool(odl_api_test_fixture.pool)
-        assert 1 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == odl_api_test_fixture.pool.patrons_in_hold_queue
+        opds2_with_odl_api_fixture.work.last_update_time = last_update
+        opds2_with_odl_api_fixture.api.update_licensepool_and_hold_queue(
+            opds2_with_odl_api_fixture.pool
+        )
+        assert 1 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 0 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
         # The work's last update time is changed so it will be moved up in the crawlable OPDS feed.
-        assert odl_api_test_fixture.work.last_update_time > last_update
+        assert opds2_with_odl_api_fixture.work.last_update_time > last_update
 
         # If there are holds, a license will get reserved for the next hold
         # and its end date will be set.
-        hold, _ = odl_api_test_fixture.pool.on_hold_to(
-            odl_api_test_fixture.patron, start=utc_now(), position=1
+        hold, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
+            opds2_with_odl_api_fixture.patron, start=utc_now(), position=1
         )
-        later_hold, _ = odl_api_test_fixture.pool.on_hold_to(
+        later_hold, _ = opds2_with_odl_api_fixture.pool.on_hold_to(
             db.patron(), start=utc_now() + datetime.timedelta(days=1), position=2
         )
-        odl_api_test_fixture.api.update_licensepool(odl_api_test_fixture.pool)
+        opds2_with_odl_api_fixture.api.update_licensepool_and_hold_queue(
+            opds2_with_odl_api_fixture.pool
+        )
 
         # The pool's licenses were updated.
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 1 == odl_api_test_fixture.pool.licenses_reserved
-        assert 2 == odl_api_test_fixture.pool.patrons_in_hold_queue
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 1 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 2 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
 
         # And the first hold changed.
         assert 0 == hold.position
@@ -1183,20 +1141,22 @@ class TestODLAPI:
             hours=1
         )
 
-        # The later hold is the same.
-        assert 2 == later_hold.position
+        # The later hold also moved one position.
+        assert 1 == later_hold.position
 
         # Now there's a reserved hold. If we add another license, it's reserved and,
         # the later hold is also updated.
         l = db.license(
-            odl_api_test_fixture.pool, terms_concurrency=1, checkouts_available=1
+            opds2_with_odl_api_fixture.pool, terms_concurrency=1, checkouts_available=1
         )
         licenses.append(l)
-        odl_api_test_fixture.api.update_licensepool(odl_api_test_fixture.pool)
+        opds2_with_odl_api_fixture.api.update_licensepool_and_hold_queue(
+            opds2_with_odl_api_fixture.pool
+        )
 
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 2 == odl_api_test_fixture.pool.licenses_reserved
-        assert 2 == odl_api_test_fixture.pool.patrons_in_hold_queue
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 2 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 2 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
         assert 0 == later_hold.position
         assert later_hold.end - utc_now() - datetime.timedelta(
             days=3
@@ -1205,52 +1165,58 @@ class TestODLAPI:
         # Now there are no more holds. If we add another license,
         # it ends up being available.
         l = db.license(
-            odl_api_test_fixture.pool, terms_concurrency=1, checkouts_available=1
+            opds2_with_odl_api_fixture.pool, terms_concurrency=1, checkouts_available=1
         )
         licenses.append(l)
-        odl_api_test_fixture.api.update_licensepool(odl_api_test_fixture.pool)
-        assert 1 == odl_api_test_fixture.pool.licenses_available
-        assert 2 == odl_api_test_fixture.pool.licenses_reserved
-        assert 2 == odl_api_test_fixture.pool.patrons_in_hold_queue
+        opds2_with_odl_api_fixture.api.update_licensepool_and_hold_queue(
+            opds2_with_odl_api_fixture.pool
+        )
+        assert 1 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 2 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 2 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
 
         # License pool is updated when the holds are removed.
         db.session.delete(hold)
         db.session.delete(later_hold)
-        odl_api_test_fixture.api.update_licensepool(odl_api_test_fixture.pool)
-        assert 3 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == odl_api_test_fixture.pool.patrons_in_hold_queue
+        opds2_with_odl_api_fixture.api.update_licensepool_and_hold_queue(
+            opds2_with_odl_api_fixture.pool
+        )
+        assert 3 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 0 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
 
         # We can also make multiple licenses reserved at once.
         loans = []
         holds = []
-        for i in range(3):
-            p = db.patron()
-            loan, _ = odl_api_test_fixture.checkout(patron=p)
-            loans.append((loan, p))
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == odl_api_test_fixture.pool.patrons_in_hold_queue
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            for i in range(3):
+                p = db.patron()
+                loan = opds2_with_odl_api_fixture.checkout(patron=p, create_loan=True)
+                loans.append((loan, p))
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 0 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
 
         l = db.license(
-            odl_api_test_fixture.pool, terms_concurrency=2, checkouts_available=2
+            opds2_with_odl_api_fixture.pool, terms_concurrency=2, checkouts_available=2
         )
         licenses.append(l)
         for i in range(3):
-            hold, ignore = odl_api_test_fixture.pool.on_hold_to(
+            hold, ignore = opds2_with_odl_api_fixture.pool.on_hold_to(
                 db.patron(),
                 start=utc_now() - datetime.timedelta(days=3 - i),
                 position=i + 1,
             )
             holds.append(hold)
-
-        odl_api_test_fixture.api.update_licensepool(odl_api_test_fixture.pool)
-        assert 2 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 3 == odl_api_test_fixture.pool.patrons_in_hold_queue
+        opds2_with_odl_api_fixture.api.update_licensepool_and_hold_queue(
+            opds2_with_odl_api_fixture.pool
+        )
+        assert 2 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 0 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 3 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
         assert 0 == holds[0].position
         assert 0 == holds[1].position
-        assert 3 == holds[2].position
+        assert 1 == holds[2].position
         assert holds[0].end - utc_now() - datetime.timedelta(
             days=3
         ) < datetime.timedelta(hours=1)
@@ -1259,294 +1225,153 @@ class TestODLAPI:
         ) < datetime.timedelta(hours=1)
 
         # If there are more licenses that change than holds, some of them become available.
-        for i in range(2):
-            _, p = loans[i]
-            odl_api_test_fixture.checkin(patron=p)
-        assert 3 == odl_api_test_fixture.pool.licenses_reserved
-        assert 1 == odl_api_test_fixture.pool.licenses_available
-        assert 3 == odl_api_test_fixture.pool.patrons_in_hold_queue
-        for hold in holds:
-            assert 0 == hold.position
-            assert hold.end - utc_now() - datetime.timedelta(
-                days=3
-            ) < datetime.timedelta(hours=1)
-
-    def test_place_hold_success(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        loan, _ = odl_api_test_fixture.checkout(patron=db.patron())
-
-        hold = odl_api_test_fixture.api.place_hold(
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            "notifications@librarysimplified.org",
-        )
-
-        assert 1 == odl_api_test_fixture.pool.patrons_in_hold_queue
-        assert odl_api_test_fixture.collection == hold.collection(db.session)
-        assert odl_api_test_fixture.pool.identifier.type == hold.identifier_type
-        assert odl_api_test_fixture.pool.identifier.identifier == hold.identifier
-        assert hold.start_date > utc_now() - datetime.timedelta(minutes=1)
-        assert hold.start_date < utc_now() + datetime.timedelta(minutes=1)
-        assert loan.end_date == hold.end_date
-        assert 1 == hold.hold_position
-
-    def test_place_hold_already_on_hold(
-        self, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        odl_api_test_fixture.license.setup(concurrency=1, available=0)  # type: ignore[attr-defined]
-        odl_api_test_fixture.pool.on_hold_to(odl_api_test_fixture.patron)
-        pytest.raises(
-            AlreadyOnHold,
-            odl_api_test_fixture.api.place_hold,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            "notifications@librarysimplified.org",
-        )
-
-    def test_place_hold_currently_available(
-        self, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        pytest.raises(
-            CurrentlyAvailable,
-            odl_api_test_fixture.api.place_hold,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-            "notifications@librarysimplified.org",
-        )
-
-    def test_release_hold_success(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        loan_patron = db.patron()
-        odl_api_test_fixture.checkout(patron=loan_patron)
-        odl_api_test_fixture.pool.on_hold_to(odl_api_test_fixture.patron, position=1)
-
-        odl_api_test_fixture.api.release_hold(
-            odl_api_test_fixture.patron, "pin", odl_api_test_fixture.pool
-        )
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == odl_api_test_fixture.pool.patrons_in_hold_queue
-        assert 0 == db.session.query(Hold).count()
-
-        odl_api_test_fixture.pool.on_hold_to(odl_api_test_fixture.patron, position=0)
-        odl_api_test_fixture.checkin(patron=loan_patron)
-
-        odl_api_test_fixture.api.release_hold(
-            odl_api_test_fixture.patron, "pin", odl_api_test_fixture.pool
-        )
-        assert 1 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == odl_api_test_fixture.pool.patrons_in_hold_queue
-        assert 0 == db.session.query(Hold).count()
-
-        odl_api_test_fixture.pool.on_hold_to(odl_api_test_fixture.patron, position=0)
-        other_hold, ignore = odl_api_test_fixture.pool.on_hold_to(
-            db.patron(), position=2
-        )
-
-        odl_api_test_fixture.api.release_hold(
-            odl_api_test_fixture.patron, "pin", odl_api_test_fixture.pool
-        )
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 1 == odl_api_test_fixture.pool.licenses_reserved
-        assert 1 == odl_api_test_fixture.pool.patrons_in_hold_queue
-        assert 1 == db.session.query(Hold).count()
-        assert 0 == other_hold.position
-
-    def test_release_hold_not_on_hold(
-        self, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        pytest.raises(
-            NotOnHold,
-            odl_api_test_fixture.api.release_hold,
-            odl_api_test_fixture.patron,
-            "pin",
-            odl_api_test_fixture.pool,
-        )
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            for i in range(2):
+                loan, patron = loans[i]
+                opds2_with_odl_api_fixture.checkin(patron=patron)
+        assert 3 == opds2_with_odl_api_fixture.pool.licenses_reserved
+        assert 1 == opds2_with_odl_api_fixture.pool.licenses_available
+        assert 3 == opds2_with_odl_api_fixture.pool.patrons_in_hold_queue
+        assert 0 == holds[0].position
+        assert 0 == holds[1].position
+        assert 0 == holds[2].position  # The last hold also became ready for checkout.
 
     def test_patron_activity_loan(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
     ) -> None:
         # No loans yet.
-        assert [] == odl_api_test_fixture.api.patron_activity(
-            odl_api_test_fixture.patron, "pin"
+        assert [] == opds2_with_odl_api_fixture.api.patron_activity(
+            opds2_with_odl_api_fixture.patron, "pin"
         )
 
         # One loan.
-        _, loan = odl_api_test_fixture.checkout()
+        loan, _ = opds2_with_odl_api_fixture.pool.loan_to(
+            opds2_with_odl_api_fixture.patron,
+            end=utc_now() + datetime.timedelta(weeks=2),
+        )
 
-        activity = odl_api_test_fixture.api.patron_activity(
-            odl_api_test_fixture.patron, "pin"
+        activity = opds2_with_odl_api_fixture.api.patron_activity(
+            opds2_with_odl_api_fixture.patron, "pin"
         )
         assert 1 == len(activity)
-        assert odl_api_test_fixture.collection == activity[0].collection(db.session)
-        assert odl_api_test_fixture.pool.identifier.type == activity[0].identifier_type
-        assert odl_api_test_fixture.pool.identifier.identifier == activity[0].identifier
+        assert opds2_with_odl_api_fixture.collection == activity[0].collection(
+            db.session
+        )
+        assert (
+            opds2_with_odl_api_fixture.pool.identifier.type
+            == activity[0].identifier_type
+        )
+        assert (
+            opds2_with_odl_api_fixture.pool.identifier.identifier
+            == activity[0].identifier
+        )
         assert loan.start == activity[0].start_date
         assert loan.end == activity[0].end_date
-        assert loan.external_identifier == activity[0].external_identifier
+        assert loan.external_identifier == activity[0].external_identifier  # type: ignore[union-attr]
 
         # Two loans.
-        pool2 = db.licensepool(None, collection=odl_api_test_fixture.collection)
+        pool2 = db.licensepool(None, collection=opds2_with_odl_api_fixture.collection)
+        loan2, _ = pool2.loan_to(
+            opds2_with_odl_api_fixture.patron,
+            end=utc_now() + datetime.timedelta(weeks=2),
+        )
         license2 = db.license(pool2, terms_concurrency=1, checkouts_available=1)
-        _, loan2 = odl_api_test_fixture.checkout(pool=pool2)
-
-        activity = odl_api_test_fixture.api.patron_activity(
-            odl_api_test_fixture.patron, "pin"
+        activity = opds2_with_odl_api_fixture.api.patron_activity(
+            opds2_with_odl_api_fixture.patron, "pin"
         )
         assert 2 == len(activity)
-        [l1, l2] = sorted(activity, key=lambda x: x.start_date)
+        [l1, l2] = sorted(activity, key=lambda x: x.start_date)  # type: ignore
 
-        assert odl_api_test_fixture.collection == l1.collection(db.session)
-        assert odl_api_test_fixture.pool.identifier.type == l1.identifier_type
-        assert odl_api_test_fixture.pool.identifier.identifier == l1.identifier
+        assert opds2_with_odl_api_fixture.collection == l1.collection(db.session)
+        assert opds2_with_odl_api_fixture.pool.identifier.type == l1.identifier_type
+        assert opds2_with_odl_api_fixture.pool.identifier.identifier == l1.identifier
         assert loan.start == l1.start_date
         assert loan.end == l1.end_date
-        assert loan.external_identifier == l1.external_identifier
+        assert loan.external_identifier == l1.external_identifier  # type: ignore[union-attr]
 
-        assert odl_api_test_fixture.collection == l2.collection(db.session)
+        assert opds2_with_odl_api_fixture.collection == l2.collection(db.session)
         assert pool2.identifier.type == l2.identifier_type
         assert pool2.identifier.identifier == l2.identifier
         assert loan2.start == l2.start_date
         assert loan2.end == l2.end_date
-        assert loan2.external_identifier == l2.external_identifier
+        assert loan2.external_identifier == l2.external_identifier  # type: ignore[union-attr]
 
         # If a loan is expired already, it's left out.
-        loan2.end = utc_now() - datetime.timedelta(days=2)
-        activity = odl_api_test_fixture.api.patron_activity(
-            odl_api_test_fixture.patron, "pin"
+        loan2.end = utc_now() - datetime.timedelta(days=1)
+        activity = opds2_with_odl_api_fixture.api.patron_activity(
+            opds2_with_odl_api_fixture.patron, "pin"
         )
         assert 1 == len(activity)
-        assert odl_api_test_fixture.pool.identifier.identifier == activity[0].identifier
-        odl_api_test_fixture.checkin(pool=pool2)
-
         # Open access loans are included.
         oa_work = db.work(
-            with_open_access_download=True, collection=odl_api_test_fixture.collection
+            with_open_access_download=True,
+            collection=opds2_with_odl_api_fixture.collection,
         )
         pool3 = oa_work.license_pools[0]
-        loan3, ignore = pool3.loan_to(odl_api_test_fixture.patron)
+        loan3, _ = pool3.loan_to(
+            opds2_with_odl_api_fixture.patron,
+            end=utc_now() + datetime.timedelta(weeks=2),
+        )
 
-        activity = odl_api_test_fixture.api.patron_activity(
-            odl_api_test_fixture.patron, "pin"
+        activity = opds2_with_odl_api_fixture.api.patron_activity(
+            opds2_with_odl_api_fixture.patron, "pin"
         )
         assert 2 == len(activity)
-        [l1, l2] = sorted(activity, key=lambda x: x.start_date)
+        [l1, l2] = sorted(activity, key=lambda x: x.start_date)  # type: ignore
 
-        assert odl_api_test_fixture.collection == l1.collection(db.session)
-        assert odl_api_test_fixture.pool.identifier.type == l1.identifier_type
-        assert odl_api_test_fixture.pool.identifier.identifier == l1.identifier
+        assert opds2_with_odl_api_fixture.collection == l1.collection(db.session)
+        assert opds2_with_odl_api_fixture.pool.identifier.type == l1.identifier_type
+        assert opds2_with_odl_api_fixture.pool.identifier.identifier == l1.identifier
         assert loan.start == l1.start_date
         assert loan.end == l1.end_date
-        assert loan.external_identifier == l1.external_identifier
+        assert loan.external_identifier == l1.external_identifier  # type: ignore[union-attr]
 
-        assert odl_api_test_fixture.collection == l2.collection(db.session)
+        assert opds2_with_odl_api_fixture.collection == l2.collection(db.session)
         assert pool3.identifier.type == l2.identifier_type
         assert pool3.identifier.identifier == l2.identifier
         assert loan3.start == l2.start_date
         assert loan3.end == l2.end_date
-        assert loan3.external_identifier == l2.external_identifier
+        assert loan3.external_identifier == l2.external_identifier  # type: ignore[union-attr]
 
         # remove the open access loan
         db.session.delete(loan3)
 
         # One hold.
         other_patron = db.patron()
-        odl_api_test_fixture.checkout(patron=other_patron, pool=pool2)
-        hold, _ = pool2.on_hold_to(odl_api_test_fixture.patron)
-        hold.start = utc_now() - datetime.timedelta(days=2)
-        hold.end = hold.start + datetime.timedelta(days=3)
+        pool2.loan_to(other_patron, end=utc_now() + datetime.timedelta(weeks=2))
+        hold, _ = pool2.on_hold_to(opds2_with_odl_api_fixture.patron)
+        hold.start_date = utc_now() - datetime.timedelta(days=2)
+        hold.end_date = hold.start + datetime.timedelta(days=3)
         hold.position = 3
-        activity = odl_api_test_fixture.api.patron_activity(
-            odl_api_test_fixture.patron, "pin"
+        activity = opds2_with_odl_api_fixture.api.patron_activity(
+            opds2_with_odl_api_fixture.patron, "pin"
         )
         assert 2 == len(activity)
-        [h1, l1] = sorted(activity, key=lambda x: x.start_date)
-
-        assert odl_api_test_fixture.collection == h1.collection(db.session)
+        [l1, h1] = sorted(activity, key=lambda x: x.start_date)  # type: ignore
+        assert opds2_with_odl_api_fixture.collection == h1.collection(db.session)
         assert pool2.identifier.type == h1.identifier_type
         assert pool2.identifier.identifier == h1.identifier
         assert hold.start == h1.start_date
         assert hold.end == h1.end_date
         # Hold position was updated.
-        assert 1 == h1.hold_position
+        assert 1 == h1.hold_position  # type: ignore[union-attr]
         assert 1 == hold.position
 
         # If the hold is expired, it's deleted right away and the license
         # is made available again.
-        odl_api_test_fixture.checkin(patron=other_patron, pool=pool2)
+        with opds2_with_odl_api_fixture.mock_http.patch():
+            opds2_with_odl_api_fixture.checkin(patron=other_patron, pool=pool2)
         hold.end = utc_now() - datetime.timedelta(days=1)
         hold.position = 0
-        activity = odl_api_test_fixture.api.patron_activity(
-            odl_api_test_fixture.patron, "pin"
+        activity = opds2_with_odl_api_fixture.api.patron_activity(
+            opds2_with_odl_api_fixture.patron, "pin"
         )
         assert 1 == len(activity)
         assert 0 == db.session.query(Hold).count()
         assert 1 == pool2.licenses_available
         assert 0 == pool2.licenses_reserved
-
-    def test_update_loan_still_active(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        odl_api_test_fixture.license.setup(concurrency=6, available=6)  # type: ignore[attr-defined]
-        loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
-        loan.external_identifier = db.fresh_str()
-        status_doc = {
-            "status": "active",
-        }
-
-        odl_api_test_fixture.api.update_loan(loan, status_doc)
-        # Availability hasn't changed, and the loan still exists.
-        assert 6 == odl_api_test_fixture.pool.licenses_available
-        assert 1 == db.session.query(Loan).count()
-
-    def test_update_loan_removes_loan(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        odl_api_test_fixture.license.setup(concurrency=7, available=7)  # type: ignore[attr-defined]
-        _, loan = odl_api_test_fixture.checkout()
-
-        assert 6 == odl_api_test_fixture.pool.licenses_available
-        assert 1 == db.session.query(Loan).count()
-
-        status_doc = {
-            "status": "cancelled",
-        }
-
-        odl_api_test_fixture.api.update_loan(loan, status_doc)
-
-        # Availability has increased, and the loan is gone.
-        assert 7 == odl_api_test_fixture.pool.licenses_available
-        assert 0 == db.session.query(Loan).count()
-
-    def test_update_loan_removes_loan_with_hold_queue(
-        self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture
-    ) -> None:
-        _, loan = odl_api_test_fixture.checkout()
-        hold, _ = odl_api_test_fixture.pool.on_hold_to(db.patron(), position=1)
-        odl_api_test_fixture.pool.update_availability_from_licenses()
-
-        assert odl_api_test_fixture.pool.licenses_owned == 1
-        assert odl_api_test_fixture.pool.licenses_available == 0
-        assert odl_api_test_fixture.pool.licenses_reserved == 0
-        assert odl_api_test_fixture.pool.patrons_in_hold_queue == 1
-
-        status_doc = {
-            "status": "cancelled",
-        }
-
-        odl_api_test_fixture.api.update_loan(loan, status_doc)
-
-        # The license is reserved for the next patron, and the loan is gone.
-        assert 0 == odl_api_test_fixture.pool.licenses_available
-        assert 1 == odl_api_test_fixture.pool.licenses_reserved
-        assert 0 == hold.position
-        assert 0 == db.session.query(Loan).count()
 
 
 class TestODLImporter:

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -406,9 +406,16 @@ class TestODLNotificationController:
         route_test.set_controller_name(self.CONTROLLER_NAME)
         return route_test
 
-    def test_odl_notify(self, fixture: RouteTestFixture):
+    def test_odl_notify_deprecated(self, fixture: RouteTestFixture):
         url = "/odl_notify/<loan_id>"
-        fixture.assert_request_calls(url, fixture.controller.notify, "<loan_id>")  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.notify_deprecated, "<loan_id>")  # type: ignore[union-attr]
+        fixture.assert_supported_methods(url, "GET", "POST")
+
+    def test_odl_notify(self, fixture: RouteTestFixture):
+        url = "/odl/notify/<patron_id>/<license_id>"
+        fixture.assert_request_calls(
+            url, fixture.controller.notify, "<patron_id>", "<license_id>"  # type: ignore[union-attr]
+        )
         fixture.assert_supported_methods(url, "GET", "POST")
 
 

--- a/tests/core/models/test_licensing.py
+++ b/tests/core/models/test_licensing.py
@@ -26,6 +26,7 @@ from core.model.licensing import (
     RightsStatus,
 )
 from core.model.resource import Hyperlink, Representation
+from core.util import first_or_default
 from core.util.datetime_helpers import utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
 
@@ -467,7 +468,7 @@ class TestLicense:
         assert left == l.checkouts_left
         assert available == l.checkouts_available
 
-    def test_best_available_license(self, licenses: TestLicenseFixture):
+    def test_best_available_licenses(self, licenses: TestLicenseFixture):
         next_week = utc_now() + datetime.timedelta(days=7)
         time_limited_2 = licenses.db.license(
             licenses.pool,
@@ -479,37 +480,66 @@ class TestLicense:
             licenses.pool, expires=None, checkouts_left=2, checkouts_available=1
         )
 
-        # First, we use the time-limited license that's expiring first.
-        assert time_limited_2 == licenses.pool.best_available_license()
+        # First, make sure the overall order is correct
+        assert licenses.pool.best_available_licenses() == [
+            time_limited_2,
+            licenses.time_limited,
+            licenses.perpetual,
+            licenses.time_and_loan_limited,
+            licenses.loan_limited,
+            loan_limited_2,
+        ]
+
+        # We use the time-limited license that's expiring first.
+        assert (
+            first_or_default(licenses.pool.best_available_licenses()) == time_limited_2
+        )
         time_limited_2.checkout()
 
         # When that's not available, we use the next time-limited license.
-        assert licenses.time_limited == licenses.pool.best_available_license()
+        assert (
+            first_or_default(licenses.pool.best_available_licenses())
+            == licenses.time_limited
+        )
         licenses.time_limited.checkout()
 
-        # The time-and-loan-limited license also counts as time-limited for this.
-        assert licenses.time_and_loan_limited == licenses.pool.best_available_license()
-        licenses.time_and_loan_limited.checkout()
-
         # Next is the perpetual license.
-        assert licenses.perpetual == licenses.pool.best_available_license()
+        assert (
+            first_or_default(licenses.pool.best_available_licenses())
+            == licenses.perpetual
+        )
         licenses.perpetual.checkout()
 
+        # Next up is the time-and-loan-limited license.
+        assert (
+            first_or_default(licenses.pool.best_available_licenses())
+            == licenses.time_and_loan_limited
+        )
+        licenses.time_and_loan_limited.checkout()
+
         # Then the loan-limited license with the most remaining checkouts.
-        assert licenses.loan_limited == licenses.pool.best_available_license()
+        assert (
+            first_or_default(licenses.pool.best_available_licenses())
+            == licenses.loan_limited
+        )
         licenses.loan_limited.checkout()
 
         # That license allows 2 concurrent checkouts, so it's still the
         # best license until it's checked out again.
-        assert licenses.loan_limited == licenses.pool.best_available_license()
+        assert (
+            first_or_default(licenses.pool.best_available_licenses())
+            == licenses.loan_limited
+        )
         licenses.loan_limited.checkout()
 
         # There's one more loan-limited license.
-        assert loan_limited_2 == licenses.pool.best_available_license()
+        assert (
+            first_or_default(licenses.pool.best_available_licenses()) == loan_limited_2
+        )
         loan_limited_2.checkout()
 
         # Now all licenses are either loaned out or expired.
-        assert None == licenses.pool.best_available_license()
+        assert licenses.pool.best_available_licenses() == []
 
 
 class TestLicensePool:

--- a/tests/core/test_opds2_import.py
+++ b/tests/core/test_opds2_import.py
@@ -555,7 +555,7 @@ class Opds2ApiFixture:
         self.api = OPDS2API(db.session, self.collection)
 
     def fulfill(self) -> FulfillmentInfo:
-        return self.api.fulfill(self.patron, "", self.pool, self.mechanism)
+        return self.api.fulfill(self.patron, "", self.pool, self.mechanism)  # type: ignore
 
 
 @pytest.fixture
@@ -613,13 +613,13 @@ class TestOpds2Api:
             )
 
         assert (
-            fulfillment.content_link
+            fulfillment.content_link  # type: ignore
             == "http://example.org//getDrmFreeFile.action?documentId=1543720&mediaType=epub&authToken=plaintext-token"
         )
-        assert fulfillment.content_type == "application/epub+zip"
-        assert fulfillment.content is None
-        assert fulfillment.content_expires is None
-        assert fulfillment.content_link_redirect is True
+        assert fulfillment.content_type == "application/epub+zip"  # type: ignore
+        assert fulfillment.content is None  # type: ignore
+        assert fulfillment.content_expires is None  # type: ignore
+        assert fulfillment.content_link_redirect is True  # type: ignore
 
     def test_token_fulfill(self, opds2_api_fixture: Opds2ApiFixture):
         ff_info = opds2_api_fixture.fulfill()

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from collections.abc import Generator
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
@@ -11,6 +11,7 @@ import pytest
 import pytz
 from firebase_admin.exceptions import FirebaseError
 from firebase_admin.messaging import UnregisteredError
+from freezegun import freeze_time
 from google.auth import credentials
 from requests_mock import Mocker
 
@@ -105,12 +106,12 @@ class TestPushNotifications:
                 {
                     "token": "atoken",
                     "notification": messaging.Notification(
-                        title="Only 1 day left on your loan!",
-                        body=f"Your loan on {work.presentation_edition.title} is expiring soon",
+                        title=f'"{work.presentation_edition.title}" laina-aika on päättymässä!',
+                        body=f'"{work.presentation_edition.title}" laina-aika päättyy 1 päivän päästä.',
                     ),
                     "data": dict(
-                        title="Only 1 day left on your loan!",
-                        body=f"Your loan on {work.presentation_edition.title} is expiring soon",
+                        title=f'"{work.presentation_edition.title}" laina-aika on päättymässä!',
+                        body=f'"{work.presentation_edition.title}" laina-aika päättyy 1 päivän päästä.',
                         event_type=NotificationConstants.LOAN_EXPIRY_TYPE,
                         loans_endpoint="http://localhost/default/loans",
                         external_identifier=patron.external_identifier,
@@ -254,6 +255,7 @@ class TestPushNotifications:
 
             assert messaging.send.call_count == 4
 
+    @freeze_time()
     def test_holds_notification(self, push_notf_fixture: PushNotificationsFixture):
         db = push_notf_fixture.db
         # Only patron1 will get an identifier
@@ -276,8 +278,9 @@ class TestPushNotifications:
         assert p1 is not None
         p2 = work2.active_license_pool()
         assert p2 is not None
-        hold1, _ = p1.on_hold_to(patron1, position=0)
-        hold2, _ = p2.on_hold_to(patron2, position=0)
+        in_three_days = utc_now() + timedelta(days=3)
+        hold1, _ = p1.on_hold_to(patron1, position=0, end=in_three_days)
+        hold2, _ = p2.on_hold_to(patron2, position=0, end=in_three_days)
 
         with mock.patch("core.util.notifications.messaging") as mock_messaging:
             # Mock the notification method to return the kwargs passed to it
@@ -298,8 +301,8 @@ class TestPushNotifications:
             include_auth_id: bool = True,
         ) -> None:
             data = dict(
-                title="Your hold is available!",
-                body=f'Your hold on "{work.title}" is available!',
+                title=f'Varauksesi "{work.title}" on lainattavissa!',
+                body=f'Varaus on lainattava viimeistään {in_three_days.strftime("%-d.%-m.%Y")}.',
                 event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
                 loans_endpoint=loans_api,
                 identifier=hold.license_pool.identifier.identifier,

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -74,3 +74,16 @@ class APIFilesFixture:
 
     def sample_path(self, filename) -> str:
         return os.path.join(self._resource_path, filename)
+
+
+class OPDS2WithODLFilesFixture(APIFilesFixture):
+    """A fixture providing access to OPDS2 + ODL files."""
+
+    def __init__(self):
+        super().__init__("odl")
+
+
+@pytest.fixture()
+def opds2_with_odl_files_fixture() -> OPDS2WithODLFilesFixture:
+    """A fixture providing access to OPDS2 + ODL files."""
+    return OPDS2WithODLFilesFixture()

--- a/tests/fixtures/flask.py
+++ b/tests/fixtures/flask.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
 
-import flask
 import pytest
 from flask.ctx import RequestContext
 from flask_babel import Babel
@@ -12,6 +11,7 @@ from werkzeug.datastructures import ImmutableMultiDict
 
 from api.util.flask import PalaceFlask
 from core.model import Admin, AdminRole, Library, get_one_or_create
+from core.model.patron import Patron
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
@@ -37,26 +37,29 @@ class FlaskAppFixture:
         *args: Any,
         admin: Admin | None = None,
         library: Library | None = None,
+        patron: Patron | None = None,
         **kwargs: Any,
     ) -> Generator[RequestContext, None, None]:
         with self.app.test_request_context(*args, **kwargs) as c:
             self.db.session.begin_nested()
-            flask.request.library = library  # type: ignore[attr-defined]
-            flask.request.admin = admin  # type: ignore[attr-defined]
-            flask.request.form = ImmutableMultiDict()
-            flask.request.files = ImmutableMultiDict()
-            yield c
-
-            # Flush any changes that may have occurred during the request, then
-            # expire all objects to ensure that the next request will see the
-            # changes.
-            self.db.session.commit()
-            self.db.session.expire_all()
+            setattr(c.request, "library", library)
+            setattr(c.request, "admin", admin)
+            setattr(c.request, "patron", patron)
+            setattr(c.request, "form", ImmutableMultiDict())
+            setattr(c.request, "files", ImmutableMultiDict())
+            try:
+                yield c
+            finally:
+                # Flush any changes that may have occurred during the request, then
+                # expire all objects to ensure that the next request will see the
+                # changes.
+                self.db.session.commit()
+                self.db.session.expire_all()
 
     @contextmanager
     def test_request_context_system_admin(
         self, *args: Any, **kwargs: Any
-    ) -> Generator[RequestContext, None, None]:
+    ) -> Generator[RequestContext]:  # type: ignore[type-arg]
         admin = self.admin_user()
         with self.test_request_context(*args, **kwargs, admin=admin) as c:
             yield c

--- a/tests/fixtures/problem_detail.py
+++ b/tests/fixtures/problem_detail.py
@@ -1,0 +1,42 @@
+import dataclasses
+from collections.abc import Generator
+from contextlib import contextmanager
+
+import pytest
+
+from core.util.problem_detail import ProblemDetail, ProblemDetailException
+
+
+@dataclasses.dataclass
+class ProblemDetailInfo:
+    _value: ProblemDetail | None = None
+    _exception: ProblemDetailException | None = None
+
+    @property
+    def value(self) -> ProblemDetail:
+        assert self._value is not None
+        return self._value
+
+    @property
+    def exception(self) -> ProblemDetailException:
+        assert self._exception is not None
+        return self._exception
+
+
+@contextmanager
+def raises_problem_detail(
+    *,
+    pd: ProblemDetail | None = None,
+    detail: str | None = None,
+) -> Generator[ProblemDetailInfo]:  # type: ignore
+    info = ProblemDetailInfo()
+    with pytest.raises(ProblemDetailException) as e:
+        yield info
+    info._exception = e.value
+    info._value = e.value.problem_detail
+
+    if pd is not None:
+        assert info.value == pd
+
+    if detail is not None:
+        assert info.value.detail == detail

--- a/tests/mocks/odl.py
+++ b/tests/mocks/odl.py
@@ -1,0 +1,41 @@
+from sqlalchemy.orm import Session
+
+from api.odl import ODLAPI
+from api.odl2 import ODL2API
+from core.model.collection import Collection
+from tests.api.mockapi.mock import MockHTTPClient
+
+
+class MockOPDS2WithODLApi(ODLAPI):
+    def __init__(
+        self,
+        _db: Session,
+        collection: Collection,
+        mock_http_client: MockHTTPClient,
+    ) -> None:
+        super().__init__(_db, collection)
+
+        self.mock_http_client = mock_http_client
+
+    @staticmethod
+    def _notification_url(
+        short_name: str | None, patron_id: str, license_id: str
+    ) -> str:
+        return f"https://ekirjasto/{short_name}/odl/notify/{patron_id}/{license_id}"
+
+
+class MockODL2Api(ODL2API):
+    def __init__(
+        self,
+        _db: Session,
+        collection: Collection,
+        mock_http_client: MockHTTPClient,
+    ) -> None:
+        super().__init__(_db, collection)
+        self.mock_http_client = mock_http_client
+
+    @staticmethod
+    def _notification_url(
+        short_name: str | None, patron_id: str, license_id: str
+    ) -> str:
+        return f"https://ekirjasto/{short_name}/odl/notify/{patron_id}/{license_id}"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` file to configure pre-commands for Dependabot, specifically to install a specific version of Poetry before running updates.

Key change:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-L21): Added `pre-commands` to install Poetry version `1.8.2` and configure virtual environments to not be created. This replaces the previous commented-out `ignore` configuration.Select poetry version to use

