### PR TITLE
update deps for testenv

### DIFF
--- a/core/resources/opds2_schema/readium-metadata.schema.json
+++ b/core/resources/opds2_schema/readium-metadata.schema.json
@@ -141,7 +141,7 @@
       "$ref": "https://readium.org/webpub-manifest/schema/extensions/epub/metadata.schema.json"
     },
     {
-      "$ref": "https://readium.org/webpub-manifest/schema/experimental/presentation/metadata.schema.json"
+      "$ref": "https://readium.org/webpub-manifest/schema/publication.schema.json"
     }
   ]
 }

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py{310,311}-{api,core}-docker
 skipsdist = true
 
 [testenv]
+deps =
+    textblob
 commands_pre =
     poetry install --without ci -v
     python -m textblob.download_corpora


### PR DESCRIPTION
This pull request updates the `tox.ini` file to include the `textblob` library as a dependency
