### PR TITLE
Ekir 813 change marc fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ Make PR, and when it's merged to main, the translations will be uploaded to Tran
 Once all strings have been translated and reviewed in Transifex, Transifex will automatically create a PR in Github and
 commit the updated files.
 
+Compiled `.mo` files are generated when Docker containers are initialized.
+
 ## Technology overview
 
 E-kirjasto backend - though gone through many changes since being forked from the Palace project - is based on the

--- a/bin/util/core.babel.cfg
+++ b/bin/util/core.babel.cfg
@@ -1,5 +1,6 @@
 [python: core/*.py]
 [python: core/classifier/*.py]
+[python: core/model/contributor.py]
 [python: core/util/*.py]
 [python: default_lane_names_to_localize.py]
 [python: core/data_conversion/*.py]

--- a/core/marc.py
+++ b/core/marc.py
@@ -476,9 +476,9 @@ class Annotator(LoggerMixin):
 
     @classmethod
     def add_audience(cls, record: Record, work: Work) -> None:
-        audience = _(work.audience) or _(
+        audience = _(work.audience) or _( # type:ignore[arg-type]
             SubjectClassifier.AUDIENCE_ADULT
-        )  # type:ignore[arg-type]
+        )
         record.add_field(
             Field(
                 tag="385",

--- a/core/marc.py
+++ b/core/marc.py
@@ -73,13 +73,16 @@ class Annotator(LoggerMixin):
     # store this so it's easier to keep up-to-date.
     # There doesn't seem to be any particular vocabulary for this.
     FORMAT_TERMS: Mapping[tuple[str | None, str | None], str] = {
-        (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM): "EPUB eBook",
+        (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.LCP_DRM): "LCP EPUB e-kirja",
+        (Representation.PDF_MEDIA_TYPE, DeliveryMechanism.LCP_DRM): "LCP PDF e-kirja",
         (
-            Representation.EPUB_MEDIA_TYPE,
-            DeliveryMechanism.ADOBE_DRM,
-        ): "Adobe EPUB eBook",
-        (Representation.PDF_MEDIA_TYPE, DeliveryMechanism.NO_DRM): "PDF eBook",
-        (Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM): "Adobe PDF eBook",
+            Representation.AUDIOBOOK_PACKAGE_LCP_MEDIA_TYPE,
+            DeliveryMechanism.LCP_DRM,
+        ): "LCP äänikirja",
+        (
+            DeliveryMechanism.EKIRJASTO_STREAMING_PROFILE,
+            DeliveryMechanism.LCP_DRM,
+        ): "LCP EPUB striimattava e-kirja",
     }
 
     def __init__(
@@ -346,7 +349,7 @@ class Annotator(LoggerMixin):
                     tag="264",
                     indicators=[" ", "1"],
                     subfields=[
-                        Subfield("a", "[Place of publication not identified]"),
+                        Subfield("a", "[Kustannuspaikka tuntematon]"),
                         Subfield("b", str(edition.publisher or "")),
                         Subfield("c", year),
                     ],
@@ -373,7 +376,7 @@ class Annotator(LoggerMixin):
                     tag="300",
                     indicators=[" ", " "],
                     subfields=[
-                        Subfield("a", "1 online resource"),
+                        Subfield("a", "verkkoaineisto"),
                     ],
                 )
             )
@@ -383,7 +386,7 @@ class Annotator(LoggerMixin):
                     tag="336",
                     indicators=[" ", " "],
                     subfields=[
-                        Subfield("a", "text"),
+                        Subfield("a", "teksti"),
                         Subfield("b", "txt"),
                         Subfield("2", "rdacontent"),
                     ],
@@ -395,8 +398,8 @@ class Annotator(LoggerMixin):
                     tag="300",
                     indicators=[" ", " "],
                     subfields=[
-                        Subfield("a", "1 sound file"),
-                        Subfield("b", "digital"),
+                        Subfield("a", "äänitiedosto"),
+                        Subfield("b", "digitaalinen"),
                     ],
                 )
             )
@@ -406,7 +409,7 @@ class Annotator(LoggerMixin):
                     tag="336",
                     indicators=[" ", " "],
                     subfields=[
-                        Subfield("a", "spoken word"),
+                        Subfield("a", "puhuttu sana"),
                         Subfield("b", "spw"),
                         Subfield("2", "rdacontent"),
                     ],
@@ -418,7 +421,7 @@ class Annotator(LoggerMixin):
                 tag="337",
                 indicators=[" ", " "],
                 subfields=[
-                    Subfield("a", "computer"),
+                    Subfield("a", "tietokone"),
                     Subfield("b", "c"),
                     Subfield("2", "rdamedia"),
                 ],
@@ -430,7 +433,7 @@ class Annotator(LoggerMixin):
                 tag="338",
                 indicators=[" ", " "],
                 subfields=[
-                    Subfield("a", "online resource"),
+                    Subfield("a", "verkkoaineisto"),
                     Subfield("b", "cr"),
                     Subfield("2", "rdacarrier"),
                 ],
@@ -439,9 +442,9 @@ class Annotator(LoggerMixin):
 
         file_type = None
         if edition.medium == Edition.BOOK_MEDIUM:
-            file_type = "text file"
+            file_type = "tekstitiedosto"
         elif edition.medium == Edition.AUDIO_MEDIUM:
-            file_type = "audio file"
+            file_type = "äänitiedosto"
         if file_type:
             record.add_field(
                 Field(
@@ -531,6 +534,7 @@ class Annotator(LoggerMixin):
     def add_summary(cls, record: Record, work: Work) -> None:
         summary = work.summary_text
         if summary:
+            # E.g. De Marque summaries include html tags.
             stripped = re.sub("<[^>]+?>", " ", summary)
             record.add_field(
                 Field(

--- a/core/marc.py
+++ b/core/marc.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import gettext
+import os
 import re
 import urllib.parse
 from collections.abc import Mapping
@@ -40,6 +42,16 @@ from core.util.datetime_helpers import utc_now
 from core.util.log import LoggerMixin
 from core.util.uuid import uuid_encode
 
+# Finna needs Finnish data.
+localedir = os.path.join(os.path.dirname(__file__), "../translations")
+try:
+    fi = gettext.translation("messages", localedir=localedir, languages=["fi"])
+    fi.install()
+    _ = fi.gettext
+except FileNotFoundError:
+    # Fallback: use the default (no translation)
+    _ = lambda x: x
+
 
 class Annotator(LoggerMixin):
     """The Annotator knows how to add information about a Work to
@@ -47,10 +59,14 @@ class Annotator(LoggerMixin):
 
     # From https://www.loc.gov/standards/valuelist/marctarget.html
     AUDIENCE_TERMS: Mapping[str, str] = {
-        SubjectClassifier.AUDIENCE_CHILDREN: "Juvenile",
-        SubjectClassifier.AUDIENCE_YOUNG_ADULT: "Adolescent",
-        SubjectClassifier.AUDIENCE_ADULTS_ONLY: "Adult",
-        SubjectClassifier.AUDIENCE_ADULT: "General",
+        SubjectClassifier.AUDIENCE_CHILDREN: _(SubjectClassifier.AUDIENCE_CHILDREN),
+        SubjectClassifier.AUDIENCE_YOUNG_ADULT: _(
+            SubjectClassifier.AUDIENCE_YOUNG_ADULT
+        ),
+        SubjectClassifier.AUDIENCE_ADULTS_ONLY: _(
+            SubjectClassifier.AUDIENCE_ADULTS_ONLY
+        ),
+        SubjectClassifier.AUDIENCE_ADULT: _(SubjectClassifier.AUDIENCE_ADULT),
     }
 
     # TODO: Add remaining formats. Maybe there's a better place to
@@ -313,7 +329,7 @@ class Annotator(LoggerMixin):
                             indicators=["1", " "],
                             subfields=[
                                 Subfield("a", str(contributor.sort_name)),
-                                Subfield("e", contribution.role),
+                                Subfield("e", _(contribution.role)),
                             ],
                         )
                     )
@@ -459,8 +475,7 @@ class Annotator(LoggerMixin):
 
     @classmethod
     def add_audience(cls, record: Record, work: Work) -> None:
-        work_audience = work.audience or SubjectClassifier.AUDIENCE_ADULT
-        audience = cls.AUDIENCE_TERMS.get(work_audience, "General")
+        audience = _(work.audience) or _(SubjectClassifier.AUDIENCE_ADULT)
         record.add_field(
             Field(
                 tag="385",
@@ -527,17 +542,15 @@ class Annotator(LoggerMixin):
 
     @classmethod
     def add_genres(cls, record: Record, work: Work) -> None:
-        """Create subject fields for this work."""
-        genres = work.genres
-
-        for genre in genres:
+        """Create genre fields for this work."""
+        genre_names = [_(wg.genre.name) for wg in work.work_genres]
+        for genre in genre_names:
             record.add_field(
                 Field(
-                    tag="650",
-                    indicators=["0", "7"],
+                    tag="655",
+                    indicators=[" ", "0"],
                     subfields=[
-                        Subfield("a", genre.name),
-                        Subfield("2", "Library Simplified"),
+                        Subfield("a", genre),
                     ],
                 )
             )

--- a/core/marc.py
+++ b/core/marc.py
@@ -136,8 +136,6 @@ class Annotator(LoggerMixin):
         self.add_physical_description(record, edition)
         self.add_audience(record, work)
         self.add_series(record, edition)
-        self.add_system_details(record)
-        self.add_ebooks_subject(record)
         self.add_distributor(record, active_license_pool)
         self.add_formats(record, active_license_pool)
 
@@ -505,16 +503,6 @@ class Annotator(LoggerMixin):
             )
 
     @classmethod
-    def add_system_details(cls, record: Record) -> None:
-        record.add_field(
-            Field(
-                tag="538",
-                indicators=[" ", " "],
-                subfields=[Subfield("a", "Mode of access: World Wide Web.")],
-            )
-        )
-
-    @classmethod
     def add_formats(cls, record: Record, pool: LicensePool) -> None:
         for lpdm in pool.delivery_mechanisms:
             dm = lpdm.delivery_mechanism
@@ -558,19 +546,6 @@ class Annotator(LoggerMixin):
                     ],
                 )
             )
-
-    @classmethod
-    def add_ebooks_subject(cls, record: Record) -> None:
-        # This is a general subject that can be added to all records.
-        record.add_field(
-            Field(
-                tag="655",
-                indicators=[" ", "0"],
-                subfields=[
-                    Subfield("a", "Electronic books."),
-                ],
-            )
-        )
 
     @classmethod
     def add_web_client_urls(

--- a/core/marc.py
+++ b/core/marc.py
@@ -50,7 +50,7 @@ try:
     _ = fi.gettext
 except FileNotFoundError:
     # Fallback: use the default (no translation)
-    _ = lambda x: x
+    _ = lambda x: x  # type: ignore[assignment]
 
 
 class Annotator(LoggerMixin):
@@ -476,7 +476,9 @@ class Annotator(LoggerMixin):
 
     @classmethod
     def add_audience(cls, record: Record, work: Work) -> None:
-        audience = _(work.audience) or _(SubjectClassifier.AUDIENCE_ADULT)
+        audience = _(work.audience) or _(
+            SubjectClassifier.AUDIENCE_ADULT
+        )  # type:ignore[arg-type]
         record.add_field(
             Field(
                 tag="385",
@@ -535,14 +537,14 @@ class Annotator(LoggerMixin):
     @classmethod
     def add_genres(cls, record: Record, work: Work) -> None:
         """Create genre fields for this work."""
-        genre_names = [_(wg.genre.name) for wg in work.work_genres]
-        for genre in genre_names:
+        genres = work.genres
+        for genre in genres:
             record.add_field(
                 Field(
                     tag="655",
                     indicators=[" ", "0"],
                     subfields=[
-                        Subfield("a", genre),
+                        Subfield("a", _(genre.name)),
                     ],
                 )
             )

--- a/core/marc.py
+++ b/core/marc.py
@@ -476,7 +476,7 @@ class Annotator(LoggerMixin):
 
     @classmethod
     def add_audience(cls, record: Record, work: Work) -> None:
-        audience = _(work.audience) or _( # type:ignore[arg-type]
+        audience = _(work.audience) or _(  # type:ignore[arg-type]
             SubjectClassifier.AUDIENCE_ADULT
         )
         record.add_field(

--- a/core/model/contributor.py
+++ b/core/model/contributor.py
@@ -6,6 +6,7 @@ import re
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from flask_babel import gettext as _
 from sqlalchemy import Column, ForeignKey, Integer, Unicode, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY, JSON
 from sqlalchemy.exc import IntegrityError
@@ -61,13 +62,13 @@ class Contributor(Base):
 
     # Types of roles
     class Role(str, Enum):
-        AUTHOR = "Author"
-        PRIMARY_AUTHOR = "Primary Author"
-        EDITOR = "Editor"
-        ARTIST = "Artist"
-        PHOTOGRAPHER = "Photographer"
-        TRANSLATOR = "Translator"
-        ILLUSTRATOR = "Illustrator"
+        AUTHOR = _("Author")
+        PRIMARY_AUTHOR = _("Primary Author")
+        EDITOR = _("Editor")
+        ARTIST = _("Artist")
+        PHOTOGRAPHER = _("Photographer")
+        TRANSLATOR = _("Translator")
+        ILLUSTRATOR = _("Illustrator")
         LETTERER = "Letterer"
         PENCILER = "Penciler"
         COLORIST = "Colorist"
@@ -76,21 +77,21 @@ class Contributor(Base):
         FOREWORD = "Foreword Author"
         AFTERWORD = "Afterword Author"
         COLOPHON = "Colophon Author"
-        UNKNOWN = "Unknown"
+        UNKNOWN = _("Unknown")
         DIRECTOR = "Director"
         PRODUCER = "Producer"
         EXECUTIVE_PRODUCER = "Executive Producer"
         ACTOR = "Actor"
         LYRICIST = "Lyricist"
-        CONTRIBUTOR = "Contributor"
+        CONTRIBUTOR = _("Contributor")
         COMPOSER = "Composer"
-        NARRATOR = "Narrator"
+        NARRATOR = _("Narrator")
         COMPILER = "Compiler"
         ADAPTER = "Adapter"
         PERFORMER = "Performer"
         MUSICIAN = "Musician"
         ASSOCIATED = "Associated name"
-        COLLABORATOR = "Collaborator"
+        COLLABORATOR = _("Collaborator")
         ENGINEER = "Engineer"
         COPYRIGHT_HOLDER = "Copyright holder"
         TRANSCRIBER = "Transcriber"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,7 @@ x-cm-variables: &cm
     PALACE_STORAGE_ENDPOINT_URL: "http://minio:9000"
     PALACE_STORAGE_PUBLIC_ACCESS_BUCKET: "public"
     PALACE_STORAGE_ANALYTICS_BUCKET: "analytics"
-    PALACE_STORAGE_URL_TEMPLATE: "http://minio:9000/{bucket}/{key}"
+    PALACE_STORAGE_URL_TEMPLATE: "http://localhost:9000/{bucket}/{key}"
     PALACE_REPORTING_NAME: "TEST CM"
     PALACE_OPENSEARCH_ANALYTICS_ENABLED: true
     PALACE_OPENSEARCH_ANALYTICS_URL: "http://opensearch:9200/"
@@ -57,7 +57,7 @@ services:
       target: scripts
 
   pg:
-    image: "postgres:12"
+    image: "postgres:16"
     container_name: postgres
     environment:
       POSTGRES_USER: palace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN . env/bin/activate && \
     poetry install --only main,pg --sync --no-root
 
 COPY --chown=simplified:simplified . /var/www/circulation
+RUN PALACE_SEARCH_URL=http://localhost:9200 core/bin/run util/compile_translations
 
 ###############################################################################
 ## Circ-exec Image
@@ -72,9 +73,7 @@ COPY docker/services/uwsgi /etc/
 RUN mkdir -p /var/log/uwsgi && \
     chown -RHh simplified:simplified /var/log/uwsgi && \
     mkdir /var/run/uwsgi && \
-    chown simplified:simplified /var/run/uwsgi && \
-    # Search url not used but script fails if not set
-    PALACE_SEARCH_URL=http://localhost:9200 core/bin/run util/compile_translations
+    chown simplified:simplified /var/run/uwsgi
 
 # Setup runit
 COPY docker/runit /etc/service/

--- a/scripts.py
+++ b/scripts.py
@@ -579,7 +579,7 @@ class CompileTranslationsScript(Script):
         for language in languages:
             base_path = "translations/%s/LC_MESSAGES" % language
             if not os.path.exists(base_path):
-                logging.warn("No translations for configured language %s" % language)
+                logging.warning("No translations for configured language %s" % language)
                 continue
 
             os.system("rm %(path)s/messages.po" % dict(path=base_path))

--- a/tests/core/test_marc.py
+++ b/tests/core/test_marc.py
@@ -11,6 +11,7 @@ import pytest
 from _pytest.logging import LogCaptureFixture
 from pymarc import MARCReader, Record
 
+from core.classifier import ClassifierConstants
 from core.marc import Annotator, MARCExporter
 from core.model import (
     Contributor,
@@ -73,15 +74,9 @@ class AnnotateWorkRecordFixture:
         )
         self.mock_add_audience = create_autospec(self.annotator.add_audience)
         self.mock_add_series = create_autospec(self.annotator.add_series)
-        self.mock_add_system_details = create_autospec(
-            self.annotator.add_system_details
-        )
         self.mock_add_formats = create_autospec(self.annotator.add_formats)
         self.mock_add_summary = create_autospec(self.annotator.add_summary)
         self.mock_add_genres = create_autospec(self.annotator.add_genres)
-        self.mock_add_ebooks_subject = create_autospec(
-            self.annotator.add_ebooks_subject
-        )
         self.mock_add_web_client_urls = create_autospec(
             self.annotator.add_web_client_urls
         )
@@ -97,11 +92,9 @@ class AnnotateWorkRecordFixture:
         self.annotator.add_physical_description = self.mock_add_physical_description
         self.annotator.add_audience = self.mock_add_audience
         self.annotator.add_series = self.mock_add_series
-        self.annotator.add_system_details = self.mock_add_system_details
         self.annotator.add_formats = self.mock_add_formats
         self.annotator.add_summary = self.mock_add_summary
         self.annotator.add_genres = self.mock_add_genres
-        self.annotator.add_ebooks_subject = self.mock_add_ebooks_subject
         self.annotator.add_web_client_urls = self.mock_add_web_client_urls
 
         self.annotate_work_record = functools.partial(
@@ -125,7 +118,8 @@ class TestAnnotator:
     ) -> None:
         fixture = annotate_work_record_fixture
         with patch("core.marc.Record") as mock_record:
-            fixture.annotate_work_record()
+            d = fixture.annotate_work_record()
+            print(d)
 
         mock_record.assert_called_once_with(
             force_utf8=True, leader=fixture.mock_leader.return_value
@@ -148,11 +142,9 @@ class TestAnnotator:
         )
         fixture.mock_add_audience.assert_called_once_with(record, fixture.work)
         fixture.mock_add_series.assert_called_once_with(record, fixture.edition)
-        fixture.mock_add_system_details.assert_called_once_with(record)
         fixture.mock_add_formats.assert_called_once_with(record, fixture.pool)
         fixture.mock_add_summary.assert_called_once_with(record, fixture.work)
         fixture.mock_add_genres.assert_called_once_with(record, fixture.work)
-        fixture.mock_add_ebooks_subject.assert_called_once_with(record)
         fixture.mock_add_web_client_urls.assert_called_once_with(
             record,
             fixture.identifier,
@@ -360,7 +352,7 @@ class TestAnnotator:
             record,
             "264",
             {
-                "a": "[Place of publication not identified]",
+                "a": "[Kustannuspaikka tuntematon]",
                 "b": edition.publisher,
                 "c": "1894",
             },
@@ -387,12 +379,12 @@ class TestAnnotator:
 
         record = Record()
         Annotator.add_physical_description(record, book)
-        self._check_field(record, "300", {"a": "1 online resource"})
+        self._check_field(record, "300", {"a": "verkkoaineisto"})
         self._check_field(
             record,
             "336",
             {
-                "a": "text",
+                "a": "teksti",
                 "b": "txt",
                 "2": "rdacontent",
             },
@@ -401,7 +393,7 @@ class TestAnnotator:
             record,
             "337",
             {
-                "a": "computer",
+                "a": "tietokone",
                 "b": "c",
                 "2": "rdamedia",
             },
@@ -410,7 +402,7 @@ class TestAnnotator:
             record,
             "338",
             {
-                "a": "online resource",
+                "a": "verkkoaineisto",
                 "b": "cr",
                 "2": "rdacarrier",
             },
@@ -419,7 +411,7 @@ class TestAnnotator:
             record,
             "347",
             {
-                "a": "text file",
+                "a": "tekstitiedosto",
                 "2": "rda",
             },
         )
@@ -438,15 +430,15 @@ class TestAnnotator:
             record,
             "300",
             {
-                "a": "1 sound file",
-                "b": "digital",
+                "a": "äänitiedosto",
+                "b": "digitaalinen",
             },
         )
         self._check_field(
             record,
             "336",
             {
-                "a": "spoken word",
+                "a": "puhuttu sana",
                 "b": "spw",
                 "2": "rdacontent",
             },
@@ -455,7 +447,7 @@ class TestAnnotator:
             record,
             "337",
             {
-                "a": "computer",
+                "a": "tietokone",
                 "b": "c",
                 "2": "rdamedia",
             },
@@ -464,7 +456,7 @@ class TestAnnotator:
             record,
             "338",
             {
-                "a": "online resource",
+                "a": "verkkoaineisto",
                 "b": "cr",
                 "2": "rdacarrier",
             },
@@ -473,7 +465,7 @@ class TestAnnotator:
             record,
             "347",
             {
-                "a": "audio file",
+                "a": "äänitiedosto",
                 "2": "rda",
             },
         )
@@ -531,22 +523,17 @@ class TestAnnotator:
         Annotator.add_series(record, edition)
         assert [] == record.get_fields("490")
 
-    def test_add_system_details(self):
-        record = Record()
-        Annotator.add_system_details(record)
-        self._check_field(record, "538", {"a": "Mode of access: World Wide Web."})
-
     def test_add_formats(self, db: DatabaseTransactionFixture):
         edition, pool = db.edition(with_license_pool=True)
-        epub_no_drm, ignore = DeliveryMechanism.lookup(
-            db.session, Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM
+        epub_lcp_drm, ignore = DeliveryMechanism.lookup(
+            db.session, Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.LCP_DRM
         )
-        pool.delivery_mechanisms[0].delivery_mechanism = epub_no_drm
+        pool.delivery_mechanisms[0].delivery_mechanism = epub_lcp_drm
         LicensePoolDeliveryMechanism.set(
             pool.data_source,
             pool.identifier,
             Representation.PDF_MEDIA_TYPE,
-            DeliveryMechanism.ADOBE_DRM,
+            DeliveryMechanism.LCP_DRM,
             RightsStatus.IN_COPYRIGHT,
         )
 
@@ -555,9 +542,9 @@ class TestAnnotator:
         fields = record.get_fields("538")
         assert 2 == len(fields)
         [pdf, epub] = sorted(fields, key=lambda x: x.get_subfields("a")[0])
-        assert "Adobe PDF eBook" == pdf.get_subfields("a")[0]
+        assert "LCP EPUB e-kirja" == pdf.get_subfields("a")[0]
         assert [" ", " "] == pdf.indicators
-        assert "EPUB eBook" == epub.get_subfields("a")[0]
+        assert "LCP PDF e-kirja" == epub.get_subfields("a")[0]
         assert [" ", " "] == epub.indicators
 
     def test_add_summary(self, db: DatabaseTransactionFixture):
@@ -583,21 +570,14 @@ class TestAnnotator:
 
         record = Record()
         Annotator.add_genres(record, work)
-        fields = record.get_fields("650")
+        fields = record.get_fields("655")
         [fantasy_field, romance_field] = sorted(
             fields, key=lambda x: x.get_subfields("a")[0]
         )
-        assert ["0", "7"] == fantasy_field.indicators
+        assert [" ", "0"] == fantasy_field.indicators
         assert "Fantasy" == fantasy_field.get_subfields("a")[0]
-        assert "Library Simplified" == fantasy_field.get_subfields("2")[0]
-        assert ["0", "7"] == romance_field.indicators
+        assert [" ", "0"] == romance_field.indicators
         assert "Romance" == romance_field.get_subfields("a")[0]
-        assert "Library Simplified" == romance_field.get_subfields("2")[0]
-
-    def test_add_ebooks_subject(self):
-        record = Record()
-        Annotator.add_ebooks_subject(record)
-        self._check_field(record, "655", {"a": "Electronic books."}, [" ", "0"])
 
     def test_add_web_client_urls_empty(self):
         record = MagicMock(spec=Record)
@@ -715,6 +695,7 @@ class TestMARCExporter:
             title="old title",
             authors=["old author"],
             data_source_name=DataSource.OVERDRIVE,
+            audience=ClassifierConstants.AUDIENCE_ADULT,
         )
 
         mock_revised = MagicMock()

--- a/translations/en/LC_MESSAGES/core.po
+++ b/translations/en/LC_MESSAGES/core.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-12 17:17+0200\n"
+"POT-Creation-Date: 2026-04-16 15:01+0300\n"
 "PO-Revision-Date: 2024-02-19 22:14+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -199,7 +199,7 @@ msgstr "Allow patrons to filter by language"
 msgid "Title"
 msgstr "Title"
 
-#: core/facets.py:110
+#: core/facets.py:110 core/model/contributor.py:64
 msgid "Author"
 msgstr "Author"
 
@@ -1439,6 +1439,46 @@ msgstr "Fiction"
 msgid "Nonfiction"
 msgstr "Nonfiction"
 
+#: core/model/contributor.py:65
+msgid "Primary Author"
+msgstr "Primary Author"
+
+#: core/model/contributor.py:66
+msgid "Editor"
+msgstr "Editor"
+
+#: core/model/contributor.py:67
+msgid "Artist"
+msgstr "Artist"
+
+#: core/model/contributor.py:68
+msgid "Photographer"
+msgstr "Photographer"
+
+#: core/model/contributor.py:69
+msgid "Translator"
+msgstr "Translator"
+
+#: core/model/contributor.py:70
+msgid "Illustrator"
+msgstr "Illustrator"
+
+#: core/model/contributor.py:79
+msgid "Unknown"
+msgstr "Unknown"
+
+#: core/model/contributor.py:85
+msgid "Contributor"
+msgstr "Contributor"
+
+#: core/model/contributor.py:87
+msgid "Narrator"
+msgstr "Narrator"
+
+#: core/model/contributor.py:93
+msgid "Collaborator"
+msgstr "Collaborator"
+
 #: core/util/http.py:34
 msgid "Failure contacting external service"
 msgstr "Failure contacting external service"
@@ -1482,100 +1522,3 @@ msgstr "Timeout"
 #, python-format
 msgid "The server made a request to %(service)s, and that request timed out."
 msgstr "The server made a request to %(service)s, and that request timed out."
-
-#~ msgid "Literary Fiction"
-#~ msgstr "Literary Fiction"
-
-#~ msgid "(Default) Use <id>"
-#~ msgstr "(Default) Use <id>"
-
-#~ msgid "Use <dcterms:identifier> first, if not exist use <id>"
-#~ msgstr "Use <dcterms:identifier> first, if not exist use <id>"
-
-#~ msgid "Art & Design"
-#~ msgstr "Art & Design"
-
-#~ msgid "Entertainment"
-#~ msgstr "Entertainment"
-
-#~ msgid "Women's Fiction"
-#~ msgstr "Women's Fiction"
-
-#~ msgid "Boardgames & Strategic Games"
-#~ msgstr ""
-
-#~ msgid "Biography"
-#~ msgstr "Biography"
-
-#~ msgid "Chapter Books"
-#~ msgstr "Chapter Books"
-
-#~ msgid "Children and Middle Grade"
-#~ msgstr "Children and Middle Grade"
-
-#~ msgid "Children & Young Adult"
-#~ msgstr "Children & Young Adult"
-
-#~ msgid "Contemporary Fiction"
-#~ msgstr "Contemporary Fiction"
-
-#~ msgid "Dystopian"
-#~ msgstr "Dystopian"
-
-#~ msgid "Early Readers"
-#~ msgstr "Early Readers"
-
-#~ msgid "Fiction"
-#~ msgstr "Fiction"
-
-#~ msgid "History & Sociology"
-#~ msgstr "History & Sociology"
-
-#~ msgid "Informational Books"
-#~ msgstr "Informational Books"
-
-#~ msgid "Movie and TV Novelizations"
-#~ msgstr "Movie and TV Novelizations"
-
-#~ msgid "Mystery & Thriller"
-#~ msgstr "Mystery & Thriller"
-
-#~ msgid "Nonfiction"
-#~ msgstr "Nonfiction"
-
-#~ msgid "Picture Books"
-#~ msgstr "Picture Books"
-
-#~ msgid "Poetry Books"
-#~ msgstr "Poetry Books"
-
-#~ msgid "Politics & Current Events"
-#~ msgstr "Politics & Current Events"
-
-#~ msgid "Realistic Fiction"
-#~ msgstr "Realistic Fiction"
-
-#~ msgid "Thriller"
-#~ msgstr "Thriller"
-
-#~ msgid "World Languages"
-#~ msgstr "World Languages"
-
-#~ msgid "Young Adult Fiction"
-#~ msgstr "Young Adult Fiction"
-
-#~ msgid "Young Adult Nonfiction"
-#~ msgstr "Young Adult Nonfiction"
-
-#~ msgid "Finnish"
-#~ msgstr "Finnish"
-
-#~ msgid "Swedish"
-#~ msgstr "Swedish"
-
-#~ msgid "English"
-#~ msgstr "English"
-
-#~ msgid "Others"
-#~ msgstr "Others"
-

--- a/translations/fi/LC_MESSAGES/core.po
+++ b/translations/fi/LC_MESSAGES/core.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-12 17:17+0200\n"
+"POT-Creation-Date: 2026-04-16 15:01+0300\n"
 "PO-Revision-Date: 2025-10-16 10:07+0000\n"
 "Last-Translator: Kaisa Kuivalahti, 2025\n"
 "Language: fi\n"
@@ -203,7 +203,7 @@ msgstr "Salli asiakkaiden suodattaa kielen mukaan"
 msgid "Title"
 msgstr "Nimi"
 
-#: core/facets.py:110
+#: core/facets.py:110 core/model/contributor.py:64
 msgid "Author"
 msgstr "Tekijä"
 
@@ -1445,6 +1445,46 @@ msgstr "Kaunokirjallisuus"
 #: core/feed/annotator/base.py:172
 msgid "Nonfiction"
 msgstr "Tietokirjallisuus"
+
+#: core/model/contributor.py:65
+msgid "Primary Author"
+msgstr "Päätekijä"
+
+#: core/model/contributor.py:66
+msgid "Editor"
+msgstr "Toimittaja"
+
+#: core/model/contributor.py:67
+msgid "Artist"
+msgstr "Artisti"
+
+#: core/model/contributor.py:68
+msgid "Photographer"
+msgstr "Valokuvaaja"
+
+#: core/model/contributor.py:69
+msgid "Translator"
+msgstr "Kääntäjä"
+
+#: core/model/contributor.py:70
+msgid "Illustrator"
+msgstr "Kuvittaja"
+
+#: core/model/contributor.py:79
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: core/model/contributor.py:85
+msgid "Contributor"
+msgstr "Muu tekijä"
+
+#: core/model/contributor.py:87
+msgid "Narrator"
+msgstr "Lukija"
+
+#: core/model/contributor.py:93
+msgid "Collaborator"
+msgstr "Yhteistyökumppani"
 
 #: core/util/http.py:34
 msgid "Failure contacting external service"

--- a/translations/sv/LC_MESSAGES/core.po
+++ b/translations/sv/LC_MESSAGES/core.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-02-12 17:17+0200\n"
+"POT-Creation-Date: 2026-04-16 15:01+0300\n"
 "PO-Revision-Date: 2025-10-16 10:07+0000\n"
 "Last-Translator: Kaisa Kuivalahti, 2025\n"
 "Language: sv\n"
@@ -203,7 +203,7 @@ msgstr "Tillåt kunder att filtrera enligt språk"
 msgid "Title"
 msgstr "Titel"
 
-#: core/facets.py:110
+#: core/facets.py:110 core/model/contributor.py:64
 msgid "Author"
 msgstr "Författare"
 
@@ -1443,6 +1443,54 @@ msgstr "Skönlitteratur"
 msgid "Nonfiction"
 msgstr "Facklitteratur"
 
+#: core/model/contributor.py:65
+#, fuzzy
+msgid "Primary Author"
+msgstr ""
+
+#: core/model/contributor.py:66
+#, fuzzy
+msgid "Editor"
+msgstr ""
+
+#: core/model/contributor.py:67
+#, fuzzy
+msgid "Artist"
+msgstr ""
+
+#: core/model/contributor.py:68
+#, fuzzy
+msgid "Photographer"
+msgstr ""
+
+#: core/model/contributor.py:69
+#, fuzzy
+msgid "Translator"
+msgstr ""
+
+#: core/model/contributor.py:70
+#, fuzzy
+msgid "Illustrator"
+msgstr ""
+
+#: core/model/contributor.py:79
+msgid "Unknown"
+msgstr ""
+
+#: core/model/contributor.py:85
+#, fuzzy
+msgid "Contributor"
+msgstr ""
+
+#: core/model/contributor.py:87
+#, fuzzy
+msgid "Narrator"
+msgstr ""
+
+#: core/model/contributor.py:93
+msgid "Collaborator"
+msgstr ""
+
 #: core/util/http.py:34
 msgid "Failure contacting external service"
 msgstr "Det gick inte att kontakta den externa tjänsten"
@@ -1488,100 +1536,3 @@ msgid "The server made a request to %(service)s, and that request timed out."
 msgstr ""
 "Servern skickade en begäran till %(service)s och tidsgränsen för begäran "
 "överskreds."
-
-#~ msgid "Literary Fiction"
-#~ msgstr "Allmän skönlitteratur"
-
-#~ msgid "(Default) Use <id>"
-#~ msgstr "(Standard) Använd <id>"
-
-#~ msgid "Use <dcterms:identifier> first, if not exist use <id>"
-#~ msgstr "Använd först <dcterms:identifier>, om den inte finns, använd <id>"
-
-#~ msgid "Art & Design"
-#~ msgstr "Konst och formgivning"
-
-#~ msgid "Entertainment"
-#~ msgstr "Underhållning"
-
-#~ msgid "Women's Fiction"
-#~ msgstr "Feministisk litteratur"
-
-#~ msgid "Boardgames & Strategic Games"
-#~ msgstr "TRANSLATE!"
-
-#~ msgid "Biography"
-#~ msgstr "Biografi"
-
-#~ msgid "Chapter Books"
-#~ msgstr "Kapitelböcker"
-
-#~ msgid "Children and Middle Grade"
-#~ msgstr "Barn och skolbarn"
-
-#~ msgid "Children & Young Adult"
-#~ msgstr "Barn och ung vuxen"
-
-#~ msgid "Contemporary Fiction"
-#~ msgstr "Samtida skönlitteratur"
-
-#~ msgid "Dystopian"
-#~ msgstr "Dystopi"
-
-#~ msgid "Early Readers"
-#~ msgstr "Tidiga läsare"
-
-#~ msgid "Fiction"
-#~ msgstr "Fiktion"
-
-#~ msgid "History & Sociology"
-#~ msgstr "Historia och sociologi"
-
-#~ msgid "Informational Books"
-#~ msgstr "Informativ"
-
-#~ msgid "Movie and TV Novelizations"
-#~ msgstr "Baserad på film eller TV-serie"
-
-#~ msgid "Mystery & Thriller"
-#~ msgstr "Deckare och thriller"
-
-#~ msgid "Nonfiction"
-#~ msgstr "Facklitteratur"
-
-#~ msgid "Picture Books"
-#~ msgstr "Bilderböcker"
-
-#~ msgid "Poetry Books"
-#~ msgstr "Poesi"
-
-#~ msgid "Politics & Current Events"
-#~ msgstr "Politik och aktualiteter"
-
-#~ msgid "Realistic Fiction"
-#~ msgstr "Realistisk fiktion"
-
-#~ msgid "Thriller"
-#~ msgstr "Thriller"
-
-#~ msgid "World Languages"
-#~ msgstr "Världens språk"
-
-#~ msgid "Young Adult Fiction"
-#~ msgstr "Fiktion för unga vuxna"
-
-#~ msgid "Young Adult Nonfiction"
-#~ msgstr "Facklitteratur för unga vuxna"
-
-#~ msgid "Finnish"
-#~ msgstr "finska"
-
-#~ msgid "Swedish"
-#~ msgstr "svenska"
-
-#~ msgid "English"
-#~ msgstr "engelska"
-
-#~ msgid "Others"
-#~ msgstr "Annat"
-


### PR DESCRIPTION
## Description

- **What does this PR do?**

<!--- Provide a brief summary of the changes made in this PR. -->
This PR makes some Finna-specific changes to MARC conversion of which the most visible one is providing all the field data in Finnish. Due to this requirement, a small `DockerFile` change was needed so that the compiled `.mo` files are available also in the `scripts` container where the `CacheMARCFiles` script is run.

- **Why is this change necessary?**

<!--- Explain the rationale behind the changes. What problem does it solve or what feature does it add? -->

This is the second step of our Finna integration (the first one being that the MARC files are available via our `/marc` endpoint).

## Changes Made

<!-- List all changes -->
- Genres, some relevant contributor roles and audience localizations are fetched from the Finnish `.mo` file to `MARC` fields.
- All other `MARC` field data are hard-coded to Finnish.
- Formats are collected according to E-kirjasto formats.
- `compile_translations` is run in as a common task for our `Docker` containers.

## How was this tested?

<!--- Describe the testing strategy used (unit tests, integration tests, manual testing, etc.). -->
<!--- Include any relevant test cases or scenarios that were tested. -->
Locally

## Was AI used in the process of making this pr?

<!--- If AI was used during the process, describe how. -->

- Help with understanding how to use the existing translations outside `flask_babel`.
- Debug why `compile_translations` was not working.

## QA Testing

- **How should QA test this change?**

    - **Environment Setup:**
    Set up your local circulation as described in the README.
    Enable MARC export in each collection via the library configuration site: `http://localhost:6500/admin/web/config/collections`. In optional fields, select to `Generate MARC records`.
    Setup MARc exports in `http://localhost:6500/admin/web/config/catalogServices` by adding `Marc Export` as a service. Remember to include the library!
    You'll also need a tool to tranform the soon generated `.mrc` files to `.xml` so e.g. `brew install yaz`.

    - **Test Cases:**
    Jump into your `scripts` container `docker exec -it scripts /bin/bash `.
    Run the marc script `../core/bin/run cache_marc_files`.
    Check `localhost:6500/{library_short_name}/marc`. You should see a `MARC` file per each collection. Download the generated `MARC` exports.
   To view the data in `XML`, run `yaz-marcdump -i marc -o marcxml {input_file_name} > {output_file_name}`.
    Check the file and check that all the data is in Finnish, especially contributor roles, genres and audience.
    Check that Ellibs `EPUB`s have two formats.
    Check that `pdf` formats and audiobooks have appropriate formats.
    If you want, you can also preview the data in Finna's`https://finna.fi/RecordPreview`: copy one of the `record`s from the `XML` and paste it to the metadata box. Select e.g. Helmet library from the list. View the by selecting Lähetä.

    - **Edge Cases:**

    - **Regression Testing:**
    Any requests should still return responses with the requested language. You can check e.g. `http://localhost:6500/groups` to see that the categories are as per language.

## Is there any relevant documentation updated?

<!--- Link or describe if there's any updated or new documentation (e.g., Kupoli, README, etc.). -->
README updated regarding the compiled `.mo` files.

### Checklist

- [x] Translations updated / Translators notified if applicable
- [x] AI was used during the process and I have described above how.
