### PR TITLE
EKIR-772 Separate streaming fulfillment event from non-streaming

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1597,12 +1597,15 @@ class CirculationAPI:
         if not fulfillment:
             raise NoAcceptableFormat()
 
-        # Send out an analytics event to record the fact that
-        # a fulfillment was initiated through the circulation
-        # manager.
-        self._collect_event(
-            patron, licensepool, CirculationEvent.CM_FULFILL, include_neighborhood=True
-        )
+        # Send out an analytics event to record whether the fulfillment was for
+        # a streaming or non-streaming delivery mechanism.
+        if isinstance(fulfillment, StreamingFulfillment) or isinstance(
+            fulfillment, EllibsStreamingFulfillment
+        ):
+            cm_event = CirculationEvent.CM_STREAMING_FULFILL
+        else:
+            cm_event = CirculationEvent.CM_FULFILL
+        self._collect_event(patron, licensepool, cm_event, include_neighborhood=True)
 
         # Make sure the delivery mechanism we just used is associated
         # with the loan, if any.

--- a/core/model/circulationevent.py
+++ b/core/model/circulationevent.py
@@ -89,7 +89,7 @@ class CirculationEvent(Base):
     CM_HOLD_PLACE = "circulation_manager_hold_place"
     CM_HOLD_RELEASE = "circulation_manager_hold_release"
     CM_FULFILL = "circulation_manager_fulfill"
-
+    CM_STREAMING_FULFILL = "circulation_stream_fulfill"
     # Events that we hear about from a distributor.
     DISTRIBUTOR_CHECKOUT = "distributor_check_out"
     DISTRIBUTOR_CHECKIN = "distributor_check_in"

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -15,9 +15,11 @@ from api.circulation import (
     BaseCirculationAPI,
     CirculationAPI,
     CirculationInfo,
+    EllibsStreamingFulfillment,
     FulfillmentInfo,
     HoldInfo,
     LoanInfo,
+    StreamingFulfillment,
 )
 from api.circulation_exceptions import *
 from core.analytics import Analytics
@@ -943,6 +945,64 @@ class TestCirculationAPI:
         circulation_api.circulation.can_fulfill_without_loan = yes_we_can
         result = try_to_fulfill()
         assert fulfillment == result
+
+    def test_fulfill_records_streaming_event_for_streaming_fulfillment(
+        self, circulation_api: CirculationAPIFixture
+    ):
+        """Test that StreamingFulfillment records CM_STREAMING_FULFILL event."""
+        circulation_api.pool.loan_to(circulation_api.patron)
+
+        # Queue a StreamingFulfillment
+        streaming_fulfillment = StreamingFulfillment(
+            content_link="https://example.com/stream"
+        )
+        circulation_api.remote.queue_fulfill(streaming_fulfillment)
+
+        result = circulation_api.circulation.fulfill(
+            circulation_api.patron,
+            "1234",
+            circulation_api.pool,
+            circulation_api.pool.delivery_mechanisms[0],
+        )
+
+        # The fulfillment looks good.
+        assert streaming_fulfillment == result
+
+        # An analytics event was created with CM_STREAMING_FULFILL.
+        assert 1 == circulation_api.analytics.count
+        assert (
+            CirculationEvent.CM_STREAMING_FULFILL
+            == circulation_api.analytics.event_type
+        )
+
+    def test_fulfill_records_streaming_event_for_ellips_streaming_fulfillment(
+        self, circulation_api: CirculationAPIFixture
+    ):
+        """Test that EllibsStreamingFulfillment records CM_STREAMING_FULFILL event."""
+        circulation_api.pool.loan_to(circulation_api.patron)
+
+        # Queue an EllibsStreamingFulfillment
+        ellibs_fulfillment = EllibsStreamingFulfillment(
+            content_link="https://example.com/ellips"
+        )
+        circulation_api.remote.queue_fulfill(ellibs_fulfillment)
+
+        result = circulation_api.circulation.fulfill(
+            circulation_api.patron,
+            "1234",
+            circulation_api.pool,
+            circulation_api.pool.delivery_mechanisms[0],
+        )
+
+        # The fulfillment looks good.
+        assert ellibs_fulfillment == result
+
+        # An analytics event was created with CM_STREAMING_FULFILL.
+        assert 1 == circulation_api.analytics.count
+        assert (
+            CirculationEvent.CM_STREAMING_FULFILL
+            == circulation_api.analytics.event_type
+        )
 
     @pytest.mark.parametrize("open_access", [True, False])
     def test_revoke_loan(self, circulation_api: CirculationAPIFixture, open_access):


### PR DESCRIPTION
## Description

- **What does this PR do?**

This pull request updates the fulfillment analytics to better distinguish between streaming and non-streaming fulfillments, and adds tests to ensure correct event logging. The main changes are the introduction of a new event type for streaming fulfillments, updates to the event recording logic, and new tests to verify this behavior.

- **Why is this change necessary?**
We want to track how many loans are fulfilled by streaming vs. loading.

## Changes Made

**Analytics event tracking improvements:**

* Added a new event type `CM_STREAMING_FULFILL` to the `CirculationEvent` class for tracking streaming fulfillments separately from standard fulfillments.
* Updated the `fulfill` method in `api/circulation.py` to log `CM_STREAMING_FULFILL` when the fulfillment is a `StreamingFulfillment` or `EllibsStreamingFulfillment`, otherwise log the standard `CM_FULFILL` event.

**Testing enhancements:**

* Added imports for `StreamingFulfillment` and `EllibsStreamingFulfillment` in the test file to support new test cases.
* Added tests to verify that streaming fulfillments correctly record the `CM_STREAMING_FULFILL` event for both `StreamingFulfillment` and `EllibsStreamingFulfillment` types.

## How was this tested?

<!--- Describe the testing strategy used (unit tests, integration tests, manual testing, etc.). -->
<!--- Include any relevant test cases or scenarios that were tested. -->
Locally

## Was AI used in the process of making this pr?

<!--- If AI was used during the process, describe how. -->
Created unit tests.

## QA Testing

- **How should QA test this change?**

    - **Environment Setup:**

    - **Test Cases:**

      1. **Test case 1:**
      Loan a Finnish/Swedish book and fulfill the loan by streaming. You should see 1) in webapp container that `circulation_stream_fulfill ` event was logged, 2) pgadmin `circulationevents` has a new event type, and 3) opensearch shows the new event type.

      3. **Test case 2:**
      Loan an English book and fulfill the loan by streaming. Same observations should be made as above.

    - **Edge Cases:**

    - **Regression Testing:**
    Downloading an ebook creates `circulation_manager_fulfill` event.

## Is there any relevant documentation updated?

<!--- Link or describe if there's any updated or new documentation (e.g., Kupoli, README, etc.). -->

### Checklist

- [ ] Translations updated / Translators notified if applicable
- [ ] AI was used during the process and I have described above how.
