### PR TITLE
Ekir 247 fix revoke last loan in license pool

### DIFF
--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -448,11 +448,10 @@ class LoanController(CirculationManagerController):
                 self.circulation.release_hold(patron, credential, pool)
             except (CirculationException, RemoteInitiatedServerError) as e:
                 return e.problem_detail
-
-        annotator = self.manager.annotator(None)
-        single_entry_feed = OPDSAcquisitionFeed.single_entry(work, annotator)
-        return OPDSAcquisitionFeed.entry_as_response(
-            entry=single_entry_feed,  # type: ignore
+        
+        return OPDSAcquisitionFeed.single_entry_loans_feed(
+            self.circulation,
+            pool,
             mime_types=flask.request.accept_mimetypes,
         )
 

--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -448,12 +448,13 @@ class LoanController(CirculationManagerController):
                 self.circulation.release_hold(patron, credential, pool)
             except (CirculationException, RemoteInitiatedServerError) as e:
                 return e.problem_detail
-        
-        return OPDSAcquisitionFeed.single_entry_loans_feed(
+
+        result = OPDSAcquisitionFeed.single_entry_loans_feed(
             self.circulation,
             pool,
             mime_types=flask.request.accept_mimetypes,
         )
+        return result  # type: ignore[return-value]
 
     def detail(
         self, identifier_type: str, identifier: str

--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -397,7 +397,7 @@ class LoanController(CirculationManagerController):
         # doesn't identify its patrons.)
         return self.circulation.can_fulfill_without_loan(patron, pool, lpdm)
 
-    def revoke(self, license_pool_id: int) -> OPDSEntryResponse | ProblemDetail:
+    def revoke(self, license_pool_id: int) -> OPDSEntryResponse | ProblemDetail | None:
         patron = flask.request.patron  # type: ignore[attr-defined]
         pool = self.load_licensepool(license_pool_id)
         if isinstance(pool, ProblemDetail):
@@ -454,7 +454,7 @@ class LoanController(CirculationManagerController):
             pool,
             mime_types=flask.request.accept_mimetypes,
         )
-        return result  # type: ignore[return-value]
+        return result
 
     def detail(
         self, identifier_type: str, identifier: str

--- a/core/feed/acquisition.py
+++ b/core/feed/acquisition.py
@@ -651,7 +651,9 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         selected_books_by_work[work] = selected_book
         annotator.selected_books_by_work = selected_books_by_work
 
-        entry = cls.single_entry(work, annotator, even_if_no_license_pool=True)
+        entry = cls.single_entry(
+            work, annotator, even_if_no_license_pool=True, license_pool=license_pool
+        )
 
         if isinstance(entry, WorkEntry) and entry.computed:
             return cls.entry_as_response(entry, **response_kwargs)
@@ -666,6 +668,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         work: Work | Edition | None,
         annotator: Annotator,
         even_if_no_license_pool: bool = False,
+        license_pool: LicensePool | None = None,
     ) -> WorkEntry | OPDSMessage | None:
         """Turn a work into an annotated work entry for an acquisition feed."""
         identifier = None
@@ -681,7 +684,10 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
                 # metadata for this work yet.
                 return None
             _work = work
-            active_license_pool = annotator.active_licensepool_for(work)
+            # Use the provided license_pool if available, otherwise try to find an active one.
+            # This is relevant when revoking a hold or loan and the license pool has become
+            # inactive.
+            active_license_pool = license_pool or annotator.active_licensepool_for(work)
             if active_license_pool:
                 identifier = active_license_pool.identifier
                 active_edition = active_license_pool.presentation_edition

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -1015,7 +1015,7 @@ class TestLoanController:
 
             response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
 
-        assert 200 == response.status_code
+        assert 200 == response.status_code  # type: ignore
         serialization_helper.verify_and_get_single_entry_feed_links(response)
 
     def test_revoke_loan_exception(
@@ -1083,7 +1083,7 @@ class TestLoanController:
 
             response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
 
-        assert 200 == response.status_code
+        assert 200 == response.status_code  # type: ignore
         _ = serialization_helper.verify_and_get_single_entry_feed_links(response)
 
     def test_revoke_hold_exception(
@@ -1169,7 +1169,7 @@ class TestLoanController:
         # Should return 200 with valid OPDS entry (not 403 error)
         # Without even_if_no_license_pool=True, this would fail with 403 because
         # the pool has no active license pool for the annotator after revocation
-        assert 200 == response.status_code
+        assert 200 == response.status_code  # type: ignore
 
         # Verify it's a valid OPDS entry response with proper serialization
         serialization_helper = OPDSSerializationTestHelper(
@@ -1256,7 +1256,7 @@ class TestLoanController:
             response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
 
         # Should return 200 with valid OPDS entry (not 403 error)
-        assert 200 == response.status_code
+        assert 200 == response.status_code  # type: ignore
 
         # Verify it's a valid OPDS entry response with proper serialization
         serialization_helper = OPDSSerializationTestHelper(

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -1114,6 +1114,70 @@ class TestLoanController:
             assert isinstance(response, ProblemDetail)
             assert INVALID_INPUT.uri == response.uri
 
+    def test_revoke_loan_last_in_pool(
+        self,
+        loan_fixture: LoanFixture,
+    ):
+        """Test revoking the last (only) loan in a license pool.
+        
+        When a patron returns the last loan in a license pool, the pool may
+        transition to having licenses_owned=0, making it appear as 'inactive'
+        in the collection. The revoke endpoint should still generate a valid
+        OPDS entry response so the client sees the final state after revocation,
+        instead of returning a 403 error.
+        
+        This tests that even_if_no_license_pool=True is used in the revoke
+        endpoint's response generation, so it can generate a response even when
+        annotator.active_licensepool_for() returns None (the condition that
+        would otherwise trigger a 403 "no active licenses" error).
+        """
+        # Set up the pool with only one owned license
+        loan_fixture.pool.licenses_owned = 1
+        loan_fixture.pool.licenses_available = 1
+        
+        headers = {"Authorization": loan_fixture.valid_auth}
+
+        with loan_fixture.request_context_with_library("/", headers=headers):
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
+
+            # Verify pool is active (has licenses)
+            assert 1 == loan_fixture.pool.licenses_owned
+            assert 1 == loan_fixture.pool.licenses_available
+
+            # Create a loan
+            loan, newly_created = loan_fixture.pool.loan_to(patron)
+            assert newly_created
+            assert loan is not None
+
+            # Queue a successful checkin
+            loan_fixture.manager.d_circulation.queue_checkin(
+                loan_fixture.pool, True
+            )
+
+            # Revoke the loan
+            response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
+
+        # Should return 200 with valid OPDS entry (not 403 error)
+        # Without even_if_no_license_pool=True, this would fail with 403 because
+        # the pool has no active license pool for the annotator after revocation
+        assert 200 == response.status_code
+        
+        # Verify it's a valid OPDS entry response with proper serialization
+        serialization_helper = OPDSSerializationTestHelper(
+            None, "application/atom+xml;type=entry;profile=opds-catalog"
+        )
+        feed_links = serialization_helper.verify_and_get_single_entry_feed_links(response)
+        
+        # Ensure the response has the expected structure
+        assert feed_links is not None
+        assert len(feed_links) > 0
+        
+        # Verify the response contains a valid OPDS entry
+        feed = feedparser.parse(response.data)
+        entries = feed.get("entries", [])
+        assert len(entries) == 1
+
     def test_hold_fails_when_patron_is_at_hold_limit(self, loan_fixture: LoanFixture):
         edition, pool = loan_fixture.db.edition(with_license_pool=True)
         pool.open_access = False

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -1119,13 +1119,13 @@ class TestLoanController:
         loan_fixture: LoanFixture,
     ):
         """Test revoking the last (only) loan in a license pool.
-        
+
         When a patron returns the last loan in a license pool, the pool may
         transition to having licenses_owned=0, making it appear as 'inactive'
         in the collection. The revoke endpoint should still generate a valid
         OPDS entry response so the client sees the final state after revocation,
         instead of returning a 403 error.
-        
+
         This tests that even_if_no_license_pool=True is used in the revoke
         endpoint's response generation, so it can generate a response even when
         annotator.active_licensepool_for() returns None (the condition that
@@ -1134,7 +1134,7 @@ class TestLoanController:
         # Set up the pool with only one owned license
         loan_fixture.pool.licenses_owned = 1
         loan_fixture.pool.licenses_available = 1
-        
+
         headers = {"Authorization": loan_fixture.valid_auth}
 
         with loan_fixture.request_context_with_library("/", headers=headers):
@@ -1151,9 +1151,7 @@ class TestLoanController:
             assert loan is not None
 
             # Queue a successful checkin
-            loan_fixture.manager.d_circulation.queue_checkin(
-                loan_fixture.pool, True
-            )
+            loan_fixture.manager.d_circulation.queue_checkin(loan_fixture.pool, True)
 
             # Revoke the loan
             response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
@@ -1162,18 +1160,21 @@ class TestLoanController:
         # Without even_if_no_license_pool=True, this would fail with 403 because
         # the pool has no active license pool for the annotator after revocation
         assert 200 == response.status_code
-        
+
         # Verify it's a valid OPDS entry response with proper serialization
         serialization_helper = OPDSSerializationTestHelper(
             None, "application/atom+xml;type=entry;profile=opds-catalog"
         )
-        feed_links = serialization_helper.verify_and_get_single_entry_feed_links(response)
-        
+        feed_links = serialization_helper.verify_and_get_single_entry_feed_links(
+            response
+        )
+
         # Ensure the response has the expected structure
         assert feed_links is not None
         assert len(feed_links) > 0
-        
+
         # Verify the response contains a valid OPDS entry
+        assert isinstance(response, OPDSEntryResponse)
         feed = feedparser.parse(response.data)
         entries = feed.get("entries", [])
         assert len(entries) == 1

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -1131,6 +1131,10 @@ class TestLoanController:
         annotator.active_licensepool_for() returns None (the condition that
         would otherwise trigger a 403 "no active licenses" error).
         """
+        # Ensure pool is not open_access so license counts matter
+        loan_fixture.pool.open_access = False
+        loan_fixture.pool.unlimited_access = False
+
         # Set up the pool with only one owned license
         loan_fixture.pool.licenses_owned = 1
         loan_fixture.pool.licenses_available = 1
@@ -1152,6 +1156,12 @@ class TestLoanController:
 
             # Queue a successful checkin
             loan_fixture.manager.d_circulation.queue_checkin(loan_fixture.pool, True)
+
+            # Simulate what the real API does: after checkin, the pool would have no available licenses
+            # We set this before revoke so the response generation sees the unavailable state
+            loan_fixture.pool.licenses_available = 0
+            loan_fixture.pool.licenses_owned = 0
+            loan_fixture.db.session.flush()
 
             # Revoke the loan
             response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
@@ -1178,6 +1188,106 @@ class TestLoanController:
         feed = feedparser.parse(response.data)
         entries = feed.get("entries", [])
         assert len(entries) == 1
+
+        # Verify that availability information is present in the entry
+        # After revoking the last loan, availability should show "unavailable"
+        entry = entries[0]
+        assert (
+            "opds_availability" in entry
+        ), "OPDS entry should include availability information after loan revocation"
+        availability = entry["opds_availability"]
+        assert isinstance(availability, dict), "Availability should be a dict"
+        assert "status" in availability, "Availability should have a status"
+        # Status should be 'unavailable' when pool has no active licenses
+        assert (
+            availability["status"] == "unavailable"
+        ), "Status should be 'unavailable' when pool has no active licenses"
+
+    def test_revoke_hold_last_in_pool(
+        self,
+        loan_fixture: LoanFixture,
+    ):
+        """Test releasing the last (only) hold in a license pool.
+
+        Similar to test_revoke_loan_last_in_pool, when a patron releases the
+        last hold in a license pool, the pool may transition to having
+        licenses_owned=0. The revoke endpoint should still generate a valid
+        OPDS entry response showing the final state, instead of returning a 403 error.
+        """
+        # Ensure pool is not open_access so license counts matter
+        loan_fixture.pool.open_access = False
+        loan_fixture.pool.unlimited_access = False
+
+        # Set up the pool with only one owned license
+        loan_fixture.pool.licenses_owned = 1
+        loan_fixture.pool.licenses_available = 1
+
+        headers = {"Authorization": loan_fixture.valid_auth}
+
+        with loan_fixture.request_context_with_library("/", headers=headers):
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
+
+            # Verify pool is active (has licenses)
+            assert 1 == loan_fixture.pool.licenses_owned
+            assert 1 == loan_fixture.pool.licenses_available
+
+            # Create a hold at position 10 in the queue
+            hold, newly_created = loan_fixture.pool.on_hold_to(patron, position=10)
+            assert newly_created
+            assert hold is not None
+
+            # Simulate that the hold was placed long ago (several weeks before the pool became inactive)
+            hold.start = utc_now() - datetime.timedelta(days=30)
+            loan_fixture.db.session.flush()
+
+            # Queue a successful release_hold
+            loan_fixture.manager.d_circulation.queue_release_hold(
+                loan_fixture.pool, True
+            )
+
+            # Simulate what the real API does: after release, the pool would have no active licenses
+            # We set this before revoke so the response generation sees the unavailable state
+            loan_fixture.pool.licenses_available = 0
+            loan_fixture.pool.licenses_owned = 0
+            loan_fixture.db.session.flush()
+
+            # Revoke (release) the hold
+            response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
+
+        # Should return 200 with valid OPDS entry (not 403 error)
+        assert 200 == response.status_code
+
+        # Verify it's a valid OPDS entry response with proper serialization
+        serialization_helper = OPDSSerializationTestHelper(
+            None, "application/atom+xml;type=entry;profile=opds-catalog"
+        )
+        feed_links = serialization_helper.verify_and_get_single_entry_feed_links(
+            response
+        )
+
+        # Ensure the response has the expected structure
+        assert feed_links is not None
+        assert len(feed_links) > 0
+
+        # Verify the response contains a valid OPDS entry
+        assert isinstance(response, OPDSEntryResponse)
+        feed = feedparser.parse(response.data)
+        entries = feed.get("entries", [])
+        assert len(entries) == 1
+
+        # Verify that availability information is present in the entry
+        entry = entries[0]
+        assert (
+            "opds_availability" in entry
+        ), "OPDS entry should include availability information after hold revocation"
+        availability = entry["opds_availability"]
+        assert isinstance(availability, dict), "Availability should be a dict"
+        assert "status" in availability, "Availability should have a status"
+        # Status should be 'unavailable' when pool has no active licenses
+        assert (
+            availability["status"] == "unavailable"
+        ), "Status should be 'unavailable' when pool has no active licenses"
 
     def test_hold_fails_when_patron_is_at_hold_limit(self, loan_fixture: LoanFixture):
         edition, pool = loan_fixture.db.edition(with_license_pool=True)


### PR DESCRIPTION
## Description

- **What does this PR do?**
This pull request updates the way revoked loans are handled, especially for the case where a patron returns the last loan in a license pool, and adds a test to ensure correct behavior. The main focus is to guarantee that clients always receive a valid OPDS entry response after revocation, even if the license pool becomes inactive.

- **Why is this change necessary?**
We've received feedback from patrons that, at times, they get an error when revoking their loan. Checking the logs, it was due to the loan being the last one in a license pool.

## Changes Made

<!-- List all changes -->
**Improvements to loan revocation endpoint:**

* The `revoke` method in `loan.py` now uses `OPDSAcquisitionFeed.single_entry_loans_feed` to generate the response, ensuring a valid OPDS entry is returned even when the license pool becomes inactive after the last loan is revoked. This prevents a 403 error and provides the client with the final state after revocation.

**Test coverage enhancements:**

* Added the `test_revoke_loan_last_in_pool` test to verify that revoking the last loan in a license pool returns a valid OPDS entry response (status 200), rather than a 403 error, and that the response has the correct structure and serialization.

## How was this tested?

<!--- Describe the testing strategy used (unit tests, integration tests, manual testing, etc.). -->
<!--- Include any relevant test cases or scenarios that were tested. -->
Locally with web and IOS.

## Was AI used in the process of making this pr?

<!--- If AI was used during the process, describe how. -->
Suggested the fix and created a unit test.

## QA Testing

- **How should QA test this change?**

    - **Environment Setup:**
    Basic backend setup.
You'll need to change a license pool availability information to create the needed situation: identify a license pool with only one license with a "loan pool". `terms_concurrency` should be 1. Change the `checkouts_left` to 1.

    - **Test Cases:**

      1. **Test case 1:**
      Loan the book and then return it. You should not get an error but a 200 and an OPDS entry response. If you check the OPDS, there's no `opds:availability` information. In web, the UI shows that there is 1/1 available (bug), whereas IOS shows an empty availability box. If you then go to home page, the book should not appear anywhere. You can GET the work, and it should return a response with 403 `I've heard about this work but have no active licenses for it.`.

    - **Edge Cases:**

    - **Regression Testing:**
    All loan revokes should work normally.

## Is there any relevant documentation updated?

<!--- Link or describe if there's any updated or new documentation (e.g., Kupoli, README, etc.). -->
No

### Checklist

- [ ] Translations updated / Translators notified if applicable
- [ ] AI was used during the process and I have described above how.
