### PR TITLE
Skip DRMs set in ODL2 collection settings

### DIFF
--- a/api/odl2.py
+++ b/api/odl2.py
@@ -49,6 +49,21 @@ class ODL2Settings(ODLSettings, OPDS2ImporterSettings):
         ),
     )
 
+    skipped_drm_schemes: list[str] = FormField(
+        default=[],
+        alias="odl2_skipped_drm_schemes",
+        form=ConfigurationFormItem(
+            label=_("Skipped DRM schemes"),
+            description=_(
+                "List of DRM schemes (from the license's protection.format) that "
+                "will NOT be imported into Circulation Manager. "
+                "Example: application/vnd.adobe.adept+xml"
+            ),
+            type=ConfigurationFormItemType.LIST,
+            required=False,
+        ),
+    )
+
     loan_limit: PositiveInt | None = FormField(
         default=None,
         alias="odl2_loan_limit",
@@ -198,6 +213,7 @@ class ODL2Importer(BaseODLImporter[ODL2Settings], OPDS2Importer):
         # E-Kirjasto: If this is a generic OPDS2 publication, it is an open-access title.
         if isinstance(publication, odl.Publication):
             skipped_license_formats = set(self.settings.skipped_license_formats)
+            skipped_drm_schemes = set(self.settings.skipped_drm_schemes)
             publication_availability = publication.metadata.availability.available
 
             for odl_license in publication.licenses:
@@ -275,6 +291,8 @@ class ODL2Importer(BaseODLImporter[ODL2Settings], OPDS2Importer):
                         )
 
                     for drm_scheme in drm_schemes or [None]:
+                        if drm_scheme in skipped_drm_schemes:
+                            continue
                         formats.append(
                             FormatData(
                                 content_type=license_format,
@@ -290,6 +308,17 @@ class ODL2Importer(BaseODLImporter[ODL2Settings], OPDS2Importer):
             metadata.circulation.patrons_in_hold_queue = None
             metadata.circulation.formats.extend(formats)
             metadata.medium = medium
+
+        # Filter out any FormatData (including those produced by the base
+        # OPDS2 importer from acquisition links) whose DRM scheme has been
+        # configured to be skipped.
+        skipped_drm_schemes = set(self.settings.skipped_drm_schemes)
+        if skipped_drm_schemes:
+            metadata.circulation.formats = [
+                format_data
+                for format_data in metadata.circulation.formats
+                if format_data.drm_scheme not in skipped_drm_schemes
+            ]
 
         return metadata
 

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 from api.circulation_exceptions import PatronHoldLimitReached, PatronLoanLimitReached
 from api.odl2 import ODL2HoldQueueReaper, ODL2HoldReaper, ODL2Importer, ODL2LoanReaper
 from core.coverage import CoverageFailure
+from core.integration.base import integration_settings_load
 from core.model import (
     Collection,
     Contribution,
@@ -64,6 +65,79 @@ class TestODL2Importer:
                 return mechanism
 
         return None
+
+    @pytest.mark.parametrize(
+        "skipped_drm,expected_drms",
+        [
+            pytest.param(
+                [DeliveryMechanism.ADOBE_DRM],
+                {DeliveryMechanism.LCP_DRM},
+                id="skip-adobe",
+            ),
+            pytest.param(
+                [DeliveryMechanism.LCP_DRM],
+                {DeliveryMechanism.ADOBE_DRM},
+                id="skip-lcp",
+            ),
+            pytest.param(
+                [DeliveryMechanism.ADOBE_DRM, DeliveryMechanism.LCP_DRM],
+                set(),
+                id="skip-both",
+            ),
+            pytest.param(
+                [],
+                {DeliveryMechanism.ADOBE_DRM, DeliveryMechanism.LCP_DRM},
+                id="skip-none",
+            ),
+        ],
+    )
+    @freeze_time("2016-01-01T00:00:00+00:00")
+    def test_import_skipped_drm_schemes(
+        self,
+        odl2_importer: ODL2Importer,
+        odl_mock_get: MockGet,
+        api_odl_files_fixture: ODLAPIFilesFixture,
+        skipped_drm: list[str],
+        expected_drms: set[str],
+    ) -> None:
+        """Delivery mechanisms whose DRM scheme is listed in
+        ``skipped_drm_schemes`` must not be imported."""
+        moby_dick_license = LicenseInfoHelper(
+            license=LicenseHelper(
+                identifier="urn:uuid:f7847120-fc6f-11e3-8158-56847afe9799",
+                concurrency=10,
+                checkouts=30,
+                expires="2016-04-25T12:25:21+02:00",
+            ),
+            left=30,
+            available=10,
+        )
+        odl_mock_get.add(moby_dick_license)
+        feed = api_odl_files_fixture.sample_text("feed.json")
+
+        config = odl2_importer.collection.integration_configuration
+        odl2_importer.ignored_identifier_types = [IdentifierConstants.URI]
+        DatabaseTransactionFixture.set_settings(
+            config,
+            odl2_skipped_license_formats=["text/html"],
+            odl2_skipped_drm_schemes=skipped_drm,
+        )
+        # ``self.settings`` is cached on the importer at construction time
+        # (and the pydantic model is frozen), so reload it from the updated
+        # integration configuration to reflect the test configuration.
+        odl2_importer.settings = integration_settings_load(
+            odl2_importer.settings_class(), config
+        )
+
+        _, pools, _, _ = odl2_importer.import_from_feed(feed)
+
+        [pool] = pools
+        actual_drms = {
+            lpdm.delivery_mechanism.drm_scheme
+            for lpdm in pool.delivery_mechanisms
+            if lpdm.delivery_mechanism.content_type == MediaTypes.EPUB_MEDIA_TYPE
+        }
+        assert actual_drms == expected_drms
 
     @freeze_time("2016-01-01T00:00:00+00:00")
     def test_import(


### PR DESCRIPTION
This pull request introduces a new configuration option to allow skipping the import of specific DRM schemes in the ODL2 importer. This feature is implemented by filtering out formats with DRM schemes listed in the new setting, and it is thoroughly tested with new parameterized tests. The main changes are as follows:

### Feature: Skipping Specific DRM Schemes

* Added a new `skipped_drm_schemes` setting to `ODL2Settings`, allowing configuration of DRM schemes (by MIME type) that should not be imported into Circulation Manager. (`api/odl2.py`)
* Updated the `_extract_publication_metadata` method to filter out any `FormatData` entries whose DRM scheme is in the skipped list, both during license processing and after all formats are collected. (`api/odl2.py`) [[1]](diffhunk://#diff-5a2bf2262c2da46636a14c82f6df67e9427e7bcfa7fa788c230a7302d1c0200aR216) [[2]](diffhunk://#diff-5a2bf2262c2da46636a14c82f6df67e9427e7bcfa7fa788c230a7302d1c0200aR294-R295) [[3]](diffhunk://#diff-5a2bf2262c2da46636a14c82f6df67e9427e7bcfa7fa788c230a7302d1c0200aR312-R322)

### Testing

* Added a new parameterized test `test_import_skipped_drm_schemes` to verify that delivery mechanisms with skipped DRM schemes are not imported, covering various combinations of skipped schemes. (`tests/api/test_odl2.py`)
* Ensured that integration settings are reloaded in the test to reflect changes to the skipped DRM schemes configuration. (`tests/api/test_odl2.py`)

- **Why is this change necessary?**

<!--- Explain the rationale behind the changes. What problem does it solve or what feature does it add? -->
De Marque feed contains Adobe DRM but we would like to ignore them. This code change enables an admin to define any DRM to be skipped.

## How was this tested?

<!--- Describe the testing strategy used (unit tests, integration tests, manual testing, etc.). -->
<!--- Include any relevant test cases or scenarios that were tested. -->
Locally and unit tests.

## Was AI used in the process of making this pr?

<!--- If AI was used during the process, describe how. -->
Implemented the needed code changes and unit test and PR description (partially).

## QA Testing

- **How should QA test this change?**

    - **Environment Setup:**
    Basic backend setup with two collections.
Go to pgadmin and make a query that shows each book and their delivery mechanisms and content types. I'll communicate the query in slack. You should see that there are Adobe DRMs and LCP DRMs and all available content types.

    - **Test Cases:**

      1. **Test case 1:**
      Go to the admin UI and open settings of a collection. In the Optional Fields, you should see a new field `Skipped DRM schemes`. Add the Adobe DRM and save.
Run `odl2_import_monitor` in the scripts container. Run the same sql query and see that the Adobe DRMs have been removed and LCP DRM is still availble in addition to De Marque audio specific DRM.

    - **Regression Testing:**

## Is there any relevant documentation updated?

<!--- Link or describe if there's any updated or new documentation (e.g., Kupoli, README, etc.). -->
N/A

### Checklist

- [ ] Translations updated / Translators notified if applicable
- [ ] AI was used during the process and I have described above how.
