### PR TITLE
update poetry version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: increase-if-necessary
+    # Ensure Poetry version is explicitly installed
+    pre-commands:
+      - curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
+      - poetry config virtualenvs.create false
+
     # Ignore everything for now (and stay in pace with the upstream)
     # ignore:
     #    - dependency-name: "*"

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -18,26 +18,26 @@ RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends -o Dpkg::Options::="--force-confold" && \
     /bd_build/cleanup.sh
 
-ARG POETRY_VERSION=1.7.1
+ARG POETRY_VERSION=1.8.5
 
 # Install required packages including python, pip, compiliers and libraries needed
 # to build the python wheels we need and poetry.
 RUN install_clean \
-      nginx \
-      python3 \
-      python3-dev \
-      python3-venv \
-      python3-pip \
-      gcc \
-      # needed for uwsgi
-      libpcre3-dev \
-      # needed for psycopg2
-      libpq-dev \
-      # needed for xmlsec
-      libxmlsec1-dev \
-      libxmlsec1-openssl \
-      tzdata \
-      pkg-config && \
+    nginx \
+    python3 \
+    python3-dev \
+    python3-venv \
+    python3-pip \
+    gcc \
+    # needed for uwsgi
+    libpcre3-dev \
+    # needed for psycopg2
+    libpq-dev \
+    # needed for xmlsec
+    libxmlsec1-dev \
+    libxmlsec1-openssl \
+    tzdata \
+    pkg-config && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version $POETRY_VERSION && \
     ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry && \
     rm -rf /etc/logrotate.d/dpkg && \


### PR DESCRIPTION
This pull request introduces updates to ensure compatibility with Poetry version 1.8.5 across the project. The changes include specifying the Poetry version explicitly in the Dependabot configuration and updating the base Docker image to use the same version.

Dependency management updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R11-R15): Added pre-commands to explicitly install Poetry version 1.8.5 and configure virtual environments to not be created, ensuring consistency in dependency management.

Docker image updates:

* [`docker/Dockerfile.baseimage`](diffhunk://#diff-75655dfc2bb881acbe6d73277ce882f5bdb460b0bd793a51dd9fada83ddb23daL21-R21): Updated the `POETRY_VERSION` argument from 1.7.1 to 1.8.5 to align the Docker base image with the latest Poetry version used in the project.