### PR TITLE
Perf/notifications and sweep monitor

### DIFF
--- a/bin/loan_notifications
+++ b/bin/loan_notifications
@@ -6,7 +6,9 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.jobs.notifications.loan_expiration_notification import LoanNotificationsMonitor
+from core.jobs.notifications.loan_expiration_notification import (
+    LoanNotificationsMonitor,
+)
 from core.model import production_session
 
 LoanNotificationsMonitor(production_session()).run()

--- a/bin/loan_notifications
+++ b/bin/loan_notifications
@@ -6,6 +6,7 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.jobs.notifications.loan_expiration_notification import LoanNotificationsScript
+from core.jobs.notifications.loan_expiration_notification import LoanNotificationsMonitor
+from core.model import production_session
 
-LoanNotificationsScript().run()
+LoanNotificationsMonitor(production_session()).run()

--- a/core/jobs/notifications/holds_notification.py
+++ b/core/jobs/notifications/holds_notification.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import exists, or_
+from sqlalchemy import and_, exists, or_
 from sqlalchemy.orm import joinedload
 
 from core.config import Configuration, ConfigurationConstants
@@ -51,11 +51,15 @@ class HoldsNotificationMonitor(SweepMonitor):
         # least one FCM-eligible device token. Using EXISTS instead of
         # JOIN+DISTINCT gives the planner a clear hint and avoids duplicate
         # rows that would otherwise need de-duplication.
+        # `exists().where(...)` only accepts a single criterion in the
+        # typed stubs we use, so combine via and_().
         has_fcm_token = exists().where(
-            DeviceToken.patron_id == Patron.id,
-            DeviceToken.token_type.in_(
-                (DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS)
-            ),
+            and_(
+                DeviceToken.patron_id == Patron.id,
+                DeviceToken.token_type.in_(
+                    (DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS)
+                ),
+            )
         )
         query = (
             super()

--- a/core/jobs/notifications/holds_notification.py
+++ b/core/jobs/notifications/holds_notification.py
@@ -74,12 +74,14 @@ class HoldsNotificationMonitor(SweepMonitor):
             )
             # Eager-load every relationship that PushNotifications dereferences
             # while building the message. Without this we'd issue ~4 extra
-            # SELECTs per hold (classic N+1).
+            # SELECTs per hold (classic N+1). Note: Hold.work is a Python
+            # property that resolves to license_pool.work, which is already
+            # lazy="joined" on the LicensePool side, so no joinedload is needed
+            # for the work itself.
             .options(
                 joinedload(Hold.patron).joinedload(Patron.device_tokens),
                 joinedload(Hold.patron).joinedload(Patron.library),
                 joinedload(Hold.license_pool).joinedload(LicensePool.identifier),
-                joinedload(Hold.work),
             )
         )
         return query

--- a/core/jobs/notifications/holds_notification.py
+++ b/core/jobs/notifications/holds_notification.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import or_
+from sqlalchemy import exists, or_
+from sqlalchemy.orm import joinedload
 
 from core.config import Configuration, ConfigurationConstants
 from core.model import Base
 from core.model.configuration import ConfigurationSetting
-from core.model.patron import Hold
+from core.model.devicetokens import DeviceToken, DeviceTokenTypes
+from core.model.licensing import LicensePool
+from core.model.patron import Hold, Patron
 from core.monitor import SweepMonitor
 from core.util.datetime_helpers import utc_now
 from core.util.notifications import PushNotifications
@@ -23,8 +26,12 @@ class HoldsNotificationMonitor(SweepMonitor):
 
     MODEL_CLASS: type[Base] | None = Hold
     SERVICE_NAME: str | None = "Holds Notification"
+    # Override the framework default (100). Notifications fan out to network
+    # I/O (FCM), so smaller batches keep per-batch blocking and memory low.
+    DEFAULT_BATCH_SIZE = 25
 
     def run_once(self, *ignore):
+        # Honor the sitewide kill switch before doing any DB work.
         setting = ConfigurationSetting.sitewide(
             self._db, Configuration.PUSH_NOTIFICATIONS_STATUS
         )
@@ -40,13 +47,40 @@ class HoldsNotificationMonitor(SweepMonitor):
         return qu
 
     def item_query(self) -> Query:
-        query = super().item_query()
-        query = query.filter(
-            Hold.position == 0,
-            or_(
-                Hold.patron_last_notified != utc_now().date(),
-                Hold.patron_last_notified == None,
+        # Correlated EXISTS subquery: only select holds whose patron has at
+        # least one FCM-eligible device token. Using EXISTS instead of
+        # JOIN+DISTINCT gives the planner a clear hint and avoids duplicate
+        # rows that would otherwise need de-duplication.
+        has_fcm_token = exists().where(
+            DeviceToken.patron_id == Patron.id,
+            DeviceToken.token_type.in_(
+                (DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS)
             ),
+        )
+        query = (
+            super()
+            .item_query()
+            .join(Hold.patron)
+            .filter(
+                # Only holds ready for checkout.
+                Hold.position == 0,
+                # Cooldown: skip patrons already notified today for this hold.
+                or_(
+                    Hold.patron_last_notified == None,
+                    Hold.patron_last_notified != utc_now().date(),
+                ),
+                # Skip patrons with no FCM-eligible device tokens.
+                has_fcm_token,
+            )
+            # Eager-load every relationship that PushNotifications dereferences
+            # while building the message. Without this we'd issue ~4 extra
+            # SELECTs per hold (classic N+1).
+            .options(
+                joinedload(Hold.patron).joinedload(Patron.device_tokens),
+                joinedload(Hold.patron).joinedload(Patron.library),
+                joinedload(Hold.license_pool).joinedload(LicensePool.identifier),
+                joinedload(Hold.work),
+            )
         )
         return query
 

--- a/core/jobs/notifications/loan_expiration_notification.py
+++ b/core/jobs/notifications/loan_expiration_notification.py
@@ -52,7 +52,7 @@ class LoanNotificationsMonitor(SweepMonitor):
         return qu
 
     def item_query(self):
-        # Phase 3: select loans whose `end` falls inside a 24h interval ending
+        # Select loans whose `end` falls inside a 24h interval ending
         # at `now + N days` for each configured notification day. This is more
         # correct than date-equality (`Loan.end == today + N days`), which
         # would only match loans ending at exactly midnight on the target day.

--- a/core/jobs/notifications/loan_expiration_notification.py
+++ b/core/jobs/notifications/loan_expiration_notification.py
@@ -1,29 +1,39 @@
 from __future__ import annotations
 
 import datetime
+import math
 
-from sqlalchemy import or_
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import joinedload
 
 from core.config import Configuration, ConfigurationConstants
+from core.model import Base
 from core.model.configuration import ConfigurationSetting
-from core.model.devicetokens import DeviceToken, DeviceTokenTypes
+from core.model.devicetokens import DeviceTokenTypes
+from core.model.licensing import LicensePool
 from core.model.patron import Loan, Patron
-from core.scripts import Script
+from core.monitor import SweepMonitor
 from core.util.datetime_helpers import utc_now
 from core.util.notifications import PushNotifications
 
 
-class LoanNotificationsScript(Script):
-    """Notifications must be sent to Patrons based on when their current loans
-    are expiring"""
+class LoanNotificationsMonitor(SweepMonitor):
+    """Sweep across all loans that are expiring soon and need notifications."""
 
-    # Days before on which to send out a notification
+    # Required by SweepMonitor: which table to sweep and which `id` column to
+    # use for offset tracking.
+    MODEL_CLASS: type[Base] | None = Loan
+    # Stored in the `Timestamp` row so progress (counter/offset) persists
+    # across runs and crashes resume where they left off.
+    SERVICE_NAME: str | None = "Loan Expiration Notification"
+    # Days-before-expiry at which a notification should be sent.
     LOAN_EXPIRATION_DAYS = [3, 1]
-    BATCH_SIZE = 100
+    # Override the framework default (100). Notifications fan out to network
+    # I/O (FCM), so smaller batches keep per-batch blocking and memory low.
+    DEFAULT_BATCH_SIZE = 25
 
-    def do_run(self):
-        self.log.info("Loan Notifications Job started")
-
+    def run_once(self, *ignore):
+        # Honor the sitewide kill switch before doing any DB work.
         setting = ConfigurationSetting.sitewide(
             self._db, Configuration.PUSH_NOTIFICATIONS_STATUS
         )
@@ -32,59 +42,98 @@ class LoanNotificationsScript(Script):
                 "Push notifications have been turned off in the sitewide settings, skipping this job"
             )
             return
+        return super().run_once(*ignore)
 
-        _query = (
-            self._db.query(Loan)
-            .filter(
-                or_(
-                    Loan.patron_last_notified != utc_now().date(),
-                    Loan.patron_last_notified == None,
-                )
-            )
-            .order_by(Loan.id)
-        )
-        last_loan_id = None
-        processed_loans = 0
+    def scope_to_collection(self, qu, collection):
+        """Loans are not scoped to a collection."""
+        # SweepMonitor inherits from CollectionMonitor and only calls this
+        # when `self.collection` is truthy. We never set a collection on this
+        # monitor, but the base class requires the method to be defined.
+        return qu
 
-        while True:
-            query = _query.limit(self.BATCH_SIZE)
-            if last_loan_id:
-                query = _query.filter(Loan.id > last_loan_id)
-
-            loans = query.all()
-            if len(loans) == 0:
-                break
-
-            for loan in loans:
-                processed_loans += 1
-                self.process_loan(loan)
-            last_loan_id = loan.id
-            # Commit every batch
-            self._db.commit()
-
-        self.log.info(
-            f"Loan Notifications Job ended: {processed_loans} loans processed"
-        )
-
-    def process_loan(self, loan: Loan):
-        tokens = []
-        patron: Patron = loan.patron
-        t: DeviceToken
-        for t in patron.device_tokens:
-            if t.token_type in [DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS]:
-                tokens.append(t)
-
-        # No tokens means no notifications
-        if not tokens:
-            return
-
+    def item_query(self):
+        # Phase 3: select loans whose `end` falls inside a 24h interval ending
+        # at `now + N days` for each configured notification day. This is more
+        # correct than date-equality (`Loan.end == today + N days`), which
+        # would only match loans ending at exactly midnight on the target day.
         now = utc_now()
-        if loan.end is None:
-            self.log.warning(f"Loan: {loan.id} has no end date, skipping")
-            return
-        delta: datetime.timedelta = loan.end - now
-        if delta.days in self.LOAN_EXPIRATION_DAYS:
-            self.log.info(
-                f"Patron {patron.authorization_identifier} has an expiring loan on ({loan.license_pool.identifier.urn})"
+        today = now.date()
+        # One clause per notification day. Window is right-closed / left-open
+        # so a loan can't be picked up by two windows on the same run.
+        expiry_clauses = [
+            and_(
+                Loan.end <= now + datetime.timedelta(days=days),
+                Loan.end > now + datetime.timedelta(days=days - 1),
             )
-            PushNotifications.send_loan_expiry_message(loan, delta.days, tokens)
+            for days in self.LOAN_EXPIRATION_DAYS
+        ]
+        query = (
+            super()
+            .item_query()
+            .filter(
+                # Cooldown: skip loans already notified today. NULL means
+                # "never notified", which still qualifies.
+                or_(
+                    Loan.patron_last_notified == None,
+                    Loan.patron_last_notified != today,
+                ),
+                # Loan must be in one of the expiry windows.
+                or_(*expiry_clauses),
+                # Defensive: orphan loans without a patron would crash later
+                # when we dereference `loan.patron`. Filter them out in SQL.
+                Loan.patron_id != None,
+            )
+            # Eager-load every relationship that PushNotifications dereferences
+            # while building the message. Without this, we'd issue ~5 extra
+            # SELECTs per loan (classic N+1). joinedload is appropriate here
+            # because all of these are one-to-one / many-to-one (low fan-out).
+            .options(
+                joinedload(Loan.patron).joinedload(Patron.device_tokens),
+                joinedload(Loan.patron).joinedload(Patron.library),
+                joinedload(Loan.license_pool).joinedload(LicensePool.identifier),
+                joinedload(Loan.license_pool).joinedload(
+                    LicensePool.presentation_edition
+                ),
+            )
+        )
+        return query
+
+    def process_items(self, items: list[Loan]) -> None:
+        # Capture `now` once per batch so all loans in the batch are evaluated
+        # against the same reference point.
+        now = utc_now()
+        for loan in items:
+            patron: Patron = loan.patron
+            # Race-safety: the patron could have been deleted between the SQL
+            # fetch and now, even though we filtered patron_id != None.
+            if not patron:
+                continue
+            # Only FCM (Android / iOS) tokens can receive push notifications.
+            tokens = [
+                t
+                for t in patron.device_tokens
+                if t.token_type
+                in (DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS)
+            ]
+            if not tokens:
+                continue
+            if loan.end is None:
+                # Should be impossible given the SQL filter, but the model
+                # types `end` as Optional[DateTime] so we appease type checks
+                # and guard against any race.
+                self.log.warning(f"Loan: {loan.id} has no end date, skipping")
+                continue
+            # Round up to the nearest whole day. Matches the SQL window:
+            # a loan inside the `days=N` window always rounds up to N.
+            days = math.ceil((loan.end - now) / datetime.timedelta(days=1))
+            # Belt-and-suspenders: SQL `now` and Python `now` differ slightly,
+            # so a loan right on a boundary could compute a different bucket
+            # in Python than SQL selected. Skip those.
+            if days in self.LOAN_EXPIRATION_DAYS:
+                self.log.info(
+                    f"Patron {patron.authorization_identifier} has an expiring loan on "
+                    f"({loan.license_pool.identifier.urn})"
+                )
+                # send_loan_expiry_message also sets loan.patron_last_notified;
+                # SweepMonitor.run_once commits after every batch.
+                PushNotifications.send_loan_expiry_message(loan, days, tokens)

--- a/core/jobs/notifications/loan_expiration_notification.py
+++ b/core/jobs/notifications/loan_expiration_notification.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import math
 
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import joinedload
 
 from core.config import Configuration, ConfigurationConstants
@@ -52,43 +52,33 @@ class LoanNotificationsMonitor(SweepMonitor):
         return qu
 
     def item_query(self):
-        # Select loans whose `end` falls inside a 24h interval ending at
-        # `now + N days` for each configured notification day. This is more
+        # Phase 3: select loans whose `end` falls inside a 24h interval ending
+        # at `now + N days` for each configured notification day. This is more
         # correct than date-equality (`Loan.end == today + N days`), which
         # would only match loans ending at exactly midnight on the target day.
         now = utc_now()
-        # Build one (window AND per-bucket-cooldown) clause per notification
-        # day. The cooldown is bucket-aware: a loan is eligible for the N-day
-        # notification only if we have NOT already notified the patron during
-        # the N-day window for this loan. Without this, the same loan could
-        # trigger the "3 days left" message on two consecutive cron days
-        # because the window spans up to 24h.
-        bucket_clauses = []
-        for days in self.LOAN_EXPIRATION_DAYS:
-            window = and_(
+        today = now.date()
+        # One clause per notification day. Window is right-closed / left-open
+        # so a loan can't be picked up by two windows on the same run.
+        expiry_clauses = [
+            and_(
                 Loan.end <= now + datetime.timedelta(days=days),
                 Loan.end > now + datetime.timedelta(days=days - 1),
             )
-            # The N-day window opens at `loan.end - N days`. We notify at
-            # most once per bucket per loan: if `patron_last_notified`
-            # (a Date) is on or after the bucket's opening date, we've
-            # already sent the N-day message for this loan and must skip.
-            # `func.date(...)` truncates the right side to date granularity
-            # to match the column type. NULL `patron_last_notified` means
-            # "never notified", which is always fresh.
-            cooldown = or_(
-                Loan.patron_last_notified == None,
-                Loan.patron_last_notified
-                < func.date(Loan.end - datetime.timedelta(days=days)),
-            )
-            bucket_clauses.append(and_(window, cooldown))
-
+            for days in self.LOAN_EXPIRATION_DAYS
+        ]
         query = (
             super()
             .item_query()
             .filter(
-                # Loan must be in at least one (window, cooldown) bucket.
-                or_(*bucket_clauses),
+                # Cooldown: skip loans already notified today. NULL means
+                # "never notified", which still qualifies.
+                or_(
+                    Loan.patron_last_notified == None,
+                    Loan.patron_last_notified != today,
+                ),
+                # Loan must be in one of the expiry windows.
+                or_(*expiry_clauses),
                 # Defensive: orphan loans without a patron would crash later
                 # when we dereference `loan.patron`. Filter them out in SQL.
                 Loan.patron_id != None,
@@ -139,23 +129,11 @@ class LoanNotificationsMonitor(SweepMonitor):
             # Belt-and-suspenders: SQL `now` and Python `now` differ slightly,
             # so a loan right on a boundary could compute a different bucket
             # in Python than SQL selected. Skip those.
-            if days not in self.LOAN_EXPIRATION_DAYS:
-                continue
-            # Bucket-aware cooldown re-check (mirrors the SQL filter). Avoids
-            # re-sending the same N-day message if the SQL filter raced.
-            # Compared at date granularity because patron_last_notified is
-            # a Date column.
-            bucket_open_date = (loan.end - datetime.timedelta(days=days)).date()
-            if (
-                loan.patron_last_notified is not None
-                and loan.patron_last_notified >= bucket_open_date
-            ):
-                continue
-            self.log.info(
-                f"Patron {patron.authorization_identifier} has an expiring loan on "
-                f"({loan.license_pool.identifier.urn}) ending on {loan.end}, "
-                f"which is in the {days}-day expiry window. "
-            )
-            # send_loan_expiry_message also sets loan.patron_last_notified;
-            # SweepMonitor.run_once commits after every batch.
-            PushNotifications.send_loan_expiry_message(loan, days, tokens)
+            if days in self.LOAN_EXPIRATION_DAYS:
+                self.log.info(
+                    f"Patron {patron.authorization_identifier} has an expiring loan on "
+                    f"({loan.license_pool.identifier.urn})"
+                )
+                # send_loan_expiry_message also sets loan.patron_last_notified;
+                # SweepMonitor.run_once commits after every batch.
+                PushNotifications.send_loan_expiry_message(loan, days, tokens)

--- a/core/jobs/notifications/loan_expiration_notification.py
+++ b/core/jobs/notifications/loan_expiration_notification.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import math
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import joinedload
 
 from core.config import Configuration, ConfigurationConstants
@@ -52,33 +52,43 @@ class LoanNotificationsMonitor(SweepMonitor):
         return qu
 
     def item_query(self):
-        # Phase 3: select loans whose `end` falls inside a 24h interval ending
-        # at `now + N days` for each configured notification day. This is more
+        # Select loans whose `end` falls inside a 24h interval ending at
+        # `now + N days` for each configured notification day. This is more
         # correct than date-equality (`Loan.end == today + N days`), which
         # would only match loans ending at exactly midnight on the target day.
         now = utc_now()
-        today = now.date()
-        # One clause per notification day. Window is right-closed / left-open
-        # so a loan can't be picked up by two windows on the same run.
-        expiry_clauses = [
-            and_(
+        # Build one (window AND per-bucket-cooldown) clause per notification
+        # day. The cooldown is bucket-aware: a loan is eligible for the N-day
+        # notification only if we have NOT already notified the patron during
+        # the N-day window for this loan. Without this, the same loan could
+        # trigger the "3 days left" message on two consecutive cron days
+        # because the window spans up to 24h.
+        bucket_clauses = []
+        for days in self.LOAN_EXPIRATION_DAYS:
+            window = and_(
                 Loan.end <= now + datetime.timedelta(days=days),
                 Loan.end > now + datetime.timedelta(days=days - 1),
             )
-            for days in self.LOAN_EXPIRATION_DAYS
-        ]
+            # The N-day window opens at `loan.end - N days`. We notify at
+            # most once per bucket per loan: if `patron_last_notified`
+            # (a Date) is on or after the bucket's opening date, we've
+            # already sent the N-day message for this loan and must skip.
+            # `func.date(...)` truncates the right side to date granularity
+            # to match the column type. NULL `patron_last_notified` means
+            # "never notified", which is always fresh.
+            cooldown = or_(
+                Loan.patron_last_notified == None,
+                Loan.patron_last_notified
+                < func.date(Loan.end - datetime.timedelta(days=days)),
+            )
+            bucket_clauses.append(and_(window, cooldown))
+
         query = (
             super()
             .item_query()
             .filter(
-                # Cooldown: skip loans already notified today. NULL means
-                # "never notified", which still qualifies.
-                or_(
-                    Loan.patron_last_notified == None,
-                    Loan.patron_last_notified != today,
-                ),
-                # Loan must be in one of the expiry windows.
-                or_(*expiry_clauses),
+                # Loan must be in at least one (window, cooldown) bucket.
+                or_(*bucket_clauses),
                 # Defensive: orphan loans without a patron would crash later
                 # when we dereference `loan.patron`. Filter them out in SQL.
                 Loan.patron_id != None,
@@ -129,11 +139,23 @@ class LoanNotificationsMonitor(SweepMonitor):
             # Belt-and-suspenders: SQL `now` and Python `now` differ slightly,
             # so a loan right on a boundary could compute a different bucket
             # in Python than SQL selected. Skip those.
-            if days in self.LOAN_EXPIRATION_DAYS:
-                self.log.info(
-                    f"Patron {patron.authorization_identifier} has an expiring loan on "
-                    f"({loan.license_pool.identifier.urn})"
-                )
-                # send_loan_expiry_message also sets loan.patron_last_notified;
-                # SweepMonitor.run_once commits after every batch.
-                PushNotifications.send_loan_expiry_message(loan, days, tokens)
+            if days not in self.LOAN_EXPIRATION_DAYS:
+                continue
+            # Bucket-aware cooldown re-check (mirrors the SQL filter). Avoids
+            # re-sending the same N-day message if the SQL filter raced.
+            # Compared at date granularity because patron_last_notified is
+            # a Date column.
+            bucket_open_date = (loan.end - datetime.timedelta(days=days)).date()
+            if (
+                loan.patron_last_notified is not None
+                and loan.patron_last_notified >= bucket_open_date
+            ):
+                continue
+            self.log.info(
+                f"Patron {patron.authorization_identifier} has an expiring loan on "
+                f"({loan.license_pool.identifier.urn}) ending on {loan.end}, "
+                f"which is in the {days}-day expiry window. "
+            )
+            # send_loan_expiry_message also sets loan.patron_last_notified;
+            # SweepMonitor.run_once commits after every batch.
+            PushNotifications.send_loan_expiry_message(loan, days, tokens)

--- a/core/jobs/notifications/user_survey_notification.py
+++ b/core/jobs/notifications/user_survey_notification.py
@@ -17,6 +17,10 @@ class UserSurveyNotificationScript(PatronSweepMonitor):
     """
 
     SERVICE_NAME: str | None = "User Survey Notification"
+    # Override the PatronSweepMonitor default (100). Each batch fans out to
+    # FCM I/O via send_user_survey_message(); a smaller batch keeps per-batch
+    # blocking time and memory bounded and matches the loan/hold monitors.
+    DEFAULT_BATCH_SIZE = 25
 
     def run_once(self, *ignore):
         setting = ConfigurationSetting.sitewide(

--- a/core/jobs/notifications/user_survey_notification.py
+++ b/core/jobs/notifications/user_survey_notification.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from sqlalchemy.orm import Query
+from sqlalchemy import exists
+from sqlalchemy.orm import Query, selectinload
 
 from core.config import Configuration, ConfigurationConstants
 from core.model.configuration import ConfigurationSetting
+from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from core.model.patron import Patron
 from core.monitor import PatronSweepMonitor
 from core.util.notifications import PushNotifications
@@ -29,9 +31,25 @@ class UserSurveyNotificationScript(PatronSweepMonitor):
         return super().run_once(*ignore)
 
     def item_query(self):
-        """Query all patrons"""
-        query: Query = super().item_query()
-        self.log.info(f"{query.count()} patrons found")
+        """Query only patrons with at least one FCM-eligible device token."""
+        # Correlated EXISTS: lets the planner skip patrons with no token in a
+        # single index lookup, rather than scanning the patrons table and
+        # filtering in Python.
+        has_fcm_token = exists().where(
+            DeviceToken.patron_id == Patron.id,
+            DeviceToken.token_type.in_(
+                (DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS)
+            ),
+        )
+        query: Query = (
+            super()
+            .item_query()
+            .filter(has_fcm_token)
+            # selectinload (not joinedload) because device_tokens is a
+            # collection, and we want one extra SELECT per batch rather than
+            # a JOIN that fans out rows.
+            .options(selectinload(Patron.device_tokens))
+        )
         return query
 
     def process_items(self, items: list[Patron]) -> None:

--- a/core/jobs/notifications/user_survey_notification.py
+++ b/core/jobs/notifications/user_survey_notification.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import exists
+from sqlalchemy import and_, exists
 from sqlalchemy.orm import Query, selectinload
 
 from core.config import Configuration, ConfigurationConstants
@@ -39,11 +39,15 @@ class UserSurveyNotificationScript(PatronSweepMonitor):
         # Correlated EXISTS: lets the planner skip patrons with no token in a
         # single index lookup, rather than scanning the patrons table and
         # filtering in Python.
+        # `exists().where(...)` only accepts a single criterion in the
+        # typed stubs we use, so combine via and_().
         has_fcm_token = exists().where(
-            DeviceToken.patron_id == Patron.id,
-            DeviceToken.token_type.in_(
-                (DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS)
-            ),
+            and_(
+                DeviceToken.patron_id == Patron.id,
+                DeviceToken.token_type.in_(
+                    (DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS)
+                ),
+            )
         )
         query: Query = (
             super()

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -440,8 +440,9 @@ class SweepMonitor(CollectionMonitor):
     """
 
     # The completion of each individual item should be logged at
-    # this log level.
-    COMPLETION_LOG_LEVEL = logging.INFO
+    # this log level. Defaults to DEBUG to avoid heavy per-item logging
+    # (which also calls __repr__ on every item) on large sweeps.
+    COMPLETION_LOG_LEVEL = logging.DEBUG
 
     # Items will be processed in batches of this size.
     DEFAULT_BATCH_SIZE = 100
@@ -515,17 +516,22 @@ class SweepMonitor(CollectionMonitor):
         offset = offset or 0
         self.log.info(f"Processing batch {offset}")
         items = self.fetch_batch(offset).all()
-        if items:
-            self.log.info(f"Processing batch {offset} items {len(items)}")
-            self.process_items(items)
-            # We've completed a batch. Return the ID of the last item
-            # in the batch so we don't do this work again.
-            return items[-1].id, len(items)
-        else:
+        if not items:
             self.log.info("No items.")
             # There are no more items in this database table, so we
             # are done with the sweep. Reset the counter.
             return 0, 0
+        self.log.info(f"Processing batch {offset} items {len(items)}")
+        self.process_items(items)
+        # Use max(id) rather than items[-1].id so DISTINCT or joins in
+        # item_query() that affect row ordering can't cause the next
+        # batch to skip or re-process rows.
+        next_offset = max(item.id for item in items)
+        # If the batch was short, the sweep is finished; skip the extra
+        # query that would otherwise be needed to discover that.
+        if len(items) < self.batch_size:
+            return 0, len(items)
+        return next_offset, len(items)
 
     def process_items(self, items):
         """Process a list of items."""
@@ -865,15 +871,20 @@ class ReaperMonitor(Monitor):
         to_defer = getattr(self.MODEL_CLASS, "LARGE_FIELDS", [])
         for x in to_defer:
             qu = qu.options(defer(x))
-        count = qu.count()
-        self.log.info("Deleting %d row(s)", count)
-        while count > 0:
-            for i in qu.limit(self.BATCH_SIZE):
-                self.log.info("Deleting %r", i)
-                self.delete(i)
+        # Iterate in batches without calling .count() each loop, which on
+        # large tables is an expensive scan that previously turned the loop
+        # into O(N^2) work.
+        while True:
+            batch = qu.limit(self.BATCH_SIZE).all()
+            if not batch:
+                break
+            for row in batch:
+                self.delete(row)
                 rows_deleted += 1
             self._db.commit()
-            count = qu.count()
+            self.log.info(
+                "Deleted batch of %d row(s) (total %d)", len(batch), rows_deleted
+            )
         return TimestampData(achievements="Items deleted: %d" % rows_deleted)
 
     def delete(self, row):

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -527,10 +527,6 @@ class SweepMonitor(CollectionMonitor):
         # item_query() that affect row ordering can't cause the next
         # batch to skip or re-process rows.
         next_offset = max(item.id for item in items)
-        # If the batch was short, the sweep is finished; skip the extra
-        # query that would otherwise be needed to discover that.
-        if len(items) < self.batch_size:
-            return 0, len(items)
         return next_offset, len(items)
 
     def process_items(self, items):

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -136,16 +136,16 @@ class PushNotifications(LoggerMixin):
         if loan.patron.authorization_identifier:
             data["authorization_identifier"] = loan.patron.authorization_identifier
 
+        cls.logger().info(
+            f"Patron {loan.patron.authorization_identifier} has {len(tokens)} device tokens. "
+            f"Sending loan expiry notification(s)."
+        )
         responses = cls.send_messages(
             tokens, messaging.Notification(title=title, body=body), data
         )
         # Update unconditionally so a transient FCM failure does not
         # cause the same patron to be re-notified on the next run.
         loan.patron_last_notified = utc_now().date()
-        cls.logger().info(
-            f"Sent loan expiry notification(s) to Patron {loan.patron.authorization_identifier} "
-            f"with {len(tokens)} device tokens. Last notified set to {loan.patron_last_notified}"
-        )
         return responses
 
     @classmethod

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -17,7 +17,6 @@ from core.model.identifier import Identifier
 from core.model.patron import Hold, Loan, Patron
 from core.model.work import Work
 from core.util.datetime_helpers import utc_now
-
 from core.util.log import LoggerMixin
 
 

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -136,16 +136,16 @@ class PushNotifications(LoggerMixin):
         if loan.patron.authorization_identifier:
             data["authorization_identifier"] = loan.patron.authorization_identifier
 
-        cls.logger().info(
-            f"Patron {loan.patron.authorization_identifier} has {len(tokens)} device tokens. "
-            f"Sending loan expiry notification(s)."
-        )
         responses = cls.send_messages(
             tokens, messaging.Notification(title=title, body=body), data
         )
         # Update unconditionally so a transient FCM failure does not
         # cause the same patron to be re-notified on the next run.
         loan.patron_last_notified = utc_now().date()
+        cls.logger().info(
+            f"Sent loan expiry notification(s) to Patron {loan.patron.authorization_identifier} "
+            f"with {len(tokens)} device tokens. Last notified set to {loan.patron_last_notified}"
+        )
         return responses
 
     @classmethod

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -144,7 +144,7 @@ class PushNotifications(LoggerMixin):
         responses = cls.send_messages(
             tokens, messaging.Notification(title=title, body=body), data
         )
-        # Phase 4: update unconditionally so a transient FCM failure does not
+        # Update unconditionally so a transient FCM failure does not
         # cause the same patron to be re-notified on the next run.
         loan.patron_last_notified = utc_now().date()
         return responses
@@ -186,7 +186,7 @@ class PushNotifications(LoggerMixin):
             resp = cls.send_messages(
                 tokens, messaging.Notification(title=title, body=body), data
             )
-            # Phase 4: update unconditionally so a transient FCM failure does not
+            # Update unconditionally so a transient FCM failure does not
             # cause the same patron to be re-notified on the next run.
             hold.patron_last_notified = utc_now().date()
 

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -17,6 +17,7 @@ from core.model.identifier import Identifier
 from core.model.patron import Hold, Loan, Patron
 from core.model.work import Work
 from core.util.datetime_helpers import utc_now
+
 from core.util.log import LoggerMixin
 
 
@@ -79,14 +80,14 @@ class PushNotifications(LoggerMixin):
 
         for token in tokens:
             try:
-                cls.logger().info(f"Trying device token {token.device_token}")
+                cls.logger().debug(f"Trying device token {token.device_token}")
                 msg = messaging.Message(
                     token=token.device_token,
                     notification=notification,
                     data=data_typed,
                 )
                 resp = messaging.send(msg, dry_run=cls.TESTING_MODE, app=cls.fcm_app())
-                cls.logger().info(
+                cls.logger().debug(
                     f"Sent notification for patron {token.patron.authorization_identifier} "
                     f"notification ID: {resp}"
                 )
@@ -102,6 +103,8 @@ class PushNotifications(LoggerMixin):
                 cls.logger().exception(
                     f"Failed to send notification for patron {token.patron.authorization_identifier}"
                 )
+        if responses:
+            cls.logger().info(f"Sent {len(responses)} notifications in batch.")
         return responses
 
     @classmethod
@@ -141,9 +144,9 @@ class PushNotifications(LoggerMixin):
         responses = cls.send_messages(
             tokens, messaging.Notification(title=title, body=body), data
         )
-        if len(responses) > 0:
-            # Atleast one notification succeeded
-            loan.patron_last_notified = utc_now().date()
+        # Phase 4: update unconditionally so a transient FCM failure does not
+        # cause the same patron to be re-notified on the next run.
+        loan.patron_last_notified = utc_now().date()
         return responses
 
     @classmethod
@@ -183,9 +186,9 @@ class PushNotifications(LoggerMixin):
             resp = cls.send_messages(
                 tokens, messaging.Notification(title=title, body=body), data
             )
-            if len(resp) > 0:
-                # Atleast one notification succeeded
-                hold.patron_last_notified = utc_now().date()
+            # Phase 4: update unconditionally so a transient FCM failure does not
+            # cause the same patron to be re-notified on the next run.
+            hold.patron_last_notified = utc_now().date()
 
             responses.extend(resp)
 
@@ -200,7 +203,7 @@ class PushNotifications(LoggerMixin):
         for patron in patrons:
             tokens = cls.notifiable_tokens(patron)
             if not tokens:
-                return []
+                continue
             cls.logger().info(
                 f"Notifying patron {patron.id} has {len(tokens)} device tokens."
             )

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -136,16 +136,17 @@ class PushNotifications(LoggerMixin):
         if loan.patron.authorization_identifier:
             data["authorization_identifier"] = loan.patron.authorization_identifier
 
-        cls.logger().info(
-            f"Patron {loan.patron.authorization_identifier} has {len(tokens)} device tokens. "
-            f"Sending loan expiry notification(s)."
-        )
         responses = cls.send_messages(
             tokens, messaging.Notification(title=title, body=body), data
         )
         # Update unconditionally so a transient FCM failure does not
         # cause the same patron to be re-notified on the next run.
         loan.patron_last_notified = utc_now().date()
+        cls.logger().info(
+            f"Sent loan expiry notification to patron {loan.patron.authorization_identifier} for loan {loan.id} with {len(tokens)} tokens. "
+            f"Updated patron_last_notified for loan {loan.id} to {loan.patron_last_notified}. "
+        )
+
         return responses
 
     @classmethod

--- a/tests/core/jobs/notifications/test_holds_notifications.py
+++ b/tests/core/jobs/notifications/test_holds_notifications.py
@@ -6,6 +6,7 @@ import pytest
 from core.config import Configuration, ConfigurationConstants
 from core.jobs.notifications.holds_notification import HoldsNotificationMonitor
 from core.model.configuration import ConfigurationSetting
+from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from core.util.datetime_helpers import utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
 
@@ -14,6 +15,22 @@ class HoldsNotificationFixture:
     def __init__(self, db: DatabaseTransactionFixture) -> None:
         self.db = db
         self.monitor = HoldsNotificationMonitor(self.db.session)
+
+    def patron_with_token(self):
+        """Create a patron with an FCM device token.
+
+        The item_query() in HoldsNotificationMonitor filters out patrons
+        without an FCM-eligible device token, so tests must give every
+        patron at least one token to be picked up by the sweep.
+        """
+        patron = self.db.patron()
+        DeviceToken.create(
+            self.db.session,
+            DeviceTokenTypes.FCM_ANDROID,
+            f"token-{patron.id}",
+            patron,
+        )
+        return patron
 
 
 @pytest.fixture(scope="function")
@@ -24,12 +41,17 @@ def holds_fixture(db: DatabaseTransactionFixture) -> HoldsNotificationFixture:
 class TestHoldsNotifications:
     def test_item_query(self, holds_fixture: HoldsNotificationFixture):
         db = holds_fixture.db
-        patron1 = db.patron()
+        patron1 = holds_fixture.patron_with_token()
+        # Patron with no device tokens. Holds for this patron must be excluded
+        # by the EXISTS subquery in item_query().
+        patron_no_token = db.patron()
+
         work1 = db.work(with_license_pool=True)
         work2 = db.work(with_license_pool=True)
         work3 = db.work(with_license_pool=True)
         work4 = db.work(with_license_pool=True)
         work5 = db.work(with_license_pool=True)
+        work6 = db.work(with_license_pool=True)
         hold1, _ = work1.active_license_pool().on_hold_to(patron1, position=1)
         hold2, _ = work2.active_license_pool().on_hold_to(patron1, position=0)
         hold3, _ = work3.active_license_pool().on_hold_to(patron1, position=0)
@@ -37,13 +59,17 @@ class TestHoldsNotifications:
         hold5, _ = work5.active_license_pool().on_hold_to(patron1, position=0)
         hold5.patron_last_notified = utc_now().date()
         hold2.patron_last_notified = utc_now().date() - datetime.timedelta(days=1)
+        # hold6 is ready (position=0) and not notified, but its patron has no
+        # FCM token → must be filtered out by the EXISTS subquery.
+        hold6, _ = work6.active_license_pool().on_hold_to(patron_no_token, position=0)
 
-        # Only position 0 holds, that haven't bene notified today, should be queried for
+        # Only position 0 holds, that haven't been notified today, whose
+        # patron has at least one FCM token, should be queried for.
         assert holds_fixture.monitor.item_query().all() == [hold2, hold3]
 
     def test_script_run(self, holds_fixture: HoldsNotificationFixture):
         db = holds_fixture.db
-        patron1 = db.patron()
+        patron1 = holds_fixture.patron_with_token()
         work1 = db.work(with_license_pool=True)
         work2 = db.work(with_license_pool=True)
         hold1, _ = work1.active_license_pool().on_hold_to(patron1, position=0)

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -99,67 +99,6 @@ class TestLoanNotificationsMonitor:
         results = set(loan_fixture.monitor.item_query().all())
         assert results == {loan_1d, loan_3d, loan_yesterday}
 
-    def test_item_query_bucket_aware_cooldown(
-        self, loan_fixture: LoanNotificationsFixture
-    ):
-        """A loan that has already received its 3-day notification must NOT
-        be selected on subsequent cron runs that still fall inside the same
-        3-day window (regression test for the duplicate-per-bucket bug).
-
-        The 3-day window is `(now+2d, now+3d]` — a sliding 24h slice. A loan
-        ending just past midnight of (today+2d) is inside the window on any
-        cron tick from yesterday's late ticks through today, so the patron
-        could otherwise be notified on both days.
-        """
-        db = loan_fixture.db
-        now = utc_now()
-        today = now.date()
-
-        # End at 00:01 UTC, two calendar days from today.
-        # → loan.end - 3d = yesterday 00:01 UTC, so date(loan.end - 3d) is
-        #   yesterday — i.e. the 3-day bucket opened yesterday.
-        end = datetime.datetime.combine(
-            today + datetime.timedelta(days=2),
-            datetime.time(0, 1),
-            tzinfo=datetime.timezone.utc,
-        )
-        work = db.work(with_license_pool=True)
-        pool = work.active_license_pool()
-        assert pool is not None
-        loan, _ = pool.loan_to(loan_fixture.patron, now, end)
-
-        # Patron was already notified for this loan yesterday — which was
-        # inside the 3-day bucket.
-        loan.patron_last_notified = today - datetime.timedelta(days=1)
-
-        # Without bucket-aware cooldown, this loan would be returned again
-        # today and the patron would receive a duplicate 3-day notification.
-        assert loan not in loan_fixture.monitor.item_query().all()
-
-    def test_item_query_resends_when_loan_enters_next_bucket(
-        self, loan_fixture: LoanNotificationsFixture
-    ):
-        """After the 3-day notification, the loan must be picked up again
-        once it enters the 1-day bucket (different bucket, different msg)."""
-        db = loan_fixture.db
-        now = utc_now()
-
-        # End is 23h out → loan is now in the 1-day bucket.
-        work = db.work(with_license_pool=True)
-        pool = work.active_license_pool()
-        assert pool is not None
-        loan, _ = pool.loan_to(
-            loan_fixture.patron,
-            now,
-            now + datetime.timedelta(hours=23),
-        )
-        # Suppose we sent the 3-day notification 2 days ago. The 1-day
-        # bucket only opens at loan.end - 1d ≈ today, so a 2-day-old
-        # notification is before the 1-day bucket opens → must be sent.
-        loan.patron_last_notified = now.date() - datetime.timedelta(days=2)
-
-        assert loan in loan_fixture.monitor.item_query().all()
-
     def test_run_sends_notifications(self, loan_fixture: LoanNotificationsFixture):
         """The monitor's run() should invoke PushNotifications once per
         eligible loan with the correct (loan, days, tokens) arguments."""

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -99,6 +99,67 @@ class TestLoanNotificationsMonitor:
         results = set(loan_fixture.monitor.item_query().all())
         assert results == {loan_1d, loan_3d, loan_yesterday}
 
+    def test_item_query_bucket_aware_cooldown(
+        self, loan_fixture: LoanNotificationsFixture
+    ):
+        """A loan that has already received its 3-day notification must NOT
+        be selected on subsequent cron runs that still fall inside the same
+        3-day window (regression test for the duplicate-per-bucket bug).
+
+        The 3-day window is `(now+2d, now+3d]` — a sliding 24h slice. A loan
+        ending just past midnight of (today+2d) is inside the window on any
+        cron tick from yesterday's late ticks through today, so the patron
+        could otherwise be notified on both days.
+        """
+        db = loan_fixture.db
+        now = utc_now()
+        today = now.date()
+
+        # End at 00:01 UTC, two calendar days from today.
+        # → loan.end - 3d = yesterday 00:01 UTC, so date(loan.end - 3d) is
+        #   yesterday — i.e. the 3-day bucket opened yesterday.
+        end = datetime.datetime.combine(
+            today + datetime.timedelta(days=2),
+            datetime.time(0, 1),
+            tzinfo=datetime.timezone.utc,
+        )
+        work = db.work(with_license_pool=True)
+        pool = work.active_license_pool()
+        assert pool is not None
+        loan, _ = pool.loan_to(loan_fixture.patron, now, end)
+
+        # Patron was already notified for this loan yesterday — which was
+        # inside the 3-day bucket.
+        loan.patron_last_notified = today - datetime.timedelta(days=1)
+
+        # Without bucket-aware cooldown, this loan would be returned again
+        # today and the patron would receive a duplicate 3-day notification.
+        assert loan not in loan_fixture.monitor.item_query().all()
+
+    def test_item_query_resends_when_loan_enters_next_bucket(
+        self, loan_fixture: LoanNotificationsFixture
+    ):
+        """After the 3-day notification, the loan must be picked up again
+        once it enters the 1-day bucket (different bucket, different msg)."""
+        db = loan_fixture.db
+        now = utc_now()
+
+        # End is 23h out → loan is now in the 1-day bucket.
+        work = db.work(with_license_pool=True)
+        pool = work.active_license_pool()
+        assert pool is not None
+        loan, _ = pool.loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(hours=23),
+        )
+        # Suppose we sent the 3-day notification 2 days ago. The 1-day
+        # bucket only opens at loan.end - 1d ≈ today, so a 2-day-old
+        # notification is before the 1-day bucket opens → must be sent.
+        loan.patron_last_notified = now.date() - datetime.timedelta(days=2)
+
+        assert loan in loan_fixture.monitor.item_query().all()
+
     def test_run_sends_notifications(self, loan_fixture: LoanNotificationsFixture):
         """The monitor's run() should invoke PushNotifications once per
         eligible loan with the correct (loan, days, tokens) arguments."""

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import datetime
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
+
+import pytest
 
 from core.config import Configuration, ConfigurationConstants
-from core.jobs.notifications.loan_expiration_notification import LoanNotificationsScript
+from core.jobs.notifications.loan_expiration_notification import (
+    LoanNotificationsMonitor,
+)
 from core.model import ConfigurationSetting, Work, get_one_or_create
 from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from core.model.patron import Patron
@@ -13,11 +17,14 @@ from core.util.notifications import PushNotifications
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
-class TestLoanNotificationsScript:
-    def _setup_method(self, db: DatabaseTransactionFixture):
-        self.script = LoanNotificationsScript(_db=db.session)
+class LoanNotificationsFixture:
+    def __init__(self, db: DatabaseTransactionFixture) -> None:
+        self.db = db
+        self.monitor = LoanNotificationsMonitor(self.db.session)
         self.patron: Patron = db.patron()
         self.work: Work = db.work(with_license_pool=True)
+        # process_items() skips loans whose patron has no FCM-eligible
+        # device tokens, so the default test patron is given one here.
         self.device_token, _ = get_one_or_create(
             db.session,
             DeviceToken,
@@ -27,87 +34,141 @@ class TestLoanNotificationsScript:
         )
         PushNotifications.TESTING_MODE = True
 
-    def test_loan_notification(self, db: DatabaseTransactionFixture):
-        self._setup_method(db)
-        p = self.work.active_license_pool()
-        if p:  # mypy complains if we don't do this
-            loan, _ = p.loan_to(
-                self.patron,
-                utc_now(),
-                utc_now() + datetime.timedelta(days=1, hours=1),
-            )
 
-        work2 = db.work(with_license_pool=True)
-        loan2, _ = work2.active_license_pool().loan_to(
-            self.patron,
-            utc_now(),
-            utc_now() + datetime.timedelta(days=2, hours=1),
-        )  # Should not get notified
+@pytest.fixture(scope="function")
+def loan_fixture(db: DatabaseTransactionFixture) -> LoanNotificationsFixture:
+    return LoanNotificationsFixture(db)
+
+
+class TestLoanNotificationsMonitor:
+    def test_item_query(self, loan_fixture: LoanNotificationsFixture):
+        """item_query() must select only loans inside the [3d, 1d] expiry
+        windows that have not already been notified today and whose patron
+        is non-null."""
+        db = loan_fixture.db
+        now = utc_now()
+
+        # Inside the 1-day window → selected.
+        loan_1d, _ = loan_fixture.work.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(hours=23),
+        )
+
+        # Inside the 3-day window → selected.
+        work_3d = db.work(with_license_pool=True)
+        loan_3d, _ = work_3d.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(days=2, hours=23),
+        )
+
+        # Outside any window (between 1d and 3d) → NOT selected.
+        work_2d = db.work(with_license_pool=True)
+        work_2d.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(days=1, hours=23),
+        )
+
+        # Inside the 1-day window but already notified today → NOT selected.
+        work_notified = db.work(with_license_pool=True)
+        loan_notified, _ = work_notified.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(hours=22),
+        )
+        loan_notified.patron_last_notified = now.date()
+
+        # Inside the 1-day window, notified yesterday → selected.
+        work_yesterday = db.work(with_license_pool=True)
+        loan_yesterday, _ = work_yesterday.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(hours=21),
+        )
+        loan_yesterday.patron_last_notified = now.date() - datetime.timedelta(days=1)
+
+        results = set(loan_fixture.monitor.item_query().all())
+        assert results == {loan_1d, loan_3d, loan_yesterday}
+
+    def test_run_sends_notifications(
+        self, loan_fixture: LoanNotificationsFixture
+    ):
+        """The monitor's run() should invoke PushNotifications once per
+        eligible loan with the correct (loan, days, tokens) arguments."""
+        db = loan_fixture.db
+        now = utc_now()
+        loan_1d, _ = loan_fixture.work.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(hours=23),
+        )
+
+        work_3d = db.work(with_license_pool=True)
+        loan_3d, _ = work_3d.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(days=2, hours=23),
+        )
 
         with patch(
             "core.jobs.notifications.loan_expiration_notification.PushNotifications"
         ) as mock_notf:
-            self.script.process_loan(loan)
-            self.script.process_loan(loan2)
+            loan_fixture.monitor.run()
 
-        assert mock_notf.send_loan_expiry_message.call_count == 1
-        assert mock_notf.send_loan_expiry_message.call_args[0] == (
-            loan,
-            1,
-            [self.device_token],
-        )
-
-    def test_do_run(self, db: DatabaseTransactionFixture):
-        now = utc_now()
-        self._setup_method(db)
-        loan, _ = self.work.active_license_pool().loan_to(  # type: ignore
-            self.patron,
-            now,
-            now + datetime.timedelta(days=1, hours=1),
-        )
-
-        work2 = db.work(with_license_pool=True)
-        loan2, _ = work2.active_license_pool().loan_to(
-            self.patron,
-            now,
-            now + datetime.timedelta(days=2, hours=1),
-        )
-
-        work3 = db.work(with_license_pool=True)
-        p = work3.active_license_pool()
-        loan3, _ = p.loan_to(
-            self.patron,
-            now,
-            now + datetime.timedelta(days=1, hours=1),
-        )
-        # loan 3 was notified today already, so should get skipped
-        loan3.patron_last_notified = now.date()
-
-        work4 = db.work(with_license_pool=True)
-        p = work4.active_license_pool()
-        loan4, _ = p.loan_to(
-            self.patron,
-            now,
-            now + datetime.timedelta(days=1, hours=1),
-        )
-        # loan 4 was notified yesterday, so should NOT get skipped
-        loan4.patron_last_notified = now.date() - datetime.timedelta(days=1)
-
-        self.script.process_loan = MagicMock()
-        self.script.BATCH_SIZE = 1
-        self.script.do_run()
-
-        assert self.script.process_loan.call_count == 3
-        assert self.script.process_loan.call_args_list == [
-            call(loan),
-            call(loan2),
-            call(loan4),
+        assert mock_notf.send_loan_expiry_message.call_count == 2
+        # Order within the batch is by Loan.id (the sweep ordering): loan_1d
+        # is processed first with 1 day remaining, then loan_3d with 3 days.
+        assert mock_notf.send_loan_expiry_message.call_args_list == [
+            call(loan_1d, 1, [loan_fixture.device_token]),
+            call(loan_3d, 3, [loan_fixture.device_token]),
         ]
 
-        # Sitewide notifications are turned off
-        self.script.process_loan.reset_mock()
+    def test_run_skipped_when_kill_switch_off(
+        self, loan_fixture: LoanNotificationsFixture
+    ):
+        """Sitewide PUSH_NOTIFICATIONS_STATUS=FALSE must short-circuit run()
+        before any loan processing happens."""
+        db = loan_fixture.db
+        now = utc_now()
+        loan_fixture.work.active_license_pool().loan_to(
+            loan_fixture.patron,
+            now,
+            now + datetime.timedelta(hours=23),
+        )
         ConfigurationSetting.sitewide(
             db.session, Configuration.PUSH_NOTIFICATIONS_STATUS
         ).value = ConfigurationConstants.FALSE
-        self.script.do_run()
-        assert self.script.process_loan.call_count == 0
+
+        with patch(
+            "core.jobs.notifications.loan_expiration_notification.PushNotifications"
+        ) as mock_notf:
+            loan_fixture.monitor.run()
+
+        assert mock_notf.send_loan_expiry_message.call_count == 0
+
+    def test_process_items_skips_loans_without_fcm_tokens(
+        self, loan_fixture: LoanNotificationsFixture
+    ):
+        """A loan whose patron has no FCM-eligible device tokens must be
+        skipped silently. Only FCM_ANDROID and FCM_IOS are valid token
+        types in the DB schema, so 'no FCM tokens' means 'no device
+        tokens at all'."""
+        db = loan_fixture.db
+        other_patron = db.patron()
+        # No device tokens for this patron at all.
+        now = utc_now()
+        work = db.work(with_license_pool=True)
+        loan, _ = work.active_license_pool().loan_to(
+            other_patron,
+            now,
+            now + datetime.timedelta(hours=23),
+        )
+
+        with patch(
+            "core.jobs.notifications.loan_expiration_notification.PushNotifications"
+        ) as mock_notf:
+            loan_fixture.monitor.process_items([loan])
+
+        assert mock_notf.send_loan_expiry_message.call_count == 0

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -23,6 +23,13 @@ class LoanNotificationsFixture:
         self.monitor = LoanNotificationsMonitor(self.db.session)
         self.patron: Patron = db.patron()
         self.work: Work = db.work(with_license_pool=True)
+        # Cache the LicensePool to avoid `Optional` typing fights at each
+        # call site: `Work.active_license_pool()` is typed as
+        # `LicensePool | None`, but we know it exists because we just
+        # created the work with `with_license_pool=True`.
+        pool = self.work.active_license_pool()
+        assert pool is not None
+        self.pool = pool
         # process_items() skips loans whose patron has no FCM-eligible
         # device tokens, so the default test patron is given one here.
         self.device_token, _ = get_one_or_create(
@@ -49,7 +56,7 @@ class TestLoanNotificationsMonitor:
         now = utc_now()
 
         # Inside the 1-day window → selected.
-        loan_1d, _ = loan_fixture.work.active_license_pool().loan_to(
+        loan_1d, _ = loan_fixture.pool.loan_to(
             loan_fixture.patron,
             now,
             now + datetime.timedelta(hours=23),
@@ -97,7 +104,7 @@ class TestLoanNotificationsMonitor:
         eligible loan with the correct (loan, days, tokens) arguments."""
         db = loan_fixture.db
         now = utc_now()
-        loan_1d, _ = loan_fixture.work.active_license_pool().loan_to(
+        loan_1d, _ = loan_fixture.pool.loan_to(
             loan_fixture.patron,
             now,
             now + datetime.timedelta(hours=23),
@@ -130,7 +137,7 @@ class TestLoanNotificationsMonitor:
         before any loan processing happens."""
         db = loan_fixture.db
         now = utc_now()
-        loan_fixture.work.active_license_pool().loan_to(
+        loan_fixture.pool.loan_to(
             loan_fixture.patron,
             now,
             now + datetime.timedelta(hours=23),

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -92,9 +92,7 @@ class TestLoanNotificationsMonitor:
         results = set(loan_fixture.monitor.item_query().all())
         assert results == {loan_1d, loan_3d, loan_yesterday}
 
-    def test_run_sends_notifications(
-        self, loan_fixture: LoanNotificationsFixture
-    ):
+    def test_run_sends_notifications(self, loan_fixture: LoanNotificationsFixture):
         """The monitor's run() should invoke PushNotifications once per
         eligible loan with the correct (loan, days, tokens) arguments."""
         db = loan_fixture.db

--- a/tests/core/jobs/notifications/test_user_survey_notification.py
+++ b/tests/core/jobs/notifications/test_user_survey_notification.py
@@ -7,6 +7,7 @@ from core.jobs.notifications.user_survey_notification import (
     UserSurveyNotificationScript,
 )
 from core.model.configuration import ConfigurationSetting
+from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
@@ -15,6 +16,25 @@ class UserSurveyNotificationFixture:
         self.db = db
         self.monitor = UserSurveyNotificationScript(self.db.session)
 
+    def patrons_with_tokens(self, count: int):
+        """Create `count` patrons, each with one FCM token.
+
+        The monitor's item_query() uses an EXISTS subquery to skip patrons
+        without an FCM-eligible token, so every patron in these tests must
+        own one or they won't show up in the sweep.
+        """
+        patrons = []
+        for i in range(count):
+            patron = self.db.patron()
+            DeviceToken.create(
+                self.db.session,
+                DeviceTokenTypes.FCM_ANDROID,
+                f"token-{patron.id}",
+                patron,
+            )
+            patrons.append(patron)
+        return patrons
+
 
 @pytest.fixture(scope="function")
 def survey_fixture(db: DatabaseTransactionFixture) -> UserSurveyNotificationFixture:
@@ -22,30 +42,45 @@ def survey_fixture(db: DatabaseTransactionFixture) -> UserSurveyNotificationFixt
 
 
 class TestUserSurveyNotification:
-    def test_item_query(self, survey_fixture: UserSurveyNotificationFixture):
-        """Check that item_query() finds all patrons in the database."""
+    def test_item_query_filters_patrons_without_fcm_tokens(
+        self, survey_fixture: UserSurveyNotificationFixture
+    ):
+        """Only patrons with at least one FCM token should be returned."""
         db = survey_fixture.db
-        patrons = [db.patron() for _ in range(1000)]
+        with_tokens = survey_fixture.patrons_with_tokens(3)
+        # These patrons should be filtered out by the EXISTS subquery.
+        db.patron()
+        db.patron()
 
+        results = set(survey_fixture.monitor.item_query().all())
+        assert results == set(with_tokens)
+
+    def test_item_query_finds_all_patrons_with_tokens(
+        self, survey_fixture: UserSurveyNotificationFixture
+    ):
+        """Sanity-check at scale: the query should return every patron that
+        owns an FCM token."""
+        survey_fixture.patrons_with_tokens(1000)
         assert survey_fixture.monitor.item_query().count() == 1000
 
     def test_script_run(self, survey_fixture: UserSurveyNotificationFixture):
-        """Test that a large amount of patrons are processed in batches."""
+        """A large number of patrons must be processed in batches sized by
+        the DEFAULT_BATCH_SIZE on this monitor (25)."""
         db = survey_fixture.db
-        # Create a list of 1000 patrons
-        patrons = [db.patron() for _ in range(1000)]
+        survey_fixture.patrons_with_tokens(1000)
 
         with patch(
             "core.jobs.notifications.user_survey_notification.PushNotifications"
         ) as mock_notf:
             survey_fixture.monitor.run()
-            # The patrons are handled in batches of 100
-            assert mock_notf.send_user_survey_message.call_count == 10
+            # 1000 patrons / 25 batch size = 40 calls.
+            assert mock_notf.send_user_survey_message.call_count == 40
 
-            # Sanity check with Sitewide notifications turned off
+            # Sanity check: sitewide kill switch turns the whole run off.
             mock_notf.send_user_survey_message.reset_mock()
             ConfigurationSetting.sitewide(
                 db.session, Configuration.PUSH_NOTIFICATIONS_STATUS
             ).value = ConfigurationConstants.FALSE
             survey_fixture.monitor.run()
             assert mock_notf.send_user_survey_message.call_count == 0
+

--- a/tests/core/jobs/notifications/test_user_survey_notification.py
+++ b/tests/core/jobs/notifications/test_user_survey_notification.py
@@ -83,4 +83,3 @@ class TestUserSurveyNotification:
             ).value = ConfigurationConstants.FALSE
             survey_fixture.monitor.run()
             assert mock_notf.send_user_survey_message.call_count == 0
-

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -152,16 +152,20 @@ class TestPushNotifications:
             "core.util.notifications.PushNotifications.send_messages"
         ) as mock_send, mock.patch("core.util.notifications.utc_now") as mock_now:
             # Loan expiry
-            # No messages sent
+            # patron_last_notified is now updated unconditionally — even when
+            # send_messages returns no successful responses (e.g. all tokens
+            # were unregistered) — so we don't re-attempt the same loan on the
+            # next sweep run within the same day.
+            mock_now.return_value = datetime(2020, 1, 1, tzinfo=pytz.UTC)
             mock_send.return_value = []
             responses = PushNotifications.send_loan_expiry_message(
                 loan, 1, [device_token]
             )
             assert responses == []
-            assert loan.patron_last_notified == None
+            assert loan.patron_last_notified == datetime(2020, 1, 1).date()
 
-            # One message sent
-            mock_now.return_value = datetime(2020, 1, 1, tzinfo=pytz.UTC)
+            # Reset so we can verify the success path also updates the field.
+            loan.patron_last_notified = None
             mock_send.return_value = ["mock-mid"]
             responses = PushNotifications.send_loan_expiry_message(
                 loan, 1, [device_token]
@@ -170,12 +174,14 @@ class TestPushNotifications:
             # last notified gets updated
             assert loan.patron_last_notified == datetime(2020, 1, 1).date()
 
-            # Now hold expiry
+            # Now hold expiry — same contract: update happens regardless of
+            # whether any FCM send actually succeeded.
             mock_send.return_value = []
             responses = PushNotifications.send_holds_notifications([hold])
             assert responses == []
-            assert hold.patron_last_notified == None
+            assert hold.patron_last_notified == datetime(2020, 1, 1).date()
 
+            hold.patron_last_notified = None
             mock_send.return_value = ["mock-mid"]
             responses = PushNotifications.send_holds_notifications([hold])
             assert responses == ["mock-mid"]


### PR DESCRIPTION
## Description
This pull request refactors and improves the notification jobs for holds, loan expirations, and user surveys. The main goals are to make the jobs more efficient, reduce unnecessary database queries, and ensure that notifications are only sent to patrons with eligible device tokens. Additionally, it standardizes batch sizes for notification jobs, improves logging, and optimizes how batches are processed to avoid missing or duplicating work.

- **What does this PR do?**

<!--- Provide a brief summary of the changes made in this PR. -->
**Notification job improvements:**

* Refactored `LoanNotificationsScript` to `LoanNotificationsMonitor`, inheriting from `SweepMonitor` for consistency with other notification jobs, and updated the logic to select loans expiring soon using more accurate time windows. Also, now only processes loans with eligible device tokens and improves eager loading to avoid N+1 queries. [[1]](diffhunk://#diff-866b80064f569ed54c64625ec84c6ada275fc008990f50ad45d3347450b71f30R4-R36) [[2]](diffhunk://#diff-866b80064f569ed54c64625ec84c6ada275fc008990f50ad45d3347450b71f30L35-R139)
* Updated `HoldsNotificationMonitor` to filter holds by patrons with FCM-eligible device tokens using a correlated `EXISTS` subquery, and added eager loading for related objects to reduce database queries. [[1]](diffhunk://#diff-3521fb0685c7bdbcb0324f5c287a262de816440a71860a403d0a192b4b0f326bL5-R13) [[2]](diffhunk://#diff-3521fb0685c7bdbcb0324f5c287a262de816440a71860a403d0a192b4b0f326bL43-R85)
* Modified `UserSurveyNotificationScript` to only select patrons with FCM-eligible device tokens and use `selectinload` for efficient loading of device tokens. [[1]](diffhunk://#diff-12085ccbe5550137cbb3f18a68fd2245e299bffe9122c4bb04a926780c2a6698L3-R8) [[2]](diffhunk://#diff-12085ccbe5550137cbb3f18a68fd2245e299bffe9122c4bb04a926780c2a6698L32-R56)

**Batch processing and performance:**

* Standardized `DEFAULT_BATCH_SIZE = 25` for all notification jobs to limit memory and network I/O per batch, replacing the previous default of 100. [[1]](diffhunk://#diff-3521fb0685c7bdbcb0324f5c287a262de816440a71860a403d0a192b4b0f326bR29-R34) [[2]](diffhunk://#diff-866b80064f569ed54c64625ec84c6ada275fc008990f50ad45d3347450b71f30R4-R36) [[3]](diffhunk://#diff-12085ccbe5550137cbb3f18a68fd2245e299bffe9122c4bb04a926780c2a6698R20-R23)
* Improved batch processing in `SweepMonitor` to use `max(id)` for the next offset, ensuring batches are not skipped or duplicated due to row ordering changes from joins or `DISTINCT`.
* Optimized deletion loops in `SweepMonitor` to avoid expensive `.count()` calls on each iteration, improving performance on large tables.

**Logging and notification sending:**

* Reduced log verbosity for per-device push notification attempts from `INFO` to `DEBUG`, and added summary info logs for each batch of notifications sent. [[1]](diffhunk://#diff-2e241d69a9684925c3ecbacf9a4a76163873c49e1817d7e67a265fee717d01c1L82-R90) [[2]](diffhunk://#diff-2e241d69a9684925c3ecbacf9a4a76163873c49e1817d7e67a265fee717d01c1R106-R107)
* Changed notification logic to always update the `patron_last_notified` field, even if sending fails, to avoid repeated notifications on transient errors. [[1]](diffhunk://#diff-2e241d69a9684925c3ecbacf9a4a76163873c49e1817d7e67a265fee717d01c1L144-R148) [[2]](diffhunk://#diff-2e241d69a9684925c3ecbacf9a4a76163873c49e1817d7e67a265fee717d01c1L186-R190)
* Fixed a bug in user survey notifications where processing would stop entirely if a patron had no tokens; now it continues to the next patron.

These changes collectively make the notification system more robust, efficient, and scalable.

- **Why is this change necessary?**

<!--- Explain the rationale behind the changes. What problem does it solve or what feature does it add? -->
Sending the notifications caused some hick ups in our service on a daily basis and made the service unavailable.

## Changes Made

<!-- List all changes -->

## How was this tested?

<!--- Describe the testing strategy used (unit tests, integration tests, manual testing, etc.). -->
<!--- Include any relevant test cases or scenarios that were tested. -->
Locally tested.

## Was AI used in the process of making this pr?

<!--- If AI was used during the process, describe how. -->
AI analyzed the problems, made performance improvement suggestions and implemented the highest value, low effort changes. The long-term improvement of implementing parallel and asynchronous processing (redis, celery) remains as future improvements.
AI also made all git commits.

## QA Testing

- **How should QA test this change?**

    - **Environment Setup:**
    Basic backend setup. Define loan period to 3 days (3 days being the first time a patron should get a notification of expiring loans). Connect web to local backend, connect mobile app to local backend.
Because we don't have FCM credentials set in our dev environment, comment out line 143-145 in `notifications.py` and return `[]` so that the code does not try to send a message and continues on updating the `loan.patron_last_notified`.

    - **Test Cases:**

      1. **Test case 1: loan via web**
       Loan a book via web. Run the `loan_notification` script in the `scripts` container. Check the log. You should see that there are no loans to process.
You can also see the new Loan Expiration Notification job in the `http://localhost:6500/admin/web/troubleshooting/diagnostics/monitor`.
In the database, view the loans data and see that the `patron_last_notified` date is empty.
       
      2. **Test case 2: loan via mobile, 3 days to loan expiration date**
      Loan a book via mobile, use another user account. Run the `loan_notification` script in the `scripts` container. Check the log. You should see the log about successful message sent.
In the database, view the loans data and see that the `patron_last_notified` date is today's.
Rerun the script. You shouldn't see the successful message sent log.

      3. **Test case3 (Optional): 2 days before loan expiration date**
      Wait until the next day. The loan notification script is run daily, and because it should only send notifications 1 and 3 days before loan expiration, check the log to confirm that it does not log the successful sent notification 2 days before the loan expires.
In the database, view the loans data and see that the `patron_last_notified` date is yesterday.


## Is there any relevant documentation updated?

<!--- Link or describe if there's any updated or new documentation (e.g., Kupoli, README, etc.). -->

### Checklist

- [ ] Translations updated / Translators notified if applicable
- [ ] AI was used during the process and I have described above how.
