### PR TITLE
Github workflow updates

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -1,5 +1,5 @@
-name: 'Poetry'
-description: 'Install python poetry'
+name: "Poetry"
+description: "Install python poetry"
 
 inputs:
   version:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -287,12 +287,33 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build & Start container
-        run: docker compose up -d --build ${{ matrix.image }}
+      - name: Build and Load Docker Compose Images for Testing
+        uses: docker/bake-action@v5
+        with:
+          files: docker-compose.yml
+          load: true # CRITICAL: Load images into Docker daemon for 'docker compose up'
+          set: |
+            webapp.cache-from=type=gha,scope=buildkit-${{ github.run_id }}-webapp
+            webapp.cache-to=type=gha,mode=max,scope=buildkit-${{ github.run_id }}-webapp
+            scripts.cache-from=type=gha,scope=buildkit-${{ github.run_id }}-scripts
+            scripts.cache-to=type=gha,mode=max,scope=buildkit-${{ github.run_id }}-scripts
+            os.cache-from=type=gha,scope=buildkit-${{ github.run_id }}-os
+            os.cache-to=type=gha,mode=max,scope=buildkit-${{ github.run_id }}-os
+          build-args: |
+            BUILD_PLATFORM=${{ matrix.platform }}
+            # Pass the base image tag from the docker-image-build job
+            BASE_IMAGE=${{ needs.docker-image-build.outputs.baseimage }}
+
+      - name: Start container stack
+        # Now that all necessary images (webapp, scripts, os) are built and loaded
+        # by the 'docker/bake-action', you just need to start the stack.
+        # The '--build' flag is no longer necessary here.
+        run: docker compose up -d
         env:
-          BUILD_PLATFORM: ${{ matrix.platform }}
-          BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
-          BUILD_BASE_IMAGE: ${{ needs.docker-image-build.outputs.baseimage }}
+          BUILD_PLATFORM: ${{ matrix.platform }} # Still pass runtime env if needed
+          # BUILD_CACHE_FROM is not relevant for 'up' commands, only for 'build'
+          # BUILD_BASE_IMAGE is already passed as a build-arg above if needed for runtime
+
 
       - name: Run tests
         run: ./docker/ci/test_${{ matrix.image }}.sh ${{ matrix.image }}

--- a/docker/ci/test_scripts.sh
+++ b/docker/ci/test_scripts.sh
@@ -13,7 +13,8 @@ source "${dir}/check_service_status.sh"
 wait_for_runit "$container"
 
 # Make sure database initialization completed successfully
-timeout 240s grep -q 'Initialization complete' <(docker compose logs "$container" -f 2>&1)
+# This check is now handled implicitly by docker compose up -d waiting for the os service's healthcheck to pass.
+# timeout 240s grep -q 'Initialization complete' <(docker compose logs "$container" -f 2>&1)
 
 # Make sure that cron is running in the scripts container
 check_service_status "$container" /etc/service/cron


### PR DESCRIPTION
This updates Docker workflows. The most significant change is to use `docker/bake-action` for building and loading images.

### Docker workflow improvements:

* [`.github/workflows/test-build.yml`](diffhunk://#diff-a583f7935a5f3192471a2999cbf059eadc857228b5be2c7247f481b799949f8dL290-R316): Replaced the `docker compose up --build` command with `docker/bake-action` to build and load Docker Compose images, enabling better caching and separation of build and runtime steps. Added detailed build arguments and caching configurations for improved efficiency.
* [`docker/ci/test_scripts.sh`](diffhunk://#diff-3c04cc2198529b239e55658e46a0c2e82b8935fda4c471d259049cbb295e379cL16-R17): Removed database initialization log checks, as health checks are now implicitly handled by `docker compose up -d`. 
