### PR TITLE
Checkin loan license

### DIFF
--- a/api/odl2.py
+++ b/api/odl2.py
@@ -348,6 +348,7 @@ class ODL2LoanReaper(CollectionMonitor):
             .filter(
                 and_(
                     LicensePool.open_access == False,
+                    LicensePool.collection_id == self.api.collection_id,
                     or_(
                         Loan.end
                         < now

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -364,8 +364,11 @@ class ODL2LoanReaper(CollectionMonitor):
         changed_pools = set()
         total_deleted_loans = 0
         for loan in expired_loans:
+            # Only a license can be checked in
+            if loan.license:
+                loan.license.checkin()
             changed_pools.add(loan.license_pool)
-            loan.license.checkin()
+            self.log.info(f"Deleting loan {loan} in pool {loan.license_pool}")
             self._db.delete(loan)
             total_deleted_loans += 1
 


### PR DESCRIPTION
## Description

Only a loan with a license can be checked in.

## Motivation and Context

The loan reaper script crashed because prod had loans not associated with a license. Obviously it's possible that loans can be associated with a license pool instead of a license.

The original script was collection-based so `collection.id` was added to the query so that the logs make more sense.

## How Has This Been Tested?

Basically the already existing `test_run_once` would have duplication if a license pool loan was implemented so decided not to add anything.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.