### PR TITLE
Stop updating license pool

### DIFF
--- a/api/controller/odl_notification.py
+++ b/api/controller/odl_notification.py
@@ -99,10 +99,6 @@ class ODLNotificationController(CirculationManagerController):
                 try:
                     with self._db.begin_nested():
                         loan.end = utc_now()
-                    api = self.manager.circulation_apis[
-                        library.id
-                    ].api_for_license_pool(loan.license_pool)
-                    api.update_availability(loan.license_pool)
                 except StaleDataError:
                     # This can happen if this callback happened while we were returning this
                     # item. We can fetch the loan, but it's deleted by the time we go to do

--- a/tests/api/controller/test_odl_notify.py
+++ b/tests/api/controller/test_odl_notify.py
@@ -245,7 +245,6 @@ class TestODLNotificationController:
         api = controller_fixture.manager.circulation_apis[
             db.default_library().id
         ].api_for_license_pool(loan.license_pool)
-        assert [loan.license_pool] == api.availability_updated_for
 
     def test_notify_errors(
         self, controller_fixture: ControllerFixture, odl_fixture: ODLFixture


### PR DESCRIPTION

## Description

Don't update license pool after changing `loan.end`.

## Motivation and Context

This was causing a deadlock problem in production. Palace doesn't run any pool update either so removing it from ours as well.

## How Has This Been Tested?

-

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
