### PR TITLE
Update scripts with more data

### DIFF
--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -688,9 +688,7 @@ class Hold(Base, LoanAndHoldMixin):
         return self.id < other.id
 
     def __repr__(self):
-        return (
-            f"Hold id={self.id} start={self.start}->{self.end} position={self.position}"
-        )
+        return f"Patron external id={self.patron.external_identifier} Hold id={self.id} From {self.start} to {self.end} Position={self.position}"
 
     @classmethod
     def _calculate_until(

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2404,6 +2404,29 @@ class Explain(IdentifierInputScript):
                     license.expires,
                 )
             )
+            self.write("Active loans:")
+            if license.loans:
+                for loan in license.loans:
+                    self.write(
+                        "   Loan ID: {}, Patron external id: {}".format(
+                            loan.external_identifier, loan.patron.external_identifier
+                        )
+                    )
+                    self.write(f"   From {loan.start} to {loan.end}")
+            else:
+                self.write("    No active loans.")
+            self.write("Holds:")
+            if pool.patrons_in_hold_queue or pool.holds:
+                self.write(
+                    "Patrons in queue: {}, Holds: {}".format(
+                        pool.patrons_in_hold_queue, len(pool.holds)
+                    )
+                )
+                for hold in pool.holds:
+                    self.write("   %s" % (hold))
+                    self.write("   Last notified: %s" % (hold.patron_last_notified))
+            else:
+                self.write("No holds")
 
     def explain_work(self, work):
         self.write("Work info:")

--- a/scripts.py
+++ b/scripts.py
@@ -902,6 +902,7 @@ class LicenseReportScript(Script):
             "Title",
             "Author",
             "Collection",
+            "Language",
             "First seen",
             "Last seen (best guess)",
             "Current copies owned",
@@ -916,6 +917,7 @@ class LicenseReportScript(Script):
             "License concurrency",
             "Active loans",
             "License expiration",
+            "License status url",
         ]
         print(",".join(first_row))
 
@@ -989,7 +991,8 @@ class LicenseReportScript(Script):
         data = [identifier.identifier]
         if edition:
             data.extend([f'"{edition.title}"', f'"{edition.author}"'])
-        data.append(licensepool.collection.name)
+        data.append(f'"{licensepool.collection.name}"')
+        data.append(f'"{edition.language}"')
         if licensepool.availability_time:
             first_seen = licensepool.availability_time.strftime(self.format)
         else:
@@ -1014,10 +1017,11 @@ class LicenseReportScript(Script):
                 license.expires.strftime(self.format) if license.expires else ""
             )
             license_data = [
-                identifier.identifier,
-                edition.title,
-                "",
-                "",
+                f'"{identifier.identifier}"',
+                f'"{edition.title}"',
+                f'"{edition.author}"',
+                f'"{licensepool.collection.name}"',
+                f'"{edition.language}"',
                 "",
                 "",
                 "",
@@ -1032,6 +1036,7 @@ class LicenseReportScript(Script):
                 license.terms_concurrency,
                 len(license.loans),
                 expire_date,
+                license.status_url,
             ]
             # And print each license on a new line
             print(",".join(str(item) for item in license_data))


### PR DESCRIPTION
## Description

Add more informative data to `explain` and `license_report` scripts.

## Motivation and Context

We often know that a title has issues with holds and/or loans. Having this data available at least in `explain` will help with investigating problems.

The `license_report` needed string formatting in order for easier csv upload to excel/numbers apps.

## How Has This Been Tested?

Locally.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.