### PR TITLE
Ekir 877 add streaming fulfillment classes

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Query, Session
 from typing_extensions import Self
 
 from api.circulation_exceptions import *
+from api.controller.circulation_manager import CirculationManagerController
 from api.integration.registry.license_providers import LicenseProvidersRegistry
 from api.util.patron import PatronUtility
 from core.analytics import Analytics
@@ -51,6 +52,7 @@ from core.model.patron import LoanCheckout
 from core.util.datetime_helpers import utc_now
 from core.util.http import HTTP, BadResponseException, ResponseCodesT
 from core.util.log import LoggerMixin
+from core.util.problem_detail import ProblemDetailException
 
 
 class CirculationInfo:
@@ -424,7 +426,9 @@ class Fulfillment(ABC):
     """
 
     @abstractmethod
-    def response(self) -> Response:
+    def response(
+        self, circulation: CirculationManagerController, loan: Loan
+    ) -> Response:
         """
         Return a Flask Response object that can be used to fulfill a loan.
         """
@@ -457,7 +461,9 @@ class DirectFulfillment(Fulfillment):
         self.content = content
         self.content_type = content_type
 
-    def response(self) -> Response:
+    def response(
+        self, circulation: CirculationManagerController, loan: Loan
+    ) -> Response:
         return Response(self.content, content_type=self.content_type)
 
     def __repr__(self) -> str:
@@ -470,7 +476,9 @@ class RedirectFulfillment(UrlFulfillment):
     Fulfill a loan by redirecting the client to a URL.
     """
 
-    def response(self) -> Response:
+    def response(
+        self, circulation: CirculationManagerController, loan: Loan
+    ) -> Response:
         return Response(
             f"Redirecting to {self.content_link} ...",
             status=302,
@@ -518,7 +526,9 @@ class FetchFulfillment(UrlFulfillment, LoggerMixin):
             allow_redirects=True,
         )
 
-    def response(self) -> Response:
+    def response(
+        self, circulation: CirculationManagerController, loan: Loan
+    ) -> Response:
         try:
             response = self.get(self.content_link)
         except BadResponseException as ex:
@@ -540,6 +550,62 @@ class FetchFulfillment(UrlFulfillment, LoggerMixin):
         return FetchResponse(
             response.content, status=response.status_code, headers=headers
         )
+
+
+class EllibsStreamingFulfillment(FetchFulfillment):
+    """
+    Fulfill a loan by fetching a URL and returning the content.
+    """
+
+    def __init__(
+        self,
+        content_link: str,
+        content_type: str | None = None,
+        *,
+        include_headers: dict[str, str] | None = None,
+        allowed_response_codes: ResponseCodesT = None,
+    ) -> None:
+        super().__init__(content_link, content_type)
+        self.include_headers = include_headers or {}
+        self.allowed_response_codes = allowed_response_codes or []
+
+
+class StreamingFulfillment(UrlFulfillment):
+    """
+    Fulfill a loan by returning an OPDS feed entry containing the streaming link.
+
+    Used for streaming delivery mechanisms where clients expect an OPDS entry
+    rather than a direct redirect to the content.
+
+    If a content type is provided, the streaming profile is automatically appended.
+    """
+
+    def __init__(self, content_link: str, content_type: str | None = None) -> None:
+        if content_type is not None:
+            content_type += DeliveryMechanism.STREAMING_PROFILE
+        super().__init__(content_link, content_type)
+
+    def response(
+        self,
+        circulation: CirculationManagerController | None = None,
+        loan: Loan | None = None,
+    ) -> Response:
+        """
+        Generate an OPDS entry response containing the fulfillment link.
+
+        :raises ProblemDetailException: If the OPDS feed cannot be generated.
+        """
+        from core.feed.acquisition import OPDSAcquisitionFeed
+
+        assert (
+            loan is not None
+        )  # To please mypy, since we'd never call this without a loan.
+        result = OPDSAcquisitionFeed.single_entry_loans_feed(
+            circulation, loan, fulfillment=self
+        )
+        if isinstance(result, ProblemDetail):
+            raise ProblemDetailException(result)
+        return result
 
 
 class LoanAndHoldInfoMixin:

--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -7,7 +7,6 @@ from flask import Response
 from flask_babel import lazy_gettext as _
 from werkzeug import Response as wkResponse
 
-from api.circulation import UrlFulfillment
 from api.circulation_exceptions import CirculationException, RemoteInitiatedServerError
 from api.controller.circulation_manager import CirculationManagerController
 from api.problem_details import (
@@ -346,20 +345,8 @@ class LoanController(CirculationManagerController):
         except (CirculationException, RemoteInitiatedServerError) as e:
             return e.problem_detail
 
-        # TODO: This should really be turned into its own Fulfillment class,
-        #   so each integration can choose when to return a feed response like
-        #   this, and when to return a direct response.
-        if mechanism.delivery_mechanism.is_streaming and isinstance(
-            fulfillment, UrlFulfillment
-        ):
-            # If this is a streaming delivery mechanism (note: E-kirjasto does not stream),
-            # create an OPDS entry with a fulfillment link to the streaming reader url.
-            return OPDSAcquisitionFeed.single_entry_loans_feed(
-                self.circulation, loan, fulfillment=fulfillment
-            )  # type: ignore[return-value]
-
         try:
-            return fulfillment.response()
+            return fulfillment.response(self.circulation, loan)
         except BaseProblemDetailException as e:
             return e.problem_detail
 

--- a/api/odl.py
+++ b/api/odl.py
@@ -20,11 +20,13 @@ from uritemplate import URITemplate
 from api.circulation import (
     BaseCirculationAPI,
     BaseCirculationEbookLoanSettings,
+    EllibsStreamingFulfillment,
     FetchFulfillment,
     Fulfillment,
     HoldInfo,
     LoanInfo,
     RedirectFulfillment,
+    StreamingFulfillment,
     UrlFulfillment,
 )
 from api.circulation_exceptions import *
@@ -645,16 +647,36 @@ class BaseODLAPI(
             )
             raise CannotFulfill()
 
+        content_type = delivery_mechanism.delivery_mechanism.content_type
         drm_scheme = delivery_mechanism.delivery_mechanism.drm_scheme
         fulfill_cls: Callable[[str, str | None], UrlFulfillment]
         assert loan_status.links  # To satisfy mypy
         if drm_scheme == DeliveryMechanism.NO_DRM:
             # If we have no DRM, we can just redirect to the content link and let the patron download the book.
+            # In E-kirjasto, this is not used for fulfilling loans at the moment.
             fulfill_link = loan_status.links.get(
                 rel="publication",
-                type=delivery_mechanism.delivery_mechanism.content_type,
+                type=content_type,
             )
             fulfill_cls = RedirectFulfillment
+        elif drm_scheme == DeliveryMechanism.STREAMING_DRM:
+            # Streaming DRM returns an OPDS entry containing the streaming reader link.
+            link_content_type = (
+                DeliveryMechanism.MEDIA_TYPES_FOR_STREAMING.get(content_type)
+                if content_type
+                else None
+            )
+            if link_content_type is None:
+                self.log.error(
+                    f"Unsupported streaming content type: {content_type!r}. "
+                    f"Supported types: {list(DeliveryMechanism.MEDIA_TYPES_FOR_STREAMING.keys())}."
+                )
+                raise CannotFulfill("The requested streaming format is not available.")
+            fulfill_link = loan_status.links.get(
+                rel="publication",
+                type=link_content_type,
+            )
+            fulfill_cls = StreamingFulfillment
         elif drm_scheme == DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM:
             # For DeMarque audiobook content using "FEEDBOOKS_AUDIOBOOK_DRM", the link
             # we are looking for is stored in the 'manifest' rel.
@@ -662,8 +684,20 @@ class BaseODLAPI(
                 rel="manifest", type=BaseODLImporter.FEEDBOOKS_AUDIO
             )
             fulfill_cls = partial(FetchFulfillment, allowed_response_codes=["2xx"])
+        elif (
+            drm_scheme == DeliveryMechanism.LCP_DRM
+            and content_type == DeliveryMechanism.EKIRJASTO_STREAMING_PROFILE
+        ):
+            # For E-Kirjasto streaming content, the link is in "license" (just as for downlaodable content), but the
+            # fulfillment class is different, since we need to handle the E-Kirjasto specific streaming format later
+            # for statistics purposes.
+            fulfill_link = loan_status.links.get(rel="license", type=drm_scheme)
+            fulfill_cls = partial(
+                EllibsStreamingFulfillment, allowed_response_codes=["2xx"]
+            )
+
         else:
-            # We are getting content via a license loan_status document, so we need to find the link
+            # We are getting content via a loan status document, so we need to find the link
             # that corresponds to the delivery mechanism we are using.
             fulfill_link = loan_status.links.get(rel="license", type=drm_scheme)
             fulfill_cls = partial(FetchFulfillment, allowed_response_codes=["2xx"])

--- a/core/feed/acquisition.py
+++ b/core/feed/acquisition.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Query, Session
 from api.circulation import Fulfillment, FulfillmentInfo
 from api.problem_details import NOT_FOUND_ON_REMOTE
 from core.entrypoint import EntryPoint
-from core.exceptions import PalaceValueError
 from core.external_search import ExternalSearchIndex, QueryParseException
 from core.facets import FacetConstants
 from core.feed.annotator.base import Annotator
@@ -585,13 +584,10 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         Returns:
             An OPDSEntryResponse object containing the feed or a ProblemDetail
             object if an error occurs.
-
-        Raises:
-            PalaceValueError: If the 'item' argument is empty or not an instance of
-                LicensePool, Loan, or Hold.
         """
         if not item:
-            raise PalaceValueError("Argument 'item' must be non-empty")
+            logging.error("No item provided for single_entry_loans_feed")
+            return INVALID_INPUT.detailed("Something went wrong, sorry for that.")
 
         if isinstance(item, LicensePool):
             license_pool = item
@@ -600,11 +596,8 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
             license_pool = item.license_pool
             library = item.library
         else:
-            raise PalaceValueError(
-                "Argument 'item' must be an instance of {}, {}, or {} classes".format(
-                    Loan, Hold, LicensePool
-                )
-            )
+            logging.error("Invalid item type provided for single_entry_loans_feed: %r", type(item))  # type: ignore[unreachable]
+            return INVALID_INPUT.detailed("Something went wrong, sorry for that.")
 
         if not annotator:
             annotator = LibraryLoanAndHoldAnnotator(circulation, None, library)
@@ -709,7 +702,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
             return cls.error_message(
                 identifier,
                 403,
-                "I've heard about this work but have no active licenses for it.",
+                "I've heard about this work but there are no active licenses for it anymore.",
             )
 
         if not active_edition:

--- a/core/feed/acquisition.py
+++ b/core/feed/acquisition.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Query, Session
 from api.circulation import Fulfillment, FulfillmentInfo
 from api.problem_details import NOT_FOUND_ON_REMOTE
 from core.entrypoint import EntryPoint
+from core.exceptions import PalaceValueError
 from core.external_search import ExternalSearchIndex, QueryParseException
 from core.facets import FacetConstants
 from core.feed.annotator.base import Annotator
@@ -562,7 +563,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         fulfillment: FulfillmentInfo | Fulfillment | None = None,
         selected_book: SelectedBook | None = None,
         **response_kwargs: Any,
-    ) -> OPDSEntryResponse | ProblemDetail | None:
+    ) -> OPDSEntryResponse | ProblemDetail:
         """
         Returns a single entry feed for a patron's loan or hold, including
         information about the loan, hold, and selected book.
@@ -582,16 +583,15 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
                 response generation.
 
         Returns:
-            An OPDSEntryResponse object containing the feed, a ProblemDetail
-            object if an error occurs, or None if the feed cannot be
-            generated.
+            An OPDSEntryResponse object containing the feed or a ProblemDetail
+            object if an error occurs.
 
         Raises:
-            ValueError: If the 'item' argument is empty or not an instance of
+            PalaceValueError: If the 'item' argument is empty or not an instance of
                 LicensePool, Loan, or Hold.
         """
         if not item:
-            raise ValueError("Argument 'item' must be non-empty")
+            raise PalaceValueError("Argument 'item' must be non-empty")
 
         if isinstance(item, LicensePool):
             license_pool = item
@@ -600,7 +600,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
             license_pool = item.license_pool
             library = item.library
         else:
-            raise ValueError(
+            raise PalaceValueError(
                 "Argument 'item' must be an instance of {}, {}, or {} classes".format(
                     Loan, Hold, LicensePool
                 )
@@ -609,18 +609,14 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         if not annotator:
             annotator = LibraryLoanAndHoldAnnotator(circulation, None, library)
 
-        log = logging.getLogger(cls.__name__)
-
         # Sometimes the pool or work may be None
         # In those cases we have to protect against the exceptions
-        try:
-            work = license_pool.work or license_pool.presentation_edition.work
-        except AttributeError as ex:
-            log.error(f"Error retrieving a Work Object {ex}")
-            log.error(
-                f"Error Data: {license_pool} | {license_pool and license_pool.presentation_edition}"
-            )
-            return NOT_FOUND_ON_REMOTE
+        work: Work | None = None
+        if license_pool:
+            if license_pool.work:
+                work = license_pool.work
+            elif license_pool.presentation_edition:
+                work = license_pool.presentation_edition.work
 
         if not work:
             return NOT_FOUND_ON_REMOTE
@@ -653,33 +649,44 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
 
         entry = cls.single_entry(work, annotator, even_if_no_license_pool=True)
 
-        if isinstance(entry, WorkEntry) and entry.computed:
-            return cls.entry_as_response(entry, **response_kwargs)
-        elif isinstance(entry, OPDSMessage):
-            return cls.entry_as_response(entry, max_age=0)
+        if entry is None:
+            # If single_entry returns None, create an error message
+            entry = cls.error_message(
+                identifier,
+                500,
+                "Unable to generate entry for this work",
+            )
 
-        return None
+        if isinstance(entry, OPDSMessage):
+            response_kwargs["max_age"] = 0
+
+        return cls.entry_as_response(entry, **response_kwargs)
 
     @classmethod
     def single_entry(
         cls,
-        work: Work | Edition | None,
+        work: Work | Edition,
         annotator: Annotator,
         even_if_no_license_pool: bool = False,
     ) -> WorkEntry | OPDSMessage | None:
         """Turn a work into an annotated work entry for an acquisition feed."""
         identifier = None
         _work: Work
+        active_edition: Edition | None
         if isinstance(work, Edition):
             active_edition = work
             identifier = active_edition.primary_identifier
             active_license_pool = None
-            _work = active_edition.work  # We always need a work for an entry
+            if active_edition.work is None:
+                # We always need a work for an entry
+                logging.warning("NO WORK FOR %r", active_edition)  # type: ignore[unreachable]
+                return cls.error_message(
+                    identifier,
+                    403,
+                    "I have no work associated with this edition.",
+                )
+            _work = active_edition.work
         else:
-            if not work:
-                # We have a license pool but no work. Most likely we don't have
-                # metadata for this work yet.
-                return None
             _work = work
             active_license_pool = annotator.active_licensepool_for(work)
             if active_license_pool:
@@ -687,7 +694,10 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
                 active_edition = active_license_pool.presentation_edition
             elif work.presentation_edition:
                 active_edition = work.presentation_edition
-                identifier = active_edition.primary_identifier
+                if active_edition is not None:
+                    identifier = active_edition.primary_identifier
+            else:
+                active_edition = None
 
         # There's no reason to present a book that has no active license pool.
         if not identifier:
@@ -718,6 +728,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
             logging.info(
                 "Work %r is not fulfillable, refusing to create an <entry>.",
                 work,
+                exc_info=e,
             )
             return cls.error_message(
                 identifier,

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -17,6 +17,7 @@ from api.circulation import (
     HoldInfo,
     LoanInfo,
     RedirectFulfillment,
+    StreamingFulfillment,
 )
 from api.circulation_exceptions import (
     AlreadyOnHold,
@@ -62,7 +63,7 @@ from core.util.datetime_helpers import utc_now
 from core.util.flask_util import OPDSEntryResponse, Response
 from core.util.http import RemoteIntegrationException
 from core.util.opds_writer import AtomFeed, OPDSFeed
-from core.util.problem_detail import ProblemDetail
+from core.util.problem_detail import ProblemDetail, ProblemDetailException
 from tests.api.mockapi.mock import MockHTTPClient
 from tests.fixtures.api_controller import CirculationControllerFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -503,10 +504,9 @@ class TestLoanController:
             # Now let's try to fulfill the loan using the streaming mechanism.
             loan_fixture.manager.d_circulation.queue_fulfill(
                 pool,
-                RedirectFulfillment(
+                StreamingFulfillment(
                     "http://streaming-content-link",
-                    Representation.TEXT_HTML_MEDIA_TYPE
-                    + DeliveryMechanism.STREAMING_PROFILE,
+                    Representation.TEXT_HTML_MEDIA_TYPE,
                 ),
             )
             fulfill_response = loan_fixture.manager.loans.fulfill(
@@ -563,10 +563,9 @@ class TestLoanController:
             # But we can still fulfill the streaming mechanism again.
             loan_fixture.manager.d_circulation.queue_fulfill(
                 pool,
-                RedirectFulfillment(
+                StreamingFulfillment(
                     "http://streaming-content-link",
-                    Representation.TEXT_HTML_MEDIA_TYPE
-                    + DeliveryMechanism.STREAMING_PROFILE,
+                    Representation.TEXT_HTML_MEDIA_TYPE,
                 ),
             )
 
@@ -817,7 +816,7 @@ class TestLoanController:
             def __init__(self):
                 self.response_called = False
 
-            def response(self) -> Response:
+            def response(self, circulation=None, loan=None) -> Response:
                 self.response_called = True
                 return response_value
 
@@ -930,9 +929,12 @@ class TestLoanController:
                 ) as feed,
                 patch.object(circulation, "fulfill") as fulfill,
             ):
-                fulfill.return_value = MagicMock(spec=RedirectFulfillment)
-                # The single_item_feed must return this error
-                feed.return_value = NOT_FOUND_ON_REMOTE
+                # Mock the fulfillment response to raise an exception when the feed fails
+                mock_fulfillment = MagicMock(spec=StreamingFulfillment)
+                mock_fulfillment.response.side_effect = ProblemDetailException(
+                    NOT_FOUND_ON_REMOTE
+                )
+                fulfill.return_value = mock_fulfillment
                 # The content type needs to be streaming
                 loan_fixture.mech1.delivery_mechanism.content_type = (
                     DeliveryMechanism.STREAMING_TEXT_CONTENT_TYPE

--- a/tests/api/feed/test_opds_acquisition_feed.py
+++ b/tests/api/feed/test_opds_acquisition_feed.py
@@ -17,7 +17,6 @@ from core.entrypoint import (
     EverythingEntryPoint,
     MediumEntryPoint,
 )
-from core.exceptions import PalaceValueError
 from core.facets import FacetConstants
 from core.feed.acquisition import LookupAcquisitionFeed, OPDSAcquisitionFeed
 from core.feed.annotator.base import Annotator
@@ -37,6 +36,7 @@ from core.model.constants import LinkRelations
 from core.util.datetime_helpers import utc_now
 from core.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
 from core.util.opds_writer import OPDSFeed, OPDSMessage
+from core.util.problem_detail import ProblemDetail
 from tests.api.feed.conftest import PatchedUrlFor, patch_url_for  # noqa
 from tests.fixtures.database import DatabaseTransactionFixture
 
@@ -507,12 +507,10 @@ class TestOPDSAcquisitionFeed:
 
         work = db.work()
         entry = OPDSAcquisitionFeed.single_entry(work, Annotator())
-        expect = OPDSAcquisitionFeed.error_message(
-            work.presentation_edition.primary_identifier,
-            403,
-            "I've heard about this work but have no active licenses for it.",
-        )
-        assert expect == entry
+        # Verify it's an OPDSMessage error
+        assert isinstance(entry, OPDSMessage)
+        assert entry.status_code == 403
+        assert "no active licenses" in entry.message
 
     def test_error_when_work_has_no_presentation_edition(
         self, db: DatabaseTransactionFixture
@@ -927,15 +925,17 @@ class TestOPDSAcquisitionFeed:
         assert feed.annotator.active_holds_by_work == {work: hold}
 
     def test_single_entry_loans_feed_errors(self, db: DatabaseTransactionFixture):
-        with pytest.raises(PalaceValueError) as raised:
-            # Mandatory loans item was missing
-            OPDSAcquisitionFeed.single_entry_loans_feed(None, None)  # type: ignore[arg-type]
-        assert str(raised.value) == "Argument 'item' must be non-empty"
+        # Mandatory loans item was missing
+        response = OPDSAcquisitionFeed.single_entry_loans_feed(None, None)  # type: ignore[arg-type]
+        assert isinstance(response, ProblemDetail)
+        assert response.status_code == 400
+        assert "sorry" in response.detail
 
-        with pytest.raises(PalaceValueError) as raised:
-            # Mandatory loans item was incorrect
-            OPDSAcquisitionFeed.single_entry_loans_feed(None, object())  # type: ignore[arg-type]
-        assert "Argument 'item' must be an instance of" in str(raised.value)
+        # Mandatory loans item was incorrect
+        response = OPDSAcquisitionFeed.single_entry_loans_feed(None, object())  # type: ignore[arg-type]
+        assert isinstance(response, ProblemDetail)
+        assert response.status_code == 400
+        assert "sorry" in response.detail
 
         # A work and pool that has no edition, will not have an entry
         work = db.work(with_open_access_download=True)

--- a/tests/api/feed/test_opds_acquisition_feed.py
+++ b/tests/api/feed/test_opds_acquisition_feed.py
@@ -929,13 +929,13 @@ class TestOPDSAcquisitionFeed:
         response = OPDSAcquisitionFeed.single_entry_loans_feed(None, None)  # type: ignore[arg-type]
         assert isinstance(response, ProblemDetail)
         assert response.status_code == 400
-        assert "sorry" in response.detail
+        assert response.detail and "sorry" in response.detail
 
         # Mandatory loans item was incorrect
         response = OPDSAcquisitionFeed.single_entry_loans_feed(None, object())  # type: ignore[arg-type]
         assert isinstance(response, ProblemDetail)
         assert response.status_code == 400
-        assert "sorry" in response.detail
+        assert response.detail and "sorry" in response.detail
 
         # A work and pool that has no edition, will not have an entry
         work = db.work(with_open_access_download=True)

--- a/tests/api/feed/test_opds_acquisition_feed.py
+++ b/tests/api/feed/test_opds_acquisition_feed.py
@@ -17,6 +17,7 @@ from core.entrypoint import (
     EverythingEntryPoint,
     MediumEntryPoint,
 )
+from core.exceptions import PalaceValueError
 from core.facets import FacetConstants
 from core.feed.acquisition import LookupAcquisitionFeed, OPDSAcquisitionFeed
 from core.feed.annotator.base import Annotator
@@ -926,12 +927,12 @@ class TestOPDSAcquisitionFeed:
         assert feed.annotator.active_holds_by_work == {work: hold}
 
     def test_single_entry_loans_feed_errors(self, db: DatabaseTransactionFixture):
-        with pytest.raises(ValueError) as raised:
+        with pytest.raises(PalaceValueError) as raised:
             # Mandatory loans item was missing
             OPDSAcquisitionFeed.single_entry_loans_feed(None, None)  # type: ignore[arg-type]
         assert str(raised.value) == "Argument 'item' must be non-empty"
 
-        with pytest.raises(ValueError) as raised:
+        with pytest.raises(PalaceValueError) as raised:
             # Mandatory loans item was incorrect
             OPDSAcquisitionFeed.single_entry_loans_feed(None, object())  # type: ignore[arg-type]
         assert "Argument 'item' must be an instance of" in str(raised.value)
@@ -955,10 +956,10 @@ class TestOPDSAcquisitionFeed:
         loan, _ = pool.loan_to(patron)
 
         with patch.object(OPDSAcquisitionFeed, "single_entry") as mock:
-            mock.return_value = None
+            mock.return_value = OPDSMessage("test_urn", 404, "Not found")
             response = OPDSAcquisitionFeed.single_entry_loans_feed(None, loan)
 
-        assert response == None
+        assert isinstance(response, OPDSEntryResponse)
         assert mock.call_count == 1
         _work, annotator = mock.call_args[0]
         assert isinstance(annotator, LibraryLoanAndHoldAnnotator)

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -14,7 +14,13 @@ from freezegun import freeze_time
 from requests import Response
 from sqlalchemy import delete
 
-from api.circulation import FetchFulfillment, HoldInfo, RedirectFulfillment
+from api.circulation import (
+    EllibsStreamingFulfillment,
+    FetchFulfillment,
+    HoldInfo,
+    RedirectFulfillment,
+    StreamingFulfillment,
+)
 from api.circulation_exceptions import (
     AlreadyOnHold,
     CannotFulfill,
@@ -828,12 +834,11 @@ class TestODLAPI:
         assert 0 == db.session.query(Loan).count()
 
     @pytest.mark.parametrize(
-        "drm_scheme, correct_type, correct_link, links",
+        "drm_scheme, content_type, links, expected_type, expected_link, expected_class",
         [
             pytest.param(
                 DeliveryMechanism.ADOBE_DRM,
-                DeliveryMechanism.ADOBE_DRM,
-                "http://acsm",
+                "ignored/format",
                 [
                     {
                         "rel": "license",
@@ -841,12 +846,14 @@ class TestODLAPI:
                         "type": DeliveryMechanism.ADOBE_DRM,
                     }
                 ],
+                DeliveryMechanism.ADOBE_DRM,
+                "http://acsm",
+                FetchFulfillment,
                 id="adobe drm",
             ),
             pytest.param(
                 DeliveryMechanism.LCP_DRM,
-                DeliveryMechanism.LCP_DRM,
-                "http://lcp",
+                "ignored/format",
                 [
                     {
                         "rel": "license",
@@ -854,12 +861,14 @@ class TestODLAPI:
                         "type": DeliveryMechanism.LCP_DRM,
                     }
                 ],
+                DeliveryMechanism.LCP_DRM,
+                "http://lcp",
+                FetchFulfillment,
                 id="lcp drm",
             ),
             pytest.param(
                 DeliveryMechanism.NO_DRM,
                 "application/epub+zip",
-                "http://publication",
                 [
                     {
                         "rel": "publication",
@@ -867,12 +876,14 @@ class TestODLAPI:
                         "type": "application/epub+zip",
                     }
                 ],
+                "application/epub+zip",
+                "http://publication",
+                RedirectFulfillment,
                 id="no drm",
             ),
             pytest.param(
                 DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
-                BaseODLImporter.FEEDBOOKS_AUDIO,
-                "http://correct",
+                "ignored/format",
                 [
                     {
                         "rel": "license",
@@ -885,7 +896,55 @@ class TestODLAPI:
                         "type": BaseODLImporter.FEEDBOOKS_AUDIO,
                     },
                 ],
-                id="feedbooks audio",
+                BaseODLImporter.FEEDBOOKS_AUDIO,
+                "http://correct",
+                FetchFulfillment,
+                id="demarque audio",
+            ),
+            pytest.param(
+                DeliveryMechanism.STREAMING_DRM,
+                DeliveryMechanism.STREAMING_TEXT_CONTENT_TYPE,
+                [
+                    {
+                        "rel": "publication",
+                        "href": "http://streaming-content",
+                        "type": "text/html",
+                    }
+                ],
+                DeliveryMechanism.EKIRJASTO_STREAMING_PROFILE,
+                "http://streaming-content",
+                StreamingFulfillment,
+                id="demarque text streaming drm",
+            ),
+            pytest.param(
+                DeliveryMechanism.STREAMING_DRM,
+                DeliveryMechanism.STREAMING_AUDIO_CONTENT_TYPE,
+                [
+                    {
+                        "rel": "publication",
+                        "href": "http://streaming-content",
+                        "type": "text/html",
+                    }
+                ],
+                DeliveryMechanism.EKIRJASTO_STREAMING_PROFILE,
+                "http://streaming-content",
+                StreamingFulfillment,
+                id="demarque audio streaming drm",
+            ),
+            pytest.param(
+                DeliveryMechanism.LCP_DRM,
+                DeliveryMechanism.EKIRJASTO_STREAMING_PROFILE,
+                [
+                    {
+                        "rel": "license",
+                        "href": "http://lcp-streaming-content",
+                        "type": DeliveryMechanism.LCP_DRM,
+                    }
+                ],
+                DeliveryMechanism.LCP_DRM,
+                "http://lcp-streaming-content",
+                EllibsStreamingFulfillment,
+                id="lcp with e-kirjasto streaming profile",
             ),
         ],
     )
@@ -894,9 +953,11 @@ class TestODLAPI:
         opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
         db: DatabaseTransactionFixture,
         drm_scheme: str,
-        correct_type: str,
-        correct_link: str,
+        content_type: str,
         links: list[dict[str, str]],
+        expected_type: str,
+        expected_link: str,
+        expected_class: type,
     ) -> None:
         # Fulfill a loan in a way that gives access to a license file.
         opds2_with_odl_api_fixture.setup_license(concurrency=1, available=1)
@@ -905,9 +966,7 @@ class TestODLAPI:
 
         lpdm = MagicMock(spec=LicensePoolDeliveryMechanism)
         lpdm.delivery_mechanism = MagicMock(spec=DeliveryMechanism)
-        lpdm.delivery_mechanism.content_type = (
-            "ignored/format" if drm_scheme != DeliveryMechanism.NO_DRM else correct_type
-        )
+        lpdm.delivery_mechanism.content_type = content_type
         lpdm.delivery_mechanism.drm_scheme = drm_scheme
 
         lsd = opds2_with_odl_api_fixture.loan_status_document("active", links=links)
@@ -921,13 +980,10 @@ class TestODLAPI:
                 opds2_with_odl_api_fixture.pool,
                 lpdm,
             )
-        assert (
-            isinstance(fulfillment, FetchFulfillment)
-            if drm_scheme != DeliveryMechanism.NO_DRM
-            else isinstance(fulfillment, RedirectFulfillment)
-        )
-        assert correct_link == fulfillment.content_link  # type: ignore[attr-defined]
-        assert correct_type == fulfillment.content_type  # type: ignore[attr-defined]
+
+        assert isinstance(fulfillment, expected_class)
+        assert expected_link == fulfillment.content_link  # type: ignore[attr-defined]
+        assert expected_type == fulfillment.content_type  # type: ignore[attr-defined]
         if isinstance(fulfillment, FetchFulfillment):
             assert fulfillment.allowed_response_codes == ["2xx"]
 


### PR DESCRIPTION
This pull request introduces new fulfillment classes and refactors how streaming and downloadable content is handled. The changes improve the flexibility and correctness of fulfillment responses, particularly for streaming content, and enhance error handling in OPDS feed generation.

Implements https://github.com/ThePalaceProject/circulation/pull/2966.

### Fulfillment Refactoring and Streaming Support

* Added new fulfillment classes: `StreamingFulfillment` for OPDS entry-based streaming responses, and `EllibsStreamingFulfillment` for Ellibs streaming, each with appropriate handling for content types and response generation. The `response` method signature was updated across fulfillment classes to accept `circulation` and `loan` parameters, allowing for context-aware responses.
* Refactored ODL fulfillment logic to use the correct fulfillment class based on DRM scheme, including new logic for streaming and E-Kirjasto content types. Streaming content now returns an OPDS entry instead of a redirect, and Ellibs streaming (which is fetching content and not streaming from the backend view) uses its own fulfillment class for future extensibility.

### Error Handling Improvements

* Improved error handling in `OPDSAcquisitionFeed.single_entry_loans_feed`: now returns a `ProblemDetail` for invalid input or missing items instead of raising exceptions, and logs errors for better diagnostics.
* Enhanced error messages and logging throughout the OPDS feed generation process for missing works, editions, or license pools, ensuring clients receive clear feedback when fulfillment is not possible.

### Controller and Test Adjustments

* Refactored the loan controller to delegate streaming fulfillment logic to the fulfillment classes, removing inline OPDS feed generation logic. Tests were updated to use `StreamingFulfillment` and to properly mock the new response signatures and error handling.

- **Why is this change necessary?**

<!--- Explain the rationale behind the changes. What problem does it solve or what feature does it add? -->
DeMarque streaming

## How was this tested?

<!--- Describe the testing strategy used (unit tests, integration tests, manual testing, etc.). -->
<!--- Include any relevant test cases or scenarios that were tested. -->
Some local testing to ensure loan feeds and fulfillment responses contain appropriate information.

## Was AI used in the process of making this pr?

<!--- If AI was used during the process, describe how. -->
Mainly used to modify unit tests and fix mypy related issues. Identify potential problems when refactoring OPDS single feed generation.

## QA Testing

- **How should QA test this change?**

    - **Environment Setup:**

    - **Test Cases:**

      1. **Test case 1:**
      GET any DeMarque ebook OPDS entry, e.g. `http://localhost:6500/test-lib/works/ISBN/9789897780387`. Under `borrow` links, one of the `indirectAcquisition`s should be
`<opds:indirectAcquisition type="application/atom+xml;type=entry;profile=opds-catalog">
    <opds:indirectAcquisition
        type="text/html;profile=&quot;http://librarysimplified.org/terms/profiles/streaming-media&quot;" />
</opds:indirectAcquisition>`

## Is there any relevant documentation updated?

<!--- Link or describe if there's any updated or new documentation (e.g., Kupoli, README, etc.). -->

### Checklist

- [ ] Translations updated / Translators notified if applicable
- [ ] AI was used during the process and I have described above how.
