### PR TITLE
Fix/notification cooldowns

### DIFF
--- a/core/jobs/notifications/holds_notification.py
+++ b/core/jobs/notifications/holds_notification.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import and_, exists, or_
+from sqlalchemy import and_, exists, func, or_
 from sqlalchemy.orm import joinedload
 
 from core.config import Configuration, ConfigurationConstants
@@ -68,10 +69,16 @@ class HoldsNotificationMonitor(SweepMonitor):
             .filter(
                 # Only holds ready for checkout.
                 Hold.position == 0,
-                # Cooldown: skip patrons already notified today for this hold.
+                # Cooldown: at most one notification per calendar day per hold.
+                # We compare on the date portion only (func.date) so legacy
+                # rows that stored a full timestamp in patron_last_notified
+                # still get normalized to a calendar date. Using `<` (not
+                # `!=`) guarantees we never re-notify a patron whose
+                # last-notified date is today, even if a clock skew or a
+                # legacy row produces an unexpected value.
                 or_(
                     Hold.patron_last_notified == None,
-                    Hold.patron_last_notified != utc_now().date(),
+                    func.date(Hold.patron_last_notified) < utc_now().date(),
                 ),
                 # Skip patrons with no FCM-eligible device tokens.
                 has_fcm_token,
@@ -91,4 +98,20 @@ class HoldsNotificationMonitor(SweepMonitor):
         return query
 
     def process_items(self, items: list[Hold]) -> None:
-        PushNotifications.send_holds_notifications(items)
+        # Race-safety re-check in Python: between the SQL fetch and now,
+        # another worker (or an earlier batch in the same run) could have
+        # already notified this patron today. Re-filter on the same
+        # calendar-day cooldown the SQL filter uses so we never send a
+        # second push on the same day.
+        today = utc_now().date()
+        eligible: list[Hold] = []
+        for hold in items:
+            last_notified = hold.patron_last_notified
+            if isinstance(last_notified, datetime.datetime):
+                # Legacy DB rows may carry a datetime; normalize to date.
+                last_notified = last_notified.date()
+            if last_notified is not None and last_notified >= today:
+                continue
+            eligible.append(hold)
+        if eligible:
+            PushNotifications.send_holds_notifications(eligible)

--- a/core/jobs/notifications/holds_notification.py
+++ b/core/jobs/notifications/holds_notification.py
@@ -106,10 +106,13 @@ class HoldsNotificationMonitor(SweepMonitor):
         today = utc_now().date()
         eligible: list[Hold] = []
         for hold in items:
-            last_notified = hold.patron_last_notified
-            if isinstance(last_notified, datetime.datetime):
+            raw = hold.patron_last_notified
+            last_notified: datetime.date | None
+            if isinstance(raw, datetime.datetime):
                 # Legacy DB rows may carry a datetime; normalize to date.
-                last_notified = last_notified.date()
+                last_notified = raw.date()
+            else:
+                last_notified = raw
             if last_notified is not None and last_notified >= today:
                 continue
             eligible.append(hold)

--- a/core/jobs/notifications/loan_expiration_notification.py
+++ b/core/jobs/notifications/loan_expiration_notification.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import math
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import joinedload
 
 from core.config import Configuration, ConfigurationConstants
@@ -57,28 +57,31 @@ class LoanNotificationsMonitor(SweepMonitor):
         # correct than date-equality (`Loan.end == today + N days`), which
         # would only match loans ending at exactly midnight on the target day.
         now = utc_now()
-        today = now.date()
-        # One clause per notification day. Window is right-closed / left-open
-        # so a loan can't be picked up by two windows on the same run.
-        expiry_clauses = [
-            and_(
+        # One clause per notification day. Each clause pairs a 24h expiry
+        # window with a bucket-aware cooldown: we only send the N-day
+        # notification once per loan, even if the sliding window contains the
+        # loan across two consecutive calendar days. The N-day bucket "opens"
+        # on date(loan.end - N days); once patron_last_notified is on or
+        # after that date, the N-day message has already been sent.
+        bucket_clauses = []
+        for days in self.LOAN_EXPIRATION_DAYS:
+            window = and_(
                 Loan.end <= now + datetime.timedelta(days=days),
                 Loan.end > now + datetime.timedelta(days=days - 1),
             )
-            for days in self.LOAN_EXPIRATION_DAYS
-        ]
+            cooldown = or_(
+                Loan.patron_last_notified == None,
+                Loan.patron_last_notified
+                < func.date(Loan.end - datetime.timedelta(days=days)),
+            )
+            bucket_clauses.append(and_(window, cooldown))
         query = (
             super()
             .item_query()
             .filter(
-                # Cooldown: skip loans already notified today. NULL means
-                # "never notified", which still qualifies.
-                or_(
-                    Loan.patron_last_notified == None,
-                    Loan.patron_last_notified != today,
-                ),
-                # Loan must be in one of the expiry windows.
-                or_(*expiry_clauses),
+                # Loan must be in one of the expiry buckets and not yet
+                # notified for that bucket.
+                or_(*bucket_clauses),
                 # Defensive: orphan loans without a patron would crash later
                 # when we dereference `loan.patron`. Filter them out in SQL.
                 Loan.patron_id != None,
@@ -129,11 +132,21 @@ class LoanNotificationsMonitor(SweepMonitor):
             # Belt-and-suspenders: SQL `now` and Python `now` differ slightly,
             # so a loan right on a boundary could compute a different bucket
             # in Python than SQL selected. Skip those.
-            if days in self.LOAN_EXPIRATION_DAYS:
-                self.log.info(
-                    f"Patron {patron.authorization_identifier} has an expiring loan on "
-                    f"({loan.license_pool.identifier.urn})"
-                )
-                # send_loan_expiry_message also sets loan.patron_last_notified;
-                # SweepMonitor.run_once commits after every batch.
-                PushNotifications.send_loan_expiry_message(loan, days, tokens)
+            if days not in self.LOAN_EXPIRATION_DAYS:
+                continue
+            # Re-check the bucket-aware cooldown in Python in case another
+            # worker notified this patron between the SQL fetch and now.
+            bucket_open = (loan.end - datetime.timedelta(days=days)).date()
+            last_notified = loan.patron_last_notified
+            if isinstance(last_notified, datetime.datetime):
+                # Legacy DB rows may still carry a datetime; normalize.
+                last_notified = last_notified.date()
+            if last_notified is not None and last_notified >= bucket_open:
+                continue
+            self.log.info(
+                f"Patron {patron.authorization_identifier} has an expiring loan on "
+                f"({loan.license_pool.identifier.urn})"
+            )
+            # send_loan_expiry_message also sets loan.patron_last_notified;
+            # SweepMonitor.run_once commits after every batch.
+            PushNotifications.send_loan_expiry_message(loan, days, tokens)

--- a/core/jobs/notifications/loan_expiration_notification.py
+++ b/core/jobs/notifications/loan_expiration_notification.py
@@ -137,10 +137,13 @@ class LoanNotificationsMonitor(SweepMonitor):
             # Re-check the bucket-aware cooldown in Python in case another
             # worker notified this patron between the SQL fetch and now.
             bucket_open = (loan.end - datetime.timedelta(days=days)).date()
-            last_notified = loan.patron_last_notified
-            if isinstance(last_notified, datetime.datetime):
+            raw = loan.patron_last_notified
+            last_notified: datetime.date | None
+            if isinstance(raw, datetime.datetime):
                 # Legacy DB rows may still carry a datetime; normalize.
-                last_notified = last_notified.date()
+                last_notified = raw.date()
+            else:
+                last_notified = raw
             if last_notified is not None and last_notified >= bucket_open:
                 continue
             self.log.info(

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -190,6 +190,11 @@ class PushNotifications(LoggerMixin):
             # cause the same patron to be re-notified on the next run.
             hold.patron_last_notified = utc_now().date()
 
+            cls.logger().info(
+                f"Sent hold available notification to patron {hold.patron.authorization_identifier} for hold {hold.id} with {len(tokens)} tokens. "
+                f"Updated patron_last_notified for hold {hold.id} to {hold.patron_last_notified}. "
+            )
+
             responses.extend(resp)
 
         return responses

--- a/tests/core/jobs/notifications/test_holds_notifications.py
+++ b/tests/core/jobs/notifications/test_holds_notifications.py
@@ -125,9 +125,7 @@ class TestHoldsNotifications:
         hold_eligible, _ = work_eligible.active_license_pool().on_hold_to(
             patron, position=0
         )
-        hold_raced, _ = work_raced.active_license_pool().on_hold_to(
-            patron, position=0
-        )
+        hold_raced, _ = work_raced.active_license_pool().on_hold_to(patron, position=0)
         # Simulate the race: another worker already notified for hold_raced.
         hold_raced.patron_last_notified = utc_now().date()
 

--- a/tests/core/jobs/notifications/test_holds_notifications.py
+++ b/tests/core/jobs/notifications/test_holds_notifications.py
@@ -91,3 +91,71 @@ class TestHoldsNotifications:
             ).value = ConfigurationConstants.FALSE
             holds_fixture.monitor.run()
             assert mock_notf.send_holds_notifications.call_count == 0
+
+    def test_item_query_skips_legacy_datetime_notified_today(
+        self, holds_fixture: HoldsNotificationFixture
+    ):
+        """Regression: legacy rows whose `patron_last_notified` is a full
+        timestamp later than midnight today must still be filtered out by
+        the cooldown. The SQL filter uses `func.date(...) < today` so any
+        non-midnight value collected today is normalized to today's date
+        and excluded."""
+        db = holds_fixture.db
+        patron = holds_fixture.patron_with_token()
+        work = db.work(with_license_pool=True)
+        hold, _ = work.active_license_pool().on_hold_to(patron, position=0)
+        # Simulate a legacy/raw timestamp stored mid-day today.
+        hold.patron_last_notified = datetime.datetime.combine(
+            utc_now().date(), datetime.time(14, 23)
+        )
+
+        assert hold not in holds_fixture.monitor.item_query().all()
+
+    def test_process_items_re_checks_cooldown(
+        self, holds_fixture: HoldsNotificationFixture
+    ):
+        """If patron_last_notified is bumped to today between the SQL
+        fetch and process_items() (e.g. another worker raced ahead),
+        process_items() must drop that hold from the batch before passing
+        it to send_holds_notifications()."""
+        db = holds_fixture.db
+        patron = holds_fixture.patron_with_token()
+        work_eligible = db.work(with_license_pool=True)
+        work_raced = db.work(with_license_pool=True)
+        hold_eligible, _ = work_eligible.active_license_pool().on_hold_to(
+            patron, position=0
+        )
+        hold_raced, _ = work_raced.active_license_pool().on_hold_to(
+            patron, position=0
+        )
+        # Simulate the race: another worker already notified for hold_raced.
+        hold_raced.patron_last_notified = utc_now().date()
+
+        with patch(
+            "core.jobs.notifications.holds_notification.PushNotifications"
+        ) as mock_notf:
+            holds_fixture.monitor.process_items([hold_eligible, hold_raced])
+
+        assert mock_notf.send_holds_notifications.call_count == 1
+        assert mock_notf.send_holds_notifications.call_args_list == [
+            call([hold_eligible])
+        ]
+
+    def test_process_items_no_eligible_holds_skips_send(
+        self, holds_fixture: HoldsNotificationFixture
+    ):
+        """When the race-safety re-check filters out every hold in the
+        batch, we must not call send_holds_notifications at all (avoids
+        an unnecessary DB session lookup and a no-op call)."""
+        db = holds_fixture.db
+        patron = holds_fixture.patron_with_token()
+        work = db.work(with_license_pool=True)
+        hold, _ = work.active_license_pool().on_hold_to(patron, position=0)
+        hold.patron_last_notified = utc_now().date()
+
+        with patch(
+            "core.jobs.notifications.holds_notification.PushNotifications"
+        ) as mock_notf:
+            holds_fixture.monitor.process_items([hold])
+
+        assert mock_notf.send_holds_notifications.call_count == 0

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -227,8 +227,6 @@ class TestLoanNotificationsMonitor:
         )
         # Simulate the 3-day notification having been sent ~2 days ago,
         # when the 3-day bucket was open: that is date(end - 3d).
-        loan.patron_last_notified = (
-            loan.end - datetime.timedelta(days=3)
-        ).date()
+        loan.patron_last_notified = (loan.end - datetime.timedelta(days=3)).date()
 
         assert loan in loan_fixture.monitor.item_query().all()

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -78,7 +78,9 @@ class TestLoanNotificationsMonitor:
             now + datetime.timedelta(days=1, hours=23),
         )
 
-        # Inside the 1-day window but already notified today → NOT selected.
+        # Inside the 1-day window but already notified for the 1-day
+        # bucket → NOT selected. The 1-day bucket opens on
+        # date(end - 1 day); a same-day notification is past that.
         work_notified = db.work(with_license_pool=True)
         loan_notified, _ = work_notified.active_license_pool().loan_to(
             loan_fixture.patron,
@@ -87,14 +89,16 @@ class TestLoanNotificationsMonitor:
         )
         loan_notified.patron_last_notified = now.date()
 
-        # Inside the 1-day window, notified yesterday → selected.
+        # Inside the 1-day window, notified well before the 1-day bucket
+        # opened (>= 2 days ago) → selected. Two days is enough to be
+        # robust against time-of-day jitter at the bucket boundary.
         work_yesterday = db.work(with_license_pool=True)
         loan_yesterday, _ = work_yesterday.active_license_pool().loan_to(
             loan_fixture.patron,
             now,
             now + datetime.timedelta(hours=21),
         )
-        loan_yesterday.patron_last_notified = now.date() - datetime.timedelta(days=1)
+        loan_yesterday.patron_last_notified = now.date() - datetime.timedelta(days=2)
 
         results = set(loan_fixture.monitor.item_query().all())
         assert results == {loan_1d, loan_3d, loan_yesterday}
@@ -177,3 +181,54 @@ class TestLoanNotificationsMonitor:
             loan_fixture.monitor.process_items([loan])
 
         assert mock_notf.send_loan_expiry_message.call_count == 0
+
+    def test_item_query_skips_loan_already_notified_for_3d_bucket(
+        self, loan_fixture: LoanNotificationsFixture
+    ):
+        """Regression: the 3-day expiry window spans a 24h slice that can
+        contain the same loan on two consecutive calendar days. Once we've
+        sent the 3-day notification, the loan must NOT be re-selected on
+        the next day's cron even if `patron_last_notified` is a different
+        calendar date than today.
+
+        Example: a loan ending now+2d+12h enters the 3-day window today;
+        after notification, patron_last_notified is set to today. Tomorrow
+        the loan is still in the 3-day window (end - 1d = now+1d+12h, still
+        > 2 days away) — but the 3-day bucket opened on
+        date(end - 3d) = today, and patron_last_notified == today, so the
+        bucket-aware cooldown must filter it out."""
+        now = utc_now()
+        loan, _ = loan_fixture.pool.loan_to(
+            loan_fixture.patron,
+            now,
+            # 2d + 12h: deep inside the 3-day window, far from the 2-day
+            # boundary so this stays valid regardless of time-of-day.
+            now + datetime.timedelta(days=2, hours=12),
+        )
+        # The 3-day bucket for this loan opens on date(end - 3d).
+        bucket_open = (loan.end - datetime.timedelta(days=3)).date()
+        loan.patron_last_notified = bucket_open
+
+        assert loan not in loan_fixture.monitor.item_query().all()
+
+    def test_item_query_selects_loan_in_1d_bucket_after_3d_notification(
+        self, loan_fixture: LoanNotificationsFixture
+    ):
+        """A loan that received the 3-day notification 2 days ago must
+        still be picked up when it enters the 1-day window: the 1-day
+        bucket opens on date(end - 1d), which is later than the 3-day
+        bucket-open date, so the cooldown allows the new notification."""
+        now = utc_now()
+        loan, _ = loan_fixture.pool.loan_to(
+            loan_fixture.patron,
+            now,
+            # Inside the 1-day window.
+            now + datetime.timedelta(hours=12),
+        )
+        # Simulate the 3-day notification having been sent ~2 days ago,
+        # when the 3-day bucket was open: that is date(end - 3d).
+        loan.patron_last_notified = (
+            loan.end - datetime.timedelta(days=3)
+        ).date()
+
+        assert loan in loan_fixture.monitor.item_query().all()

--- a/tests/core/jobs/notifications/test_loan_notification.py
+++ b/tests/core/jobs/notifications/test_loan_notification.py
@@ -198,15 +198,16 @@ class TestLoanNotificationsMonitor:
         date(end - 3d) = today, and patron_last_notified == today, so the
         bucket-aware cooldown must filter it out."""
         now = utc_now()
+        end = now + datetime.timedelta(days=2, hours=12)
         loan, _ = loan_fixture.pool.loan_to(
             loan_fixture.patron,
             now,
             # 2d + 12h: deep inside the 3-day window, far from the 2-day
             # boundary so this stays valid regardless of time-of-day.
-            now + datetime.timedelta(days=2, hours=12),
+            end,
         )
         # The 3-day bucket for this loan opens on date(end - 3d).
-        bucket_open = (loan.end - datetime.timedelta(days=3)).date()
+        bucket_open = (end - datetime.timedelta(days=3)).date()
         loan.patron_last_notified = bucket_open
 
         assert loan not in loan_fixture.monitor.item_query().all()
@@ -219,14 +220,15 @@ class TestLoanNotificationsMonitor:
         bucket opens on date(end - 1d), which is later than the 3-day
         bucket-open date, so the cooldown allows the new notification."""
         now = utc_now()
+        end = now + datetime.timedelta(hours=12)
         loan, _ = loan_fixture.pool.loan_to(
             loan_fixture.patron,
             now,
             # Inside the 1-day window.
-            now + datetime.timedelta(hours=12),
+            end,
         )
         # Simulate the 3-day notification having been sent ~2 days ago,
         # when the 3-day bucket was open: that is date(end - 3d).
-        loan.patron_last_notified = (loan.end - datetime.timedelta(days=3)).date()
+        loan.patron_last_notified = (end - datetime.timedelta(days=3)).date()
 
         assert loan in loan_fixture.monitor.item_query().all()


### PR DESCRIPTION
This pull request improves the correctness and race-safety of notification cooldown logic for both hold and loan expiration notifications. The changes ensure that notifications are sent at most once per relevant period (per calendar day for holds, per "bucket" for loans), regardless of legacy data formats or concurrent job execution. The PR also adds comprehensive regression tests to guard against edge cases and logs notification sends for better traceability.

**Cooldown logic improvements and race-safety:**

* Hold notifications now use a date-based SQL filter (`func.date(Hold.patron_last_notified) < today`) to ensure only one notification is sent per calendar day, even if legacy rows store a full timestamp. The same logic is re-checked in Python to handle race conditions between SQL fetch and notification send.
* Loan expiration notifications now use a "bucket-aware" cooldown: each notification window (e.g., 1-day, 3-day) is treated as a bucket that opens on a specific date, and a notification is sent at most once per bucket per loan. The cooldown is enforced in both SQL and Python to prevent duplicate sends due to race conditions or time-of-day jitter. 

**Testing and regression coverage:**

* Added tests to ensure that holds with legacy timestamp formats are correctly filtered, that race conditions do not result in duplicate notifications, and that no-op notification sends are avoided if all items are filtered out.
* Enhanced loan notification tests to verify bucket-aware cooldowns, including scenarios where a loan should not be re-notified in the same bucket, and that notifications are sent when a loan enters a new bucket.

- **Why is this change necessary?**

<!--- Explain the rationale behind the changes. What problem does it solve or what feature does it add? -->
Especially with loan notifications, the notifications were not sent only once when they entered the 3-day notice period but also the next day: this caused notifcations to be sent each day before the loan expirations date. The same logic was also applied to holds to ensure patrons do not get sent too many notifications.

## How was this tested?

<!--- Describe the testing strategy used (unit tests, integration tests, manual testing, etc.). -->
<!--- Include any relevant test cases or scenarios that were tested. -->
Locally up to the point that notifications are still sent when
- a hold becomes loanble
- a loan is expiring in 3 days.

## Was AI used in the process of making this pr?
AI did the whole thing.

<!--- If AI was used during the process, describe how. -->

## QA Testing

- **How should QA test this change?**

    - **Environment Setup:**
    Basic backend setup. Collections have a 3-day loan time.

    - **Test Cases:**

      1. **Test case 1: Hold notification**
      Log in as two patrons: one loans a book and the other reserves it. Then the other returns the book. At this point, you can verify in db that there is one hold with position 0. Run the `hold_notification` script. Check the log to see that there is an attempt to send a notification (unless you comment out a few lines in `notifications.py`, the code will result in an error when trying to send the message).

      3. **Test case 2: Loan notification**
      Loan a book. Run the `loan_notification` script. Check the log to see that there is an attempt to send a notification (unless you comment out a few lines in `notifications.py`, the code will result in an error when trying to send the message).

## Is there any relevant documentation updated?

<!--- Link or describe if there's any updated or new documentation (e.g., Kupoli, README, etc.). -->
No

### Checklist

- [ ] Translations updated / Translators notified if applicable
- [x] AI was used during the process and I have described above how.
