### PR TITLE
Keyerror gateway fix

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Run Tests
         run: tox
         env:
+          # Fixes KeyError: 'Gateway'
+          TOX_DOCKER_GATEWAY: "0.0.0.0"
           MODULE: ${{ matrix.module }}
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Run Migration Tests
         run: tox -e "migration-docker"
+        env:
+          TOX_DOCKER_GATEWAY: "0.0.0.0"
 
       - name: Upload coverage to Codecov
         if: false # Disable temporarily


### PR DESCRIPTION
## Description

Workaround for `Docker gateway IP detection for newer Docker versions`
https://github.com/actions/runner-images/issues/13474
https://github.com/tox-dev/tox-docker/pull/196

## Motivation and Context

This pull request makes a small change to the test workflow configuration to address a specific error encountered during testing.

* Added the `TOX_DOCKER_GATEWAY` environment variable with the value `"0.0.0.0"` in the `.github/workflows/test-build.yml` file to fix a `KeyError: 'Gateway'` when running tests.
