### PR TITLE
EKIR-556 Save subtitle as None if there isn't any

### DIFF
--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -646,7 +646,12 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
         self.log.debug(f"Started extracting metadata from publication {publication}")
 
         title = str(publication.metadata.title)
-        subtitle = str(publication.metadata.subtitle)
+
+        subtitle = (
+            str(publication.metadata.subtitle)
+            if publication.metadata.subtitle
+            else None
+        )
 
         languages = first_or_default(publication.metadata.languages)
         derived_medium = self._extract_medium_from_links(publication.links)

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -114,6 +114,7 @@ class TestODL2Importer:
         }
 
         assert "Moby-Dick" == moby_dick_edition.title
+        assert not moby_dick_edition.subtitle
         assert "eng" == moby_dick_edition.language
         assert "eng" == moby_dick_edition.language
         assert EditionConstants.BOOK_MEDIUM == moby_dick_edition.medium


### PR DESCRIPTION
## Description

Save subtitle as None if there isn't any.

## Motivation and Context

The code turned `None` into a string which resulted our test environment to show almost all our books with subtitle as None.
This will not yet change our test environment's situation but will prevent it from going into the production environment. I'll make a separate ticket to handle the situation where a book used to have a subtitle but, for some reason, it's removed later.

## How Has This Been Tested?

Unit test. Locally tested that if a book didn't have a subtitle before, it won't have one with this code change (doesn't show up in the app) after import.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.